### PR TITLE
Bug 128 - Team 2 not parsing correctly so event not found

### DIFF
--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -560,6 +560,11 @@ def _clean_team_name(name: str) -> str:
     if " // " in name:
         name = name.split(" // ")[0]
 
+    #Truncate at "(" whcih is often after team name to indicate specific conditions
+    #I.E. Ottawa @ Carolina (Available outside Senators region
+    if "(" in name:
+        name = name.split("(")[0]
+    
     # Remove datetime masks
     name = re.sub(r"\bDATE_MASK\b", "", name)
     name = re.sub(r"\bTIME_MASK\b", "", name)


### PR DESCRIPTION
Sportsnet + and other groups often have events with tags such as (Available outside of Ottawa Region) after team 2 name. In the matcher logic it does not parse this out and the team 2 ends up being team2 (outside......). No event is then found.

I updated the matcher logic to remove strip after the ( when matching the name as no team name should have ( in it.......According to my searching.