### PR TITLE
feat(event-groups): add unmatched stream channel handling

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -73,6 +73,9 @@ export interface EventGroup {
   // Multi-sport enhancements (Phase 3)
   channel_sort_order: string
   overlap_handling: string
+  // Unmatched Stream Handling
+  create_unmatched_channels: boolean
+  unmatched_channel_epg_source_id: number | null
   enabled: boolean
   created_at: string | null
   updated_at: string | null
@@ -126,6 +129,9 @@ export interface EventGroupCreate {
   // Multi-sport enhancements (Phase 3)
   channel_sort_order?: string
   overlap_handling?: string
+  // Unmatched Stream Handling
+  create_unmatched_channels?: boolean
+  unmatched_channel_epg_source_id?: number | null
   enabled?: boolean
   // Template assignments for multi-league groups (created with the group)
   template_assignments?: Array<{
@@ -156,6 +162,7 @@ export interface EventGroupUpdate extends Partial<EventGroupCreate> {
   clear_custom_regex_league?: boolean
   clear_include_teams?: boolean
   clear_exclude_teams?: boolean
+  clear_unmatched_channel_epg_source_id?: boolean
 }
 
 export interface EventGroupListResponse {

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -28,6 +28,7 @@ import { StreamProfileSelector } from "@/components/StreamProfileSelector"
 import { StreamTimezoneSelector } from "@/components/StreamTimezoneSelector"
 import { TestPatternsModal, type PatternState } from "@/components/TestPatternsModal"
 import { TemplateAssignmentModal, type LocalTemplateAssignment } from "@/components/TemplateAssignmentModal"
+import type { EPGSource } from "@/api/settings"
 
 // Group mode
 type GroupMode = "single" | "multi" | null
@@ -396,6 +397,14 @@ export function EventGroupForm() {
           }
           if (shouldClear(group.stream_timezone, formData.stream_timezone)) {
             updateData.clear_stream_timezone = true
+          }
+          if (
+            shouldClear(
+              group.unmatched_channel_epg_source_id,
+              formData.unmatched_channel_epg_source_id,
+            )
+          ) {
+            updateData.clear_unmatched_channel_epg_source_id = true;
           }
         }
 
@@ -917,7 +926,8 @@ export function EventGroupForm() {
               </div>
             </CardContent>
           </Card>}
-
+          
+          
           {/* Channel Group Assignment - hidden for child groups */}
           {!isChildGroup && <Card>
             <CardHeader>
@@ -1754,7 +1764,67 @@ export function EventGroupForm() {
               </CardContent>
             </Card>
           )}
+{/* Unmatched Stream Handling - hidden for child groups */}
+          {!isChildGroup && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Unmatched Stream Handling</CardTitle>
+                <CardDescription>
+                  Configure how to handle streams that don't match any event
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={formData.create_unmatched_channels || false}
+                    onCheckedChange={(checked) =>
+                      setFormData({
+                        ...formData,
+                        create_unmatched_channels: checked,
+                      })
+                    }
+                  />
+                  <Label className="font-normal">
+                    Create Channels for Unmatched Streams
+                  </Label>
+                </div>
 
+                {formData.create_unmatched_channels && (
+                  <div className="space-y-2 pl-6 border-l-2 border-muted ml-2">
+                    <Label htmlFor="unmatched_epg_source">
+                      Unmatched EPG Source (Optional)
+                    </Label>
+                    <Select
+                      id="unmatched_epg_source"
+                      value={
+                        formData.unmatched_channel_epg_source_id?.toString() ||
+                        ""
+                      }
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          unmatched_channel_epg_source_id: e.target.value
+                            ? Number(e.target.value)
+                            : null,
+                        })
+                      }
+                    >
+                      <option value="">None (Use default metadata)</option>
+                      {epgSources?.filter((s: EPGSource) => s.source_type === "dummy").map((source: EPGSource)=> (
+                        <option key={source.id} value={source.id}>
+                          {source.name}
+                        </option>
+                      ))}
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      If selected, unmatched channels will use this EPG source
+                      for placeholder data.
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
           {/* Actions */}
           <div className="flex justify-end gap-2">
             <Button variant="outline" onClick={() => navigate("/event-groups")}>

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -44,7 +44,22 @@ async function fetchChannelGroups(): Promise<ChannelGroup[]> {
   if (!response.ok) {
     throw new Error(response.status === 503 ? "Dispatcharr not connected" : "Failed to fetch channel groups")
   }
-  return response.json()
+  return response.json();
+}
+
+async function fetchEPGSources(): Promise<EPGSource[]> {
+  const response = await fetch(
+    "/api/v1/dispatcharr/epg-sources?include_dummy=true",
+  );
+  if (!response.ok) {
+    throw new Error(
+      response.status === 503
+        ? "Dispatcharr not connected"
+        : "Failed to fetch EPG sources",
+    );
+  }
+  const data = await response.json();
+  return data.sources || [];
 }
 
 async function createChannelGroup(name: string): Promise<ChannelGroup | null> {
@@ -89,6 +104,9 @@ export function EventGroupForm() {
     // Multi-sport enhancements (Phase 3)
     channel_sort_order: "time",
     overlap_handling: "add_stream",
+    // Unmatched stream handling
+    create_unmatched_channels: false,
+    unmatched_channel_epg_source_id: null,
     enabled: true,
     // Team filtering
     include_teams: null,
@@ -128,9 +146,15 @@ export function EventGroupForm() {
   const { data: channelGroups, refetch: refetchChannelGroups, isError: channelGroupsError, error: channelGroupsErrorMsg } = useQuery({
     queryKey: ["dispatcharr-channel-groups"],
     queryFn: fetchChannelGroups,
-    retry: false,  // Don't retry on connection errors
-  })
+    retry: false, // Don't retry on connection errors
+  });
 
+  // Fetch EPG sources from Dispatcharr
+  const { data: epgSources } = useQuery({
+    queryKey: ["dispatcharr-epg-sources"],
+    queryFn: fetchEPGSources,
+    retry: false,
+  });
 
   // Inline create state
   const [showCreateGroup, setShowCreateGroup] = useState(false)
@@ -241,6 +265,9 @@ export function EventGroupForm() {
         // Multi-sport enhancements (Phase 3)
         channel_sort_order: group.channel_sort_order || "time",
         overlap_handling: group.overlap_handling || "add_stream",
+        // Unmatched stream handling
+        create_unmatched_channels: group.create_unmatched_channels,
+        unmatched_channel_epg_source_id: group.unmatched_channel_epg_source_id,
         enabled: group.enabled,
       })
 
@@ -330,8 +357,8 @@ export function EventGroupForm() {
     }
 
     if (leagues.length === 0) {
-      toast.error("At least one league is required")
-      return
+      toast.error("At least one league is required");
+      return;
     }
 
     try {

--- a/frontend/src/pages/EventGroupImport.tsx
+++ b/frontend/src/pages/EventGroupImport.tsx
@@ -124,6 +124,8 @@ export function EventGroupImport() {
   const [bulkStreamTimezone, setBulkStreamTimezone] = useState<string | null>(null)
   const [bulkChannelSortOrder, setBulkChannelSortOrder] = useState<string>("time")
   const [bulkOverlapHandling, setBulkOverlapHandling] = useState<string>("add_stream")
+  const [bulkCreateUnmatchedChannels, setBulkCreateUnmatchedChannels] = useState(false)
+  const [bulkUnmatchedChannelEpgSourceId, setBulkUnmatchedChannelEpgSourceId] = useState<number | null>(null)
   const [bulkEnabled, setBulkEnabled] = useState(true)
   const [bulkImporting, setBulkImporting] = useState(false)
 
@@ -158,6 +160,16 @@ export function EventGroupImport() {
   const channelGroupsQuery = useQuery({
     queryKey: ["dispatcharr-channel-groups"],
     queryFn: fetchChannelGroups,
+  })
+
+  const epgSourcesQuery = useQuery({
+    queryKey: ["dispatcharr-epg-sources"],
+    queryFn: async () => {
+      const res = await api.get<any>(
+        "/dispatcharr/epg-sources?include_dummy=true",
+      )
+      return res.sources || []
+    },
   })
 
   // Get set of already-enabled (account_id, group_id) pairs
@@ -280,6 +292,8 @@ export function EventGroupImport() {
           stream_timezone: bulkStreamTimezone,
           channel_sort_order: bulkChannelSortOrder,
           overlap_handling: bulkOverlapHandling,
+          create_unmatched_channels: bulkCreateUnmatchedChannels,
+          unmatched_channel_epg_source_id: bulkUnmatchedChannelEpgSourceId,
           enabled: bulkEnabled,
         },
       })
@@ -314,6 +328,8 @@ export function EventGroupImport() {
     setBulkStreamTimezone(null)
     setBulkChannelSortOrder("time")
     setBulkOverlapHandling("add_stream")
+    setBulkCreateUnmatchedChannels(false)
+    setBulkUnmatchedChannelEpgSourceId(null)
     setBulkEnabled(true)
     setShowBulkModal(true)
   }
@@ -373,7 +389,7 @@ export function EventGroupImport() {
                   className={cn(
                     "w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/50 border-l-2 border-transparent",
                     selectedAccount?.id === account.id &&
-                      "bg-muted border-l-primary"
+                    "bg-muted border-l-primary"
                   )}
                 >
                   <Tv className="h-4 w-4 text-muted-foreground" />
@@ -473,8 +489,8 @@ export function EventGroupImport() {
                           isEnabled
                             ? "opacity-60 border-green-500/50 bg-green-500/5"
                             : isSelected
-                            ? "border-primary bg-primary/5"
-                            : "hover:border-primary/50"
+                              ? "border-primary bg-primary/5"
+                              : "hover:border-primary/50"
                         )}
                       >
                         {/* Checkbox for non-enabled groups */}
@@ -842,6 +858,47 @@ export function EventGroupImport() {
                   </div>
                 </div>
               )}
+
+              {/* Unmatched Stream Handling */}
+              <div className="pt-2 border-t space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label className="text-sm">Create Channels for Unmatched Streams</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Create channels for streams that don't match any events
+                    </p>
+                  </div>
+                  <Switch
+                    checked={bulkCreateUnmatchedChannels}
+                    onCheckedChange={setBulkCreateUnmatchedChannels}
+                  />
+                </div>
+
+                {bulkCreateUnmatchedChannels && (
+                  <div className="space-y-2 pt-2">
+                    <Label className="text-xs text-muted-foreground">Dummy EPG Source</Label>
+                    <Select
+                      value={bulkUnmatchedChannelEpgSourceId?.toString() || ""}
+                      onChange={(e) => setBulkUnmatchedChannelEpgSourceId(e.target.value ? parseInt(e.target.value) : null)}
+                    >
+                      <option value="">Select a dummy EPG source...</option>
+                      {(epgSourcesQuery.data ?? []).filter((s: any) => s.source_type === "dummy").map((source: any) => (
+                        <option key={source.id} value={source.id}>
+                          {source.name}
+                        </option>
+                      ))}
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Channels created for unmatched streams will use this EPG source for placeholder data.
+                      {epgSourcesQuery.data && !(epgSourcesQuery.data as any[]).some((s: any) => s.source_type === "dummy") && (
+                        <span className="text-destructive block mt-1">
+                          No dummy EPG sources found. Please create one in Dispatcharr first.
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Groups to import */}

--- a/frontend/src/pages/EventGroupImport.tsx
+++ b/frontend/src/pages/EventGroupImport.tsx
@@ -22,6 +22,7 @@ import { LeaguePicker } from "@/components/LeaguePicker"
 import { ChannelProfileSelector } from "@/components/ChannelProfileSelector"
 import { StreamProfileSelector } from "@/components/StreamProfileSelector"
 import { StreamTimezoneSelector } from "@/components/StreamTimezoneSelector"
+import type { EPGSource } from "@/api/settings"
 
 // Types
 interface M3UAccount {
@@ -882,7 +883,7 @@ export function EventGroupImport() {
                       onChange={(e) => setBulkUnmatchedChannelEpgSourceId(e.target.value ? parseInt(e.target.value) : null)}
                     >
                       <option value="">Select a dummy EPG source...</option>
-                      {(epgSourcesQuery.data ?? []).filter((s: any) => s.source_type === "dummy").map((source: any) => (
+                      {(epgSourcesQuery.data ?? []).filter((s: EPGSource) => s.source_type === "dummy").map((source: EPGSource) => (
                         <option key={source.id} value={source.id}>
                           {source.name}
                         </option>
@@ -890,7 +891,7 @@ export function EventGroupImport() {
                     </Select>
                     <p className="text-xs text-muted-foreground">
                       Channels created for unmatched streams will use this EPG source for placeholder data.
-                      {epgSourcesQuery.data && !(epgSourcesQuery.data as any[]).some((s: any) => s.source_type === "dummy") && (
+                      {epgSourcesQuery.data && !(epgSourcesQuery.data as EPGSource[]).some((s: EPGSource) => s.source_type === "dummy") && (
                         <span className="text-destructive block mt-1">
                           No dummy EPG sources found. Please create one in Dispatcharr first.
                         </span>

--- a/teamarr/api/routes/dispatcharr.py
+++ b/teamarr/api/routes/dispatcharr.py
@@ -274,6 +274,7 @@ def list_epg_sources() -> list[dict]:
             "name": s.name,
             "url": s.url,
             "status": s.status,
+            "source_type": s.source_type,
         }
         for s in sources
     ]

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -115,6 +115,9 @@ class GroupCreate(BaseModel):
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str = "time"
     overlap_handling: str = "add_stream"
+    # Unmatched stream handling
+    create_unmatched_channels: bool = False
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool = True
     # Template assignments for multi-league groups (optional, created after group)
     template_assignments: list["GroupTemplateCreate"] | None = None
@@ -174,6 +177,8 @@ class GroupUpdate(BaseModel):
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str | None = None
     overlap_handling: str | None = None
+    create_unmatched_channels: bool | None = None
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool | None = None
 
     # Clear flags for nullable fields
@@ -199,6 +204,7 @@ class GroupUpdate(BaseModel):
     clear_custom_regex_event_name: bool = False
     clear_include_teams: bool = False
     clear_exclude_teams: bool = False
+    clear_unmatched_channel_epg_source_id: bool = False
 
     @field_validator("channel_profile_ids", mode="before")
     @classmethod
@@ -273,6 +279,9 @@ class GroupResponse(BaseModel):
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str = "time"
     overlap_handling: str = "add_stream"
+    # Unmatched stream handling
+    create_unmatched_channels: bool = False
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool = True
     created_at: str | None = None
     updated_at: str | None = None
@@ -340,6 +349,9 @@ class BulkGroupSettings(BaseModel):
     duplicate_event_handling: str = "consolidate"
     channel_sort_order: str = "time"
     overlap_handling: str = "add_stream"
+    # Unmatched stream handling
+    create_unmatched_channels: bool = False
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool = True
 
     @field_validator("channel_profile_ids", mode="before")
@@ -395,6 +407,8 @@ class BulkGroupUpdateRequest(BaseModel):
     duplicate_event_handling: str | None = None
     channel_sort_order: str | None = None
     overlap_handling: str | None = None
+    create_unmatched_channels: bool | None = None
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool | None = None
 
     # Clear flags to explicitly set fields to NULL
@@ -403,6 +417,7 @@ class BulkGroupUpdateRequest(BaseModel):
     clear_channel_profile_ids: bool = False
     clear_stream_profile_id: bool = False
     clear_stream_timezone: bool = False
+    clear_unmatched_channel_epg_source_id: bool = False
 
     @field_validator("channel_profile_ids", mode="before")
     @classmethod
@@ -608,6 +623,8 @@ def list_groups(
                 excluded_league_not_included=g.excluded_league_not_included,
                 channel_sort_order=g.channel_sort_order,
                 overlap_handling=g.overlap_handling,
+                create_unmatched_channels=g.create_unmatched_channels,
+                unmatched_channel_epg_source_id=g.unmatched_channel_epg_source_id,
                 enabled=g.enabled,
                 created_at=g.created_at.isoformat() if g.created_at else None,
                 updated_at=g.updated_at.isoformat() if g.updated_at else None,
@@ -693,6 +710,8 @@ def create_group(request: GroupCreate):
             team_filter_mode=request.team_filter_mode,
             channel_sort_order=request.channel_sort_order,
             overlap_handling=request.overlap_handling,
+            create_unmatched_channels=request.create_unmatched_channels,
+            unmatched_channel_epg_source_id=request.unmatched_channel_epg_source_id,
             enabled=request.enabled,
         )
 
@@ -767,6 +786,8 @@ def create_group(request: GroupCreate):
         excluded_league_not_included=group.excluded_league_not_included,
         channel_sort_order=group.channel_sort_order,
         overlap_handling=group.overlap_handling,
+        create_unmatched_channels=group.create_unmatched_channels,
+        unmatched_channel_epg_source_id=group.unmatched_channel_epg_source_id,
         enabled=group.enabled,
         created_at=group.created_at.isoformat() if group.created_at else None,
         updated_at=group.updated_at.isoformat() if group.updated_at else None,
@@ -826,6 +847,8 @@ def create_groups_bulk(request: BulkGroupCreateRequest):
                     duplicate_event_handling=request.settings.duplicate_event_handling,
                     channel_sort_order=request.settings.channel_sort_order,
                     overlap_handling=request.settings.overlap_handling,
+                    create_unmatched_channels=request.settings.create_unmatched_channels,
+                    unmatched_channel_epg_source_id=request.settings.unmatched_channel_epg_source_id,
                     m3u_group_id=item.m3u_group_id,
                     m3u_group_name=item.m3u_group_name,
                     m3u_account_id=item.m3u_account_id,
@@ -919,12 +942,15 @@ def update_groups_bulk(request: BulkGroupUpdateRequest):
                     duplicate_event_handling=request.duplicate_event_handling,
                     channel_sort_order=request.channel_sort_order,
                     overlap_handling=request.overlap_handling,
+                    create_unmatched_channels=request.create_unmatched_channels,
+                    unmatched_channel_epg_source_id=request.unmatched_channel_epg_source_id,
                     enabled=request.enabled,
                     clear_template=request.clear_template,
                     clear_channel_group_id=request.clear_channel_group_id,
                     clear_channel_profile_ids=request.clear_channel_profile_ids,
                     clear_stream_profile_id=request.clear_stream_profile_id,
                     clear_stream_timezone=request.clear_stream_timezone,
+                    clear_unmatched_channel_epg_source_id=request.clear_unmatched_channel_epg_source_id,
                 )
 
                 results.append(
@@ -1044,6 +1070,8 @@ def get_group_by_id(group_id: int):
         excluded_league_not_included=group.excluded_league_not_included,
         channel_sort_order=group.channel_sort_order,
         overlap_handling=group.overlap_handling,
+        create_unmatched_channels=group.create_unmatched_channels,
+        unmatched_channel_epg_source_id=group.unmatched_channel_epg_source_id,
         enabled=group.enabled,
         created_at=group.created_at.isoformat() if group.created_at else None,
         updated_at=group.updated_at.isoformat() if group.updated_at else None,
@@ -1239,6 +1267,8 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
         excluded_league_not_included=group.excluded_league_not_included,
         channel_sort_order=group.channel_sort_order,
         overlap_handling=group.overlap_handling,
+        create_unmatched_channels=group.create_unmatched_channels,
+        unmatched_channel_epg_source_id=group.unmatched_channel_epg_source_id,
         enabled=group.enabled,
         created_at=group.created_at.isoformat() if group.created_at else None,
         updated_at=group.updated_at.isoformat() if group.updated_at else None,

--- a/teamarr/api/routes/settings/dispatcharr.py
+++ b/teamarr/api/routes/settings/dispatcharr.py
@@ -160,7 +160,7 @@ def get_dispatcharr_status() -> dict:
 
 
 @router.get("/dispatcharr/epg-sources")
-def get_dispatcharr_epg_sources() -> dict:
+def get_dispatcharr_epg_sources(include_dummy: bool = False) -> dict:
     """Get available EPG sources from Dispatcharr.
 
     Returns list of EPG sources that can be selected for EPG ID.
@@ -177,7 +177,7 @@ def get_dispatcharr_epg_sources() -> dict:
                 "sources": [],
             }
 
-        sources = conn.epg.list_sources(include_dummy=False)
+        sources = conn.epg.list_sources(include_dummy=include_dummy)
         return {
             "success": True,
             "sources": [

--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -1370,6 +1370,50 @@ class EventGroupProcessor:
                 if xmltv_content and self._dispatcharr_client:
                     self._trigger_epg_refresh(group)
 
+            # Step 8: Handle unmatched streams if enabled (Phase 8)
+            if group.create_unmatched_channels:
+                # Filter for unmatched streams that were NOT excluded by regex
+                # match_result.results contains all streams passed to matching
+                unmatched_streams = []
+                for r in match_result.results:
+                    if not r.matched:
+                        # Find the original stream dict
+                        stream = next((s for s in streams if s["name"] == r.stream_name), None)
+                        if stream:
+                            unmatched_streams.append(stream)
+
+                if unmatched_streams:
+                    logger.info(
+                        "Processing %d unmatched streams for channel creation",
+                        len(unmatched_streams),
+                    )
+
+                    # Create lifecycle service for unmatched processing
+                    unmatched_lifecycle = create_lifecycle_service(
+                        self._db_factory,
+                        self._service,
+                        self._dispatcharr_client,
+                    )
+
+                    unmatched_result = unmatched_lifecycle.process_unmatched_streams(
+                        unmatched_streams,
+                        asdict(group),
+                    )
+
+                    # Merge results into main processing stats
+                    result.channels_created += len(unmatched_result.created)
+                    result.channels_existing += len(unmatched_result.existing)
+                    result.channel_errors += len(unmatched_result.errors)
+
+                    stats_run.channels_created += len(unmatched_result.created)
+                    stats_run.channels_updated += len(unmatched_result.existing)
+                    stats_run.channels_errors += len(unmatched_result.errors)
+
+                    for error in unmatched_result.errors:
+                        result.errors.append(
+                            f"Unmatched channel error: {error.get('stream', '')}: {error.get('error', '')}"
+                        )
+
             # Mark run as completed successfully
             stats_run.complete(status="completed")
 

--- a/teamarr/database/checkpoint_v50.py
+++ b/teamarr/database/checkpoint_v50.py
@@ -1,0 +1,44 @@
+"""Database checkpoint for version 50.
+
+Adds columns for unmatched stream handling:
+- create_unmatched_channels (BOOLEAN)
+- unmatched_channel_epg_source_id (INTEGER)
+"""
+
+import logging
+from sqlite3 import Connection
+
+logger = logging.getLogger(__name__)
+
+
+def apply_checkpoint_v50(conn: Connection, current_version: int) -> None:
+    """Apply database schema updates for version 50.
+
+    Args:
+        conn: Database connection
+        current_version: Current schema version
+    """
+    if current_version >= 50:
+        return
+
+    logger.info("[MIGRATE] applying v50 checkpoint (unmatched stream handling)")
+
+    # Add columns to event_epg_groups if not present
+    cursor = conn.execute("PRAGMA table_info(event_epg_groups)")
+    columns = {row["name"] for row in cursor.fetchall()}
+
+    if "create_unmatched_channels" not in columns:
+        conn.execute(
+            "ALTER TABLE event_epg_groups ADD COLUMN create_unmatched_channels BOOLEAN DEFAULT 0"
+        )
+        logger.info("[MIGRATE] Added event_epg_groups.create_unmatched_channels column")
+
+    if "unmatched_channel_epg_source_id" not in columns:
+        conn.execute(
+            "ALTER TABLE event_epg_groups ADD COLUMN unmatched_channel_epg_source_id INTEGER"
+        )
+        logger.info("[MIGRATE] Added event_epg_groups.unmatched_channel_epg_source_id column")
+
+    # Update schema version
+    conn.execute("UPDATE settings SET schema_version = 50 WHERE id = 1")
+    logger.info("[MIGRATE] Schema updated to version 50")

--- a/teamarr/database/connection.py
+++ b/teamarr/database/connection.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from teamarr.database.checkpoint_v43 import apply_checkpoint_v43
+from teamarr.database.checkpoint_v50 import apply_checkpoint_v50
 
 logger = logging.getLogger(__name__)
 
@@ -1125,6 +1126,13 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         conn.execute("UPDATE settings SET schema_version = 49 WHERE id = 1")
         logger.info("[MIGRATE] Schema upgraded to version 49 (combat sports custom regex)")
         current_version = 49
+
+    # ==========================================================================
+    # v47: Unmatched Stream Handling
+    # ==========================================================================
+    if current_version < 50:
+        apply_checkpoint_v50(conn, current_version)
+        current_version = 50
 
 
 # =============================================================================

--- a/teamarr/database/groups.py
+++ b/teamarr/database/groups.py
@@ -80,6 +80,9 @@ class EventEPGGroup:
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str = "time"
     overlap_handling: str = "add_stream"
+    # Unmatched stream handling
+    create_unmatched_channels: bool = False
+    unmatched_channel_epg_source_id: int | None = None
     enabled: bool = True
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -213,6 +216,13 @@ def _row_to_group(row) -> EventEPGGroup:
         # Multi-sport enhancements
         channel_sort_order=row["channel_sort_order"] or "time",
         overlap_handling=row["overlap_handling"] or "add_stream",
+        # Unmatched stream handling
+        create_unmatched_channels=bool(row["create_unmatched_channels"])
+        if "create_unmatched_channels" in row.keys()
+        else False,
+        unmatched_channel_epg_source_id=row["unmatched_channel_epg_source_id"]
+        if "unmatched_channel_epg_source_id" in row.keys()
+        else None,
         enabled=bool(row["enabled"]),
         created_at=created_at,
         updated_at=updated_at,
@@ -359,6 +369,9 @@ def create_group(
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str = "time",
     overlap_handling: str = "add_stream",
+    # Unmatched stream handling
+    create_unmatched_channels: bool = False,
+    unmatched_channel_epg_source_id: int | None = None,
     enabled: bool = True,
 ) -> int:
     """Create a new event EPG group.
@@ -412,8 +425,10 @@ def create_group(
             custom_regex_event_name, custom_regex_event_name_enabled,
             skip_builtin_filter,
             include_teams, exclude_teams, team_filter_mode,
-            channel_sort_order, overlap_handling, enabled
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
+            channel_sort_order, overlap_handling,
+            create_unmatched_channels, unmatched_channel_epg_source_id,
+            enabled
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
         (
             name,
             display_name,
@@ -457,6 +472,8 @@ def create_group(
             team_filter_mode,
             channel_sort_order,
             overlap_handling,
+            int(create_unmatched_channels),
+            unmatched_channel_epg_source_id,
             int(enabled),
         ),
     )
@@ -519,6 +536,9 @@ def update_group(
     # Multi-sport enhancements (Phase 3)
     channel_sort_order: str | None = None,
     overlap_handling: str | None = None,
+    # Unmatched stream handling
+    create_unmatched_channels: bool | None = None,
+    unmatched_channel_epg_source_id: int | None = None,
     enabled: bool | None = None,
     # Clear flags
     clear_display_name: bool = False,
@@ -543,6 +563,7 @@ def update_group(
     clear_custom_regex_event_name: bool = False,
     clear_include_teams: bool = False,
     clear_exclude_teams: bool = False,
+    clear_unmatched_channel_epg_source_id: bool = False,
 ) -> bool:
     """Update an event EPG group.
 
@@ -854,6 +875,16 @@ def update_group(
     if overlap_handling is not None:
         updates.append("overlap_handling = ?")
         values.append(overlap_handling)
+
+    if create_unmatched_channels is not None:
+        updates.append("create_unmatched_channels = ?")
+        values.append(int(create_unmatched_channels))
+
+    if unmatched_channel_epg_source_id is not None:
+        updates.append("unmatched_channel_epg_source_id = ?")
+        values.append(unmatched_channel_epg_source_id)
+    elif clear_unmatched_channel_epg_source_id:
+        updates.append("unmatched_channel_epg_source_id = NULL")
 
     if enabled is not None:
         updates.append("enabled = ?")

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -423,6 +423,10 @@ CREATE TABLE IF NOT EXISTS event_epg_groups (
     overlap_handling TEXT DEFAULT 'add_stream'
         CHECK(overlap_handling IN ('add_stream', 'add_only', 'create_all', 'skip')),
 
+    -- Unmatched Stream Handling
+    create_unmatched_channels BOOLEAN DEFAULT 0,    -- Create channels for unmatched streams
+    unmatched_channel_epg_source_id INTEGER,        -- Dispatcharr EPG source ID for unmatched channels
+
     -- Status
     enabled BOOLEAN DEFAULT 1,
 


### PR DESCRIPTION
Full disclosure I used gemini to assist with these changes

Based on discussion in #22 

This adds db fields to support creation of unmatched channels and dummy epg for items that are not matched. 

Added a process_unmatched teams method that creates / removes channels after the matched channels are added, then adds the dummy epg.

EventGroupForm and EventGroupInput pull dummy EPGs and present in the form when adding or editing an event group



