### PR TITLE
feat: Formula 1 Support and Tournament Event Matching

### DIFF
--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -25,6 +25,7 @@ class StreamCategory(Enum):
 
     TEAM_VS_TEAM = "team_vs_team"  # Standard team matchup (vs/@/at)
     EVENT_CARD = "event_card"  # Combat sports (UFC, Boxing)
+    EVENT = "event"  # Individual/Tournament sports (F1, Golf, Tennis)
     PLACEHOLDER = "placeholder"  # No event info, skip
 
 
@@ -894,6 +895,30 @@ def is_event_card(text: str, league_event_type: str | None = None) -> bool:
     return detected == "EVENT_CARD"
 
 
+def is_event(text: str, league_event_type: str | None = None) -> bool:
+    """Check if stream is an individual/tournament event (F1, Golf).
+
+    Uses detect_event_type() which checks event_type_keywords.
+
+    Args:
+        text: Normalized stream name
+        league_event_type: Optional event_type from leagues table
+
+    Returns:
+        True if stream is an individual/tournament event
+    """
+    if not text:
+        return False
+
+    # If we know the league type, use that
+    if league_event_type == "event":
+        return True
+
+    # Use event type detection - checks EVENT keywords
+    detected = DetectionKeywordService.detect_event_type(text)
+    return detected == "EVENT"
+
+
 def extract_event_card_hint(text: str) -> str | None:
     """Extract event card identifier (e.g., "UFC 315").
 
@@ -1066,6 +1091,36 @@ def _clean_fighter_name(name: str) -> str | None:
     return name
 
 
+def _clean_event_name(text: str) -> str | None:
+    """Clean stream name to extract event name for individual sports.
+
+    Strips league prefixes, quality indicators, and other noise.
+
+    Args:
+        text: Normalized stream name
+
+    Returns:
+        Cleaned event name or None
+    """
+    if not text:
+        return None
+
+    # Use the same cleanup logic as _clean_team_name but specialized
+    name = _clean_team_name(text)
+
+    # Further strip common prefixes that might still be there
+    name = re.sub(r"^(?:f1|formula\s*1|racing|nascar|indycar|golf|tennis)\s*[:\-]?\s*", "", name, flags=re.IGNORECASE)
+
+    # Strip common suffixes
+    name = re.sub(r"\s+[\(\[]?(?:live|hd|sd|fhd|4k|uhd)[\)\]]?\s*$", "", name, flags=re.IGNORECASE)
+
+    # Final cleanup
+    name = re.sub(r"^[\s\-:.,]+", "", name)
+    name = re.sub(r"[\s\-:.,]+$", "", name)
+
+    return name.strip() if len(name) >= 3 else None
+
+
 # =============================================================================
 # MAIN CLASSIFICATION
 # =============================================================================
@@ -1200,6 +1255,18 @@ def classify_stream(
                 league_hint=league_hint,
                 sport_hint=sport_hint,
                 custom_regex_used=custom_regex_used,
+            )
+
+        # Step 2b: Check for individual/tournament event
+        if result is None and is_event(text, league_event_type):
+            event_name = _clean_event_name(text)
+
+            result = ClassifiedStream(
+                category=StreamCategory.EVENT,
+                normalized=normalized,
+                event_hint=event_name,
+                league_hint=league_hint,
+                sport_hint=sport_hint,
             )
 
         # Step 3: Try custom regex for team extraction (if configured)

--- a/teamarr/consumers/matching/event_matcher.py
+++ b/teamarr/consumers/matching/event_matcher.py
@@ -97,14 +97,6 @@ class EventCardMatcher:
         Returns:
             MatchOutcome with result
         """
-        if classified.category != StreamCategory.EVENT_CARD:
-            return MatchOutcome.filtered(
-                FilteredReason.NOT_EVENT,
-                stream_name=classified.normalized.original,
-                stream_id=stream_id,
-                detail="Not an event card stream",
-            )
-
         ctx = EventMatchContext(
             stream_name=classified.normalized.original,
             stream_id=stream_id,
@@ -155,6 +147,137 @@ class EventCardMatcher:
             self._cache_result(ctx, result)
 
         return result
+
+
+class TournamentMatcher:
+    """Matches individual/tournament streams (F1, Golf) to provider events.
+
+    Matches by fuzzy matching the extracted event_hint against Event.name.
+    """
+
+    def __init__(
+        self,
+        service: SportsDataService,
+        cache: StreamMatchCache,
+    ):
+        self._service = service
+        self._cache = cache
+
+    def match(
+        self,
+        classified: ClassifiedStream,
+        league: str,
+        target_date: date,
+        group_id: int,
+        stream_id: int,
+        generation: int,
+        user_tz: ZoneInfo,
+    ) -> MatchOutcome:
+        """Match a tournament stream to a provider event."""
+        if not classified.event_hint:
+            return MatchOutcome.failed(
+                FailedReason.NO_EVENT_MATCH,
+                stream_name=classified.normalized.original,
+                stream_id=stream_id,
+                detail="No event hint extracted from stream name",
+            )
+
+        ctx = EventMatchContext(
+            stream_name=classified.normalized.original,
+            stream_id=stream_id,
+            group_id=group_id,
+            target_date=target_date,
+            generation=generation,
+            user_tz=user_tz,
+            classified=classified,
+        )
+
+        # Check cache first
+        cache_result = self._check_cache(ctx)
+        if cache_result:
+            logger.debug(
+                "[CACHE HIT] event_card stream=%s matched=%s",
+                ctx.stream_name[:50],
+                cache_result.event.name if cache_result.event else "None",
+            )
+            return cache_result
+
+        # Get events for this league
+        is_tsdb = self._service.get_provider_name(league) == "tsdb"
+        events = self._service.get_events(league, target_date, cache_only=is_tsdb)
+        if not events:
+            return MatchOutcome.failed(
+                FailedReason.NO_EVENT_MATCH,
+                stream_name=ctx.stream_name,
+                stream_id=stream_id,
+                detail=f"No {league} events for {target_date}",
+            )
+
+        # Filter to events on target date
+        date_events = [e for e in events if e.start_time.astimezone(user_tz).date() == target_date]
+
+        if not date_events:
+            return MatchOutcome.failed(
+                FailedReason.NO_EVENT_MATCH,
+                stream_name=ctx.stream_name,
+                stream_id=stream_id,
+                detail=f"No {league} events on {target_date}",
+            )
+
+        # Try to match by name
+        result = self._match_by_name(ctx, date_events, league)
+
+        # Cache successful matches
+        if result.is_matched and result.event:
+            self._cache_result(ctx, result)
+
+        return result
+
+    def _match_by_name(
+        self,
+        ctx: EventMatchContext,
+        events: list[Event],
+        league: str,
+    ) -> MatchOutcome:
+        """Match stream to event by fuzzy name matching."""
+        hint_norm = normalize_text(ctx.classified.event_hint)
+
+        best_score = 0
+        best_event = None
+
+        for event in events:
+            event_norm = normalize_text(event.name)
+            score = fuzz.token_set_ratio(hint_norm, event_norm)
+
+            if score > best_score:
+                best_score = score
+                best_event = event
+
+        # F1/Racing needs high threshold to distinguish between Practice/Qualifying/Race
+        # but token_set_ratio should handle this if those words are in both
+        if best_score >= 80:
+            confidence = best_score / 100.0
+            logger.debug(
+                "[MATCHED] tournament stream=%s -> %s (score=%d)",
+                ctx.stream_name[:40],
+                best_event.name,
+                best_score,
+            )
+            return MatchOutcome.matched(
+                MatchMethod.FUZZY,
+                best_event,
+                detected_league=league,
+                confidence=confidence,
+                stream_name=ctx.stream_name,
+                stream_id=ctx.stream_id,
+            )
+
+        return MatchOutcome.failed(
+            FailedReason.NO_EVENT_MATCH,
+            stream_name=ctx.stream_name,
+            stream_id=ctx.stream_id,
+            detail=f"No {league} event matched fuzzy name (best score: {best_score})",
+        )
 
     # =========================================================================
     # PRIVATE METHODS

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -34,7 +34,7 @@ from teamarr.consumers.matching.classifier import (
     classify_stream,
 )
 from teamarr.consumers.matching.constants import MATCH_WINDOW_DAYS
-from teamarr.consumers.matching.event_matcher import EventCardMatcher
+from teamarr.consumers.matching.event_matcher import EventCardMatcher, TournamentMatcher
 from teamarr.consumers.matching.result import (
     ExcludedReason,
     FailedReason,
@@ -272,6 +272,7 @@ class StreamMatcher:
             service, self._cache, days_ahead=self._days_ahead, db_factory=db_factory
         )
         self._event_matcher = EventCardMatcher(service, self._cache)
+        self._tournament_matcher = TournamentMatcher(service, self._cache)
 
         # League event types cache
         self._league_event_types: dict[str, str] = {}
@@ -499,6 +500,12 @@ class StreamMatcher:
                 stream_id=stream_id,
                 target_date=target_date,
             )
+        elif classified.category == StreamCategory.EVENT:
+            outcome = self._match_tournament(
+                classified=classified,
+                stream_id=stream_id,
+                target_date=target_date,
+            )
         else:  # TEAM_VS_TEAM
             outcome = self._match_team_vs_team(
                 classified=classified,
@@ -598,6 +605,48 @@ class StreamMatcher:
             stream_name=classified.normalized.original,
             stream_id=stream_id,
             detail="No matching event card found",
+        )
+
+    def _match_tournament(
+        self,
+        classified: ClassifiedStream,
+        stream_id: int,
+        target_date: date,
+    ) -> MatchOutcome:
+        """Match a tournament/individual event stream (F1, Golf)."""
+        # Find tournament leagues in our search leagues
+        tournament_leagues = [
+            lg for lg in self._search_leagues if self._league_event_types.get(lg) == "event"
+        ]
+
+        if not tournament_leagues:
+            return MatchOutcome.filtered(
+                FilteredReason.LEAGUE_NOT_INCLUDED,
+                stream_name=classified.normalized.original,
+                stream_id=stream_id,
+                detail="No tournament/event leagues configured",
+            )
+
+        # Try each tournament league
+        for league in tournament_leagues:
+            outcome = self._tournament_matcher.match(
+                classified=classified,
+                league=league,
+                target_date=target_date,
+                group_id=self._group_id,
+                stream_id=stream_id,
+                generation=self._generation,
+                user_tz=self._user_tz,
+            )
+            if outcome.is_matched:
+                return outcome
+
+        # No match in any tournament league
+        return MatchOutcome.failed(
+            reason=outcome.failed_reason if outcome else None,
+            stream_name=classified.normalized.original,
+            stream_id=stream_id,
+            detail="No matching tournament event found",
         )
 
     def _outcome_to_result(

--- a/teamarr/consumers/matching/result.py
+++ b/teamarr/consumers/matching/result.py
@@ -97,6 +97,9 @@ class FailedReason(Enum):
     # Event card failures (UFC, boxing)
     NO_EVENT_CARD_MATCH = "no_event_card_match"  # Could not match to event card
 
+    # Tournament/Individual event failures (F1, Golf)
+    NO_EVENT_MATCH = "no_event_match"  # Could not match to tournament/individual event
+
     # Date validation failures (stream has date that doesn't match any event)
     DATE_MISMATCH = "date_mismatch"  # Stream date != event date
 
@@ -396,6 +399,7 @@ FAILED_DISPLAY: dict[FailedReason, str] = {
     FailedReason.AMBIGUOUS_LEAGUE: "Multiple leagues possible",
     FailedReason.NO_EVENT_FOUND: "No scheduled event found",
     FailedReason.NO_EVENT_CARD_MATCH: "No matching event card",
+    FailedReason.NO_EVENT_MATCH: "No matching event found",
     FailedReason.DATE_MISMATCH: "Stream date doesn't match event",
 }
 

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -846,7 +846,6 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
 
     -- Racing (ESPN)
     ('f1', 'espn', 'racing/f1', NULL, 'Formula 1', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/f1.png', NULL, 1, 'F1', 'f1', 'event', 'Formula 1', NULL, NULL),
-    ('nascar', 'espn', 'racing/nascar', NULL, 'NASCAR', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/nascar.png', NULL, 1, 'NASCAR', 'nascar', 'event', 'NASCAR', NULL, NULL),
 
     -- Boxing (TSDB) - Combat sport with event cards
     ('boxing', 'tsdb', '4445', 'Boxing', 'Boxing', 'boxing', NULL, NULL, 0, NULL, 'boxing', 'event_card', NULL, NULL, NULL);

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -847,8 +847,6 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     -- Racing (ESPN)
     ('f1', 'espn', 'racing/f1', NULL, 'Formula 1', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/f1.png', NULL, 1, 'F1', 'f1', 'event', 'Formula 1', NULL, NULL),
     ('nascar', 'espn', 'racing/nascar', NULL, 'NASCAR', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/nascar.png', NULL, 1, 'NASCAR', 'nascar', 'event', 'NASCAR', NULL, NULL),
-    ('indycar', 'espn', 'racing/indycar', NULL, 'IndyCar', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/indy.png', NULL, 1, 'IndyCar', 'indycar', 'event', 'IndyCar', NULL, NULL),
-    ('motogp', 'espn', 'racing/motogp', NULL, 'MotoGP', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/motogp.png', NULL, 1, 'MotoGP', 'motogp', 'event', 'MotoGP', NULL, NULL),
 
     -- Boxing (TSDB) - Combat sport with event cards
     ('boxing', 'tsdb', '4445', 'Boxing', 'Boxing', 'boxing', NULL, NULL, 0, NULL, 'boxing', 'event_card', NULL, NULL, NULL);

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -844,6 +844,12 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     ('nrl', 'tsdb', '4416', 'Australian National Rugby League', 'National Rugby League', 'rugby', 'https://r2.thesportsdb.com/images/media/league/badge/gsztcj1552071996.png', NULL, 1, 'NRL', 'nrl', 'team_vs_team', NULL, NULL, NULL),
     ('super-rugby', 'tsdb', '4551', 'Super Rugby', 'Super Rugby Pacific', 'rugby', 'https://r2.thesportsdb.com/images/media/league/badge/alpxhe1675871443.png', NULL, 1, 'Super Rugby', 'super-rugby', 'team_vs_team', NULL, NULL, NULL),
 
+    -- Racing (ESPN)
+    ('f1', 'espn', 'racing/f1', NULL, 'Formula 1', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/f1.png', NULL, 1, 'F1', 'f1', 'event', 'Formula 1', NULL, NULL),
+    ('nascar', 'espn', 'racing/nascar', NULL, 'NASCAR', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/nascar.png', NULL, 1, 'NASCAR', 'nascar', 'event', 'NASCAR', NULL, NULL),
+    ('indycar', 'espn', 'racing/indycar', NULL, 'IndyCar', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/indy.png', NULL, 1, 'IndyCar', 'indycar', 'event', 'IndyCar', NULL, NULL),
+    ('motogp', 'espn', 'racing/motogp', NULL, 'MotoGP', 'racing', 'https://a.espncdn.com/i/teamlogos/leagues/500/motogp.png', NULL, 1, 'MotoGP', 'motogp', 'event', 'MotoGP', NULL, NULL),
+
     -- Boxing (TSDB) - Combat sport with event cards
     ('boxing', 'tsdb', '4445', 'Boxing', 'Boxing', 'boxing', NULL, NULL, 0, NULL, 'boxing', 'event_card', NULL, NULL, NULL);
 

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -111,8 +111,8 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
 
         # Check if this is a tournament sport
         sport = self._get_display_sport(league)
-        if sport in TOURNAMENT_SPORTS:
-            return self._get_tournament_events(league, target_date, sport)
+        if sport.lower() in TOURNAMENT_SPORTS:
+            return self._get_tournament_events(league, target_date, sport, sport_league)
 
         date_str = target_date.strftime("%Y%m%d")
         data = self._client.get_scoreboard(league, date_str, sport_league)
@@ -146,6 +146,17 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
         This hybrid approach ensures .last variables work even during long breaks
         (bye weeks, all-star break, offseason) while still capturing playoffs.
         """
+        # Special case: F1/Racing virtual team returns full league schedule
+        if league == "f1" and team_id == "f1":
+            events = []
+            today = date.today()
+            sport = self._get_display_sport(league)
+            sport_league = self._get_sport_league_from_db(league)
+            for day_offset in range(days_ahead):
+                target_date = today + timedelta(days=day_offset)
+                events.extend(self._get_tournament_events(league, target_date, sport, sport_league))
+            return sorted(events, key=lambda e: e.start_time)
+
         # Apply team ID correction for known ESPN mismatches
         corrected_id = ESPN_TEAM_ID_CORRECTIONS.get((league, team_id))
         if corrected_id:
@@ -272,6 +283,19 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
         return False
 
     def get_team(self, team_id: str, league: str) -> Team | None:
+        # Special case: F1/Racing virtual team
+        if league == "f1" and team_id == "f1":
+            return Team(
+                id="f1",
+                provider=self.name,
+                name="Formula 1",
+                short_name="F1",
+                abbreviation="F1",
+                league="f1",
+                sport="Racing",
+                logo_url="https://a.espncdn.com/i/teamlogos/leagues/500/f1.png",
+            )
+
         # Combat sports don't have teams endpoint - skip to avoid 404 spam
         if league in self.LEAGUES_WITHOUT_TEAMS:
             return None
@@ -326,10 +350,12 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
     # Leagues without teams endpoint support
     # Leagues where /teams endpoint doesn't work or isn't needed:
     # - Combat sports (MMA, boxing): individual fighters, not teams
+    # - Racing (F1): virtual team representing league used instead
     # - Olympics: teams only in events, no team filtering/import needed
     LEAGUES_WITHOUT_TEAMS = {
         "ufc",
         "boxing",
+        "f1",
         "olympics-mens-ice-hockey",
         "olympics-womens-ice-hockey",
     }
@@ -669,6 +695,21 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
         Returns:
             List of Team objects for this league
         """
+        # Special case: F1/Racing returns a virtual team representing the league
+        if league == "f1":
+            return [
+                Team(
+                    id="f1",
+                    provider=self.name,
+                    name="Formula 1",
+                    short_name="F1",
+                    abbreviation="F1",
+                    league="f1",
+                    sport="Racing",
+                    logo_url="https://a.espncdn.com/i/teamlogos/leagues/500/f1.png",
+                )
+            ]
+
         # Combat sports don't have teams - skip to avoid 404 spam
         if league in self.LEAGUES_WITHOUT_TEAMS:
             logger.debug("[ESPN] Teams endpoint not available for %s (individual sport)", league)

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -283,6 +283,10 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
         return False
 
     def get_team(self, team_id: str, league: str) -> Team | None:
+        # Skip placeholder tournament teams
+        if team_id.startswith("tournament_"):
+            return None
+
         # Special case: F1/Racing virtual team
         if league == "f1" and team_id == "f1":
             return Team(
@@ -792,6 +796,14 @@ class ESPNProvider(UFCParserMixin, TournamentParserMixin, SportsProvider):
         Returns TeamStats with record, rankings, scoring averages,
         and conference/division info.
         """
+        # Skip leagues without teams (F1, UFC, etc.)
+        if league in self.LEAGUES_WITHOUT_TEAMS:
+            return None
+
+        # Skip placeholder tournament teams
+        if team_id.startswith("tournament_"):
+            return None
+
         # Get sport/league from database config
         sport_league = self._get_sport_league_from_db(league)
 

--- a/teamarr/providers/espn/tournament.py
+++ b/teamarr/providers/espn/tournament.py
@@ -7,7 +7,9 @@ traditional home/away matchups.
 import logging
 from datetime import date, datetime
 
+from teamarr.config import get_user_timezone
 from teamarr.core import Event, EventStatus, Team, Venue
+from teamarr.utilities.tz import to_user_tz
 
 logger = logging.getLogger(__name__)
 
@@ -20,44 +22,97 @@ class TournamentParserMixin:
         - self.name: Provider name ('espn')
     """
 
-    def _get_tournament_events(self, league: str, target_date: date, sport: str) -> list[Event]:
+    def _get_tournament_events(
+        self,
+        league: str,
+        target_date: date,
+        sport: str,
+        sport_league: tuple[str, str] | None = None,
+    ) -> list[Event]:
         """Get events for tournament sports (tennis, golf, racing).
 
         These sports have tournaments/races as events with many competitors,
         not head-to-head matchups with home/away.
         """
         date_str = target_date.strftime("%Y%m%d")
-        data = self._client.get_scoreboard(league, date_str)
+        data = self._client.get_scoreboard(league, date_str, sport_league)
         if not data:
             return []
 
         events = []
+        from teamarr.utilities.tz import to_user_tz
+
         for event_data in data.get("events", []):
-            event = self._parse_tournament_event(event_data, league, sport)
-            if event:
-                events.append(event)
+            # For tournament sports, an "event" (like a Grand Prix) can contain
+            # multiple "competitions" (Practice 1, Practice 2, Qualifying, Race).
+            # We want each competition to be its own Event in Teamarr.
+            competitions = event_data.get("competitions", [])
+            if not competitions:
+                # Fallback to top-level event if no competitions
+                event = self._parse_tournament_event(event_data, event_data, league, sport)
+                if event:
+                    events.append(event)
+                continue
+
+            for comp_data in competitions:
+                event = self._parse_tournament_event(event_data, comp_data, league, sport)
+                if event:
+                    # Filter by target_date in user timezone
+                    if to_user_tz(event.start_time).date() == target_date:
+                        events.append(event)
 
         return events
 
-    def _parse_tournament_event(self, data: dict, league: str, sport: str) -> Event | None:
-        """Parse a tournament-style event (tennis, golf, racing).
+    def _parse_tournament_event(
+        self, event_data: dict, comp_data: dict, league: str, sport: str
+    ) -> Event | None:
+        """Parse a tournament-style competition (session, round, etc.).
 
-        Creates placeholder 'teams' representing the tournament/event itself.
+        Args:
+            event_data: Top-level event data (Grand Prix name, etc.)
+            comp_data: Specific competition/session data
+            league: League code
+            sport: Sport name
+
+        Returns:
+            Event object or None
         """
         try:
-            event_id = data.get("id", "")
+            event_id = comp_data.get("id") or event_data.get("id", "")
             if not event_id:
                 return None
 
-            # Parse start time
-            date_str = data.get("date")
+            # Parse start time from competition
+            date_str = comp_data.get("date") or event_data.get("date")
             if not date_str:
                 return None
 
             start_time = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
 
-            event_name = data.get("name", "")
-            short_name = data.get("shortName", event_name)
+            # Build name: "Grand Prix Name - Session Type"
+            base_name = event_data.get("name", "")
+            comp_type = comp_data.get("type", {})
+            session_name = comp_type.get("shortDetail") or comp_type.get("abbreviation") or ""
+
+            if session_name and session_name not in base_name:
+                # Map abbreviations to friendly names for better matching
+                session_map = {
+                    "FP1": "Free Practice 1",
+                    "FP2": "Free Practice 2",
+                    "FP3": "Free Practice 3",
+                    "Qual": "Qualifying",
+                    "Race": "Race",
+                    "SR": "Sprint Race",
+                    "SS": "Sprint Shootout",
+                    "SQ": "Sprint Qualifying",
+                    "Sprint": "Sprint Qualifying",
+                }
+                friendly_session = session_map.get(session_name, session_name)
+                event_name = f"{base_name} - {friendly_session}"
+            else:
+                event_name = base_name
+
+            short_name = comp_data.get("shortName") or event_data.get("shortName") or event_name
 
             # For tournaments, create placeholder "teams"
             # This allows the event to work with existing matching logic
@@ -73,8 +128,8 @@ class TournamentParserMixin:
                 color=None,
             )
 
-            # Parse status
-            status_data = data.get("status", {})
+            # Parse status from competition
+            status_data = comp_data.get("status", {})
             type_data = status_data.get("type", {}) if status_data else {}
             state = type_data.get("state", "pre")
 
@@ -85,18 +140,26 @@ class TournamentParserMixin:
             else:
                 status = EventStatus(state="scheduled")
 
-            # Parse venue if available
+            # Parse venue
             venue = None
-            competitions = data.get("competitions", [])
-            if competitions:
-                venue_data = competitions[0].get("venue")
-                if venue_data:
-                    venue = Venue(
-                        name=venue_data.get("fullName", ""),
-                        city=venue_data.get("address", {}).get("city", ""),
-                        state=venue_data.get("address", {}).get("state", ""),
-                        country=venue_data.get("address", {}).get("country", ""),
-                    )
+            venue_data = comp_data.get("venue") or event_data.get("venue")
+            if not venue_data and "competitions" in event_data:
+                # Sometimes venue is only in the first competition of the event
+                venue_data = event_data["competitions"][0].get("venue")
+
+            if venue_data:
+                venue = Venue(
+                    name=venue_data.get("fullName", ""),
+                    city=venue_data.get("address", {}).get("city", ""),
+                    state=venue_data.get("address", {}).get("state", ""),
+                    country=venue_data.get("address", {}).get("country", ""),
+                )
+
+            # Parse broadcasts
+            broadcasts = []
+            for b in comp_data.get("broadcasts", []):
+                names = b.get("names", [])
+                broadcasts.extend(names)
 
             return Event(
                 id=str(event_id),
@@ -110,7 +173,7 @@ class TournamentParserMixin:
                 league=league,
                 sport=sport,
                 venue=venue,
-                broadcasts=[],
+                broadcasts=broadcasts,
             )
 
         except Exception as e:

--- a/teamarr/providers/espn/tournament.py
+++ b/teamarr/providers/espn/tournament.py
@@ -112,7 +112,14 @@ class TournamentParserMixin:
             else:
                 event_name = base_name
 
-            short_name = comp_data.get("shortName") or event_data.get("shortName") or event_name
+            # Build shortName: "GP ShortName - Session Abbrev"
+            base_short = event_data.get("shortName") or base_name
+            if session_name and session_name not in base_short:
+                # Use abbreviation for shortName (e.g., "Chinese GP - FP1")
+                abbrev = comp_type.get("abbreviation") or session_name
+                short_name = f"{base_short} - {abbrev}"
+            else:
+                short_name = base_short
 
             # For tournaments, create placeholder "teams"
             # This allows the event to work with existing matching logic

--- a/teamarr/utilities/constants.py
+++ b/teamarr/utilities/constants.py
@@ -455,9 +455,6 @@ LEAGUE_HINT_PATTERNS: list[tuple[str, str | list[str]]] = [
     # ==========================================================================
     (r"\bf1\b", "f1"),
     (r"\bformula\s*1\b", "f1"),
-    (r"\bmotogp\b", "motogp"),
-    (r"\bnascar\b", "nascar"),
-    (r"\bindycar\b", "indycar"),
     # ==========================================================================
     # Rugby
     # ==========================================================================
@@ -529,9 +526,6 @@ SPORT_HINT_PATTERNS: list[tuple[str, str]] = [
     # Racing
     (r"\bf1\b", "Racing"),
     (r"\bformula\s*1\b", "Racing"),
-    (r"\bmotogp\b", "Racing"),
-    (r"\bnascar\b", "Racing"),
-    (r"\bindycar\b", "Racing"),
 ]
 
 
@@ -630,9 +624,6 @@ EVENT_TYPE_KEYWORDS: dict[str, list[str]] = {
         "race",
         "golf",
         "tennis",
-        "nascar",
-        "indycar",
-        "motogp",
     ],
     # =========================================================================
     # TEAM_VS_TEAM - Team sports (detected via separators, no keywords needed)

--- a/teamarr/utilities/constants.py
+++ b/teamarr/utilities/constants.py
@@ -451,6 +451,14 @@ LEAGUE_HINT_PATTERNS: list[tuple[str, str | list[str]]] = [
     (r"\bnll[:\s-]", "nll"),
     (r"\bpll[:\s-]", "pll"),
     # ==========================================================================
+    # Racing / F1
+    # ==========================================================================
+    (r"\bf1\b", "f1"),
+    (r"\bformula\s*1\b", "f1"),
+    (r"\bmotogp\b", "motogp"),
+    (r"\bnascar\b", "nascar"),
+    (r"\bindycar\b", "indycar"),
+    # ==========================================================================
     # Rugby
     # ==========================================================================
     (r"\bnrl[:\s-]", "nrl"),
@@ -518,6 +526,12 @@ SPORT_HINT_PATTERNS: list[tuple[str, str]] = [
     (r"\btennis\b", "Tennis"),
     # Golf (not currently supported)
     (r"\bgolf\b", "Golf"),
+    # Racing
+    (r"\bf1\b", "Racing"),
+    (r"\bformula\s*1\b", "Racing"),
+    (r"\bmotogp\b", "Racing"),
+    (r"\bnascar\b", "Racing"),
+    (r"\bindycar\b", "Racing"),
 ]
 
 
@@ -601,6 +615,24 @@ EVENT_TYPE_KEYWORDS: dict[str, list[str]] = {
         "ibf",  # International Boxing Federation
         "wbo",  # World Boxing Organization
         "ibo",  # International Boxing Organization
+    ],
+    # =========================================================================
+    # EVENT - Individual/Tournament sports (Formula 1, Golf, Tennis)
+    # These match by event name hint rather than team vs team separators.
+    # =========================================================================
+    "EVENT": [
+        "f1",
+        "formula 1",
+        "grand prix",
+        "grandprix",
+        "qualifying",
+        "practice",
+        "race",
+        "golf",
+        "tennis",
+        "nascar",
+        "indycar",
+        "motogp",
     ],
     # =========================================================================
     # TEAM_VS_TEAM - Team sports (detected via separators, no keywords needed)

--- a/tests/test_espn_f1_integration.py
+++ b/tests/test_espn_f1_integration.py
@@ -1,0 +1,213 @@
+"""Integration tests for ESPN F1 provider support.
+
+Verifies that the ESPN provider correctly constructs URLs and parses
+tournament/racing data from the actual ESPN API structure.
+"""
+
+from datetime import date, UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teamarr.core import LeagueMapping, LeagueMappingSource
+from teamarr.providers.espn.client import ESPNClient
+from teamarr.providers.espn.provider import ESPNProvider
+
+@pytest.fixture(autouse=True)
+def mock_user_timezone():
+    """Ensure tests run in UTC for predictable date comparison."""
+    # Patch to_user_tz to just return the datetime as-is (assuming it's already UTC)
+    with patch("teamarr.providers.espn.tournament.to_user_tz") as mock_to_tz:
+        mock_to_tz.side_effect = lambda dt: dt
+        yield mock_to_tz
+
+class TestESPNF1Integration:
+    """Integration-style tests for ESPN F1 parsing logic."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Mock client to verify URL parameters and provide real-world JSON samples."""
+        return MagicMock(spec=ESPNClient)
+
+    @pytest.fixture
+    def mock_mapping_source(self):
+        source = MagicMock(spec=LeagueMappingSource)
+        # Mock F1 mapping - this is what triggers the 'racing/f1' logic
+        source.get_mapping.return_value = LeagueMapping(
+            league_code="f1",
+            provider="espn",
+            provider_league_id="racing/f1",
+            provider_league_name="Formula 1",
+            sport="Racing",
+            display_name="Formula 1",
+        )
+        return source
+
+    @pytest.fixture
+    def provider(self, mock_client, mock_mapping_source):
+        return ESPNProvider(client=mock_client, league_mapping_source=mock_mapping_source)
+
+    def test_get_events_f1_path_construction(self, provider, mock_client):
+        """Verify that F1 requests use the 'racing' sport and 'f1' league in the client."""
+        target_date = date(2026, 3, 1)
+        
+        # Real-world snippet of ESPN tournament scoreboard response
+        mock_client.get_scoreboard.return_value = {
+            "leagues": [{"name": "Formula 1"}],
+            "events": [
+                {
+                    "id": "401712345",
+                    "name": "Bahrain Grand Prix",
+                    "date": "2026-03-01T15:00Z",
+                    "competitions": [
+                        {
+                            "id": "401712345",
+                            "date": "2026-03-01T15:00Z",
+                            "status": {"type": {"name": "STATUS_SCHEDULED", "description": "Scheduled"}},
+                            "venue": {"fullName": "Bahrain International Circuit"},
+                            "competitors": [
+                                # Tournament competitors often have placeholder IDs or are just generic
+                                {"id": "1", "homeAway": "home", "team": {"displayName": "Bahrain Grand Prix"}},
+                                {"id": "2", "homeAway": "away", "team": {"displayName": "Bahrain Grand Prix"}}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        events = provider.get_events("f1", target_date)
+
+        # Verify the client was called with the correct sport/league extracted from provider_league_id
+        mock_client.get_scoreboard.assert_called_once_with(
+            "f1", "20260301", ("racing", "f1")
+        )
+
+        assert len(events) == 1
+        assert events[0].name == "Bahrain Grand Prix"
+        assert events[0].sport == "Racing"
+        assert events[0].venue.name == "Bahrain International Circuit"
+
+    def test_f1_virtual_team_id_handling(self, provider, mock_client):
+        """Verify that get_team_schedule for 'f1' uses tournament parsing."""
+        target_date = date.today()
+        date_str = target_date.strftime("%Y%m%d")
+        
+        mock_client.get_scoreboard.return_value = {"events": []}
+        
+        provider.get_team_schedule("f1", "f1", days_ahead=1)
+
+        # Should call get_scoreboard for 'f1' league with 'racing/f1' sport_league
+        mock_client.get_scoreboard.assert_called_with(
+            "f1", date_str, ("racing", "f1")
+        )
+
+    def test_f1_multiple_sessions_parsing(self, provider, mock_client):
+        """Verify that a Grand Prix with multiple competitions is expanded correctly."""
+        target_date = date(2025, 12, 5) # FP1 date from real data
+        
+        mock_client.get_scoreboard.return_value = {
+            "events": [
+                {
+                    "id": "401712345",
+                    "name": "Abu Dhabi Grand Prix",
+                    "competitions": [
+                        {
+                            "id": "1",
+                            "date": "2025-12-05T09:30Z",
+                            "type": {"abbreviation": "FP1", "shortDetail": "FP1"},
+                            "status": {"type": {"state": "pre"}}
+                        },
+                        {
+                            "id": "2",
+                            "date": "2025-12-05T13:00Z",
+                            "type": {"abbreviation": "FP2", "shortDetail": "FP2"},
+                            "status": {"type": {"state": "pre"}}
+                        },
+                        {
+                            "id": "5",
+                            "date": "2025-12-07T13:00Z",
+                            "type": {"abbreviation": "Race", "shortDetail": "Race"},
+                            "status": {"type": {"state": "pre"}}
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # Asking for the 5th (Practice day)
+        events = provider.get_events("f1", target_date)
+
+        # Should find 2 events (FP1 and FP2) because they both happen on target_date
+        assert len(events) == 2
+        assert any(e.name == "Abu Dhabi Grand Prix - Free Practice 1" for e in events)
+        assert any(e.name == "Abu Dhabi Grand Prix - Free Practice 2" for e in events)
+        assert not any("Race" in e.name for e in events)
+
+    def test_f1_sprint_sessions_parsing(self, provider, mock_client):
+        """Verify that F1 Sprint sessions (SR, SS) are parsed correctly."""
+        target_date = date(2024, 10, 19)
+        
+        mock_client.get_scoreboard.return_value = {
+            "events": [
+                {
+                    "id": "401712345",
+                    "name": "United States Grand Prix",
+                    "competitions": [
+                        {
+                            "id": "10",
+                            "date": "2024-10-18T21:30Z",
+                            "type": {"abbreviation": "SS"},
+                            "status": {"type": {"state": "post"}}
+                        },
+                        {
+                            "id": "11",
+                            "date": "2024-10-19T18:00Z",
+                            "type": {"abbreviation": "SR"},
+                            "status": {"type": {"state": "post"}}
+                        }
+                    ]
+                }
+            ]
+        }
+
+        events = provider.get_events("f1", target_date)
+
+        # On the 19th, only the Sprint Race should match
+        assert len(events) == 1
+        assert events[0].name == "United States Grand Prix - Sprint Race"
+
+    def test_f1_2026_sprint_abbreviation_parsing(self, provider, mock_client):
+        """Verify that the 'Sprint' abbreviation used in 2026 is parsed as Sprint Qualifying."""
+        target_date = date(2026, 3, 13)
+        
+        mock_client.get_scoreboard.return_value = {
+            "events": [
+                {
+                    "id": "600057428",
+                    "name": "Chinese Grand Prix",
+                    "competitions": [
+                        {
+                            "id": "401839034",
+                            "date": "2026-03-13T07:30Z",
+                            "type": {"abbreviation": "Sprint"},
+                            "status": {"type": {"state": "pre"}}
+                        }
+                    ]
+                }
+            ]
+        }
+
+        events = provider.get_events("f1", target_date)
+        assert len(events) == 1
+        assert events[0].name == "Chinese Grand Prix - Sprint Qualifying"
+
+    def test_leagues_without_teams_f1(self, provider):
+        """Verify F1 is correctly identified as a league without a standard /teams endpoint."""
+        # This prevents the provider from trying to hit /teams/f1 which would 404
+        assert "f1" in provider.LEAGUES_WITHOUT_TEAMS
+        
+        # Calling get_league_teams should return our virtual team instead of hitting the API
+        teams = provider.get_league_teams("f1")
+        assert len(teams) == 1
+        assert teams[0].id == "f1"

--- a/tests/test_espn_f1_integration.py
+++ b/tests/test_espn_f1_integration.py
@@ -140,6 +140,8 @@ class TestESPNF1Integration:
 
         # Should find 2 events (FP1 and FP2) because they both happen on target_date
         assert len(events) == 2
+        fp1 = next(e for e in events if "Free Practice 1" in e.name)
+        assert fp1.short_name == "Abu Dhabi Grand Prix - FP1"
         assert any(e.name == "Abu Dhabi Grand Prix - Free Practice 1" for e in events)
         assert any(e.name == "Abu Dhabi Grand Prix - Free Practice 2" for e in events)
         assert not any("Race" in e.name for e in events)

--- a/tests/test_f1_matching.py
+++ b/tests/test_f1_matching.py
@@ -1,0 +1,187 @@
+"""Tests for Formula 1 (Tournament) stream matching.
+
+Validates that F1 streams match correctly via the new TournamentMatcher
+path, which uses fuzzy matching on event names instead of team separators.
+"""
+
+import sqlite3
+from datetime import UTC, datetime, date
+from unittest.mock import MagicMock
+
+import pytest
+
+from teamarr.consumers.matching import StreamMatcher
+from teamarr.consumers.matching.classifier import StreamCategory
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.services.sports_data import SportsDataService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tournament_event(name: str, start_time: datetime, league: str = "f1") -> Event:
+    """Create a minimal tournament Event for testing."""
+    # Tournament events use same team for home/away in TournamentParserMixin
+    tournament_team = Team(
+        id=f"tournament_f1_{name.lower().replace(' ', '_')}",
+        provider="espn",
+        name=name,
+        short_name=name[:20],
+        abbreviation="F1",
+        league=league,
+        sport="racing",
+    )
+    
+    return Event(
+        id=f"evt-{name.lower().replace(' ', '_')}",
+        provider="espn",
+        name=name,
+        short_name=name[:20],
+        start_time=start_time,
+        home_team=tournament_team,
+        away_team=tournament_team,
+        status=EventStatus(state="scheduled"),
+        league=league,
+        sport="racing",
+    )
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestF1Matching:
+    """Integration tests for F1 matching via StreamMatcher."""
+
+    @pytest.fixture
+    def db_factory(self):
+        """In-memory database for settings/leagues lookup."""
+        def _factory():
+            # Use isolation_level=None to allow explicit transaction control (BEGIN EXCLUSIVE)
+            conn = sqlite3.connect(":memory:", isolation_level=None)
+            conn.row_factory = sqlite3.Row
+            conn.execute("CREATE TABLE settings (id INTEGER PRIMARY KEY, event_match_days_ahead INTEGER, epg_generation_counter INTEGER DEFAULT 0)")
+            conn.execute("INSERT INTO settings (id, event_match_days_ahead, epg_generation_counter) VALUES (1, 3, 0)")
+            
+            conn.execute("""
+                CREATE TABLE leagues (
+                    league_code TEXT PRIMARY KEY,
+                    provider TEXT,
+                    provider_league_id TEXT,
+                    provider_league_name TEXT,
+                    display_name TEXT,
+                    sport TEXT,
+                    event_type TEXT,
+                    enabled INTEGER
+                )
+            """)
+            conn.execute("""
+                INSERT INTO leagues (league_code, provider, provider_league_id, display_name, sport, event_type, enabled)
+                VALUES ('f1', 'espn', 'racing/f1', 'Formula 1', 'racing', 'event', 1)
+            """)
+
+            # Add missing tables needed by matchers
+            conn.execute("CREATE TABLE team_aliases (alias TEXT, league TEXT, provider TEXT, team_id TEXT, team_name TEXT)")
+            conn.execute("CREATE TABLE stream_match_cache (fingerprint TEXT PRIMARY KEY, group_id INTEGER, stream_id INTEGER, stream_name TEXT, event_id TEXT, league TEXT, cached_event_data TEXT, match_method TEXT, user_corrected BOOLEAN, corrected_at TIMESTAMP, last_seen_generation INTEGER, created_at TIMESTAMP, updated_at TIMESTAMP)")
+            
+            return conn
+        return _factory
+
+    @pytest.fixture
+    def service(self):
+        """Mock SportsDataService."""
+        service = MagicMock(spec=SportsDataService)
+        service.get_provider_name.return_value = "espn"
+        return service
+
+    def test_basic_f1_race_match(self, service, db_factory):
+        """F1: Bahrain Grand Prix → Bahrain Grand Prix."""
+        target_date = date(2026, 3, 1)
+        event = _make_tournament_event(
+            "Bahrain Grand Prix", 
+            datetime(2026, 3, 1, 15, 0, tzinfo=UTC)
+        )
+        service.get_events.return_value = [event]
+
+        matcher = StreamMatcher(
+            service=service,
+            db_factory=db_factory,
+            group_id=1,
+            search_leagues=["f1"],
+        )
+
+        streams = [{"id": 1, "name": "F1: Bahrain Grand Prix"}]
+        result = matcher.match_all(streams, target_date)
+
+        assert result.matched_count == 1
+        res = result.results[0]
+        assert res.matched is True
+        assert res.event.id == event.id
+        assert res.category == StreamCategory.EVENT
+
+    def test_f1_qualifying_match(self, service, db_factory):
+        """Formula 1: Qualifying - Saudi Arabian Grand Prix → Saudi Arabian Grand Prix - Qualifying."""
+        target_date = date(2026, 3, 7)
+        event = _make_tournament_event(
+            "Saudi Arabian Grand Prix - Qualifying", 
+            datetime(2026, 3, 7, 18, 0, tzinfo=UTC)
+        )
+        service.get_events.return_value = [event]
+
+        matcher = StreamMatcher(
+            service=service,
+            db_factory=db_factory,
+            group_id=1,
+            search_leagues=["f1"],
+        )
+
+        streams = [{"id": 1, "name": "Formula 1: Qualifying - Saudi Arabian Grand Prix"}]
+        result = matcher.match_all(streams, target_date)
+
+        assert result.matched_count == 1
+        res = result.results[0]
+        assert res.matched is True
+        assert res.event.id == event.id
+
+    def test_f1_sessions_disambiguation(self, service, db_factory):
+        """Ensure Practice 1 doesn't match Race if both are available on same day (unlikely but possible)."""
+        target_date = date(2026, 3, 6)
+        p1 = _make_tournament_event("Saudi Arabian Grand Prix - Practice 1", datetime(2026, 3, 6, 13, 0, tzinfo=UTC))
+        p2 = _make_tournament_event("Saudi Arabian Grand Prix - Practice 2", datetime(2026, 3, 6, 17, 0, tzinfo=UTC))
+        service.get_events.return_value = [p1, p2]
+
+        matcher = StreamMatcher(
+            service=service,
+            db_factory=db_factory,
+            group_id=1,
+            search_leagues=["f1"],
+        )
+
+        # Match Practice 1
+        streams = [{"id": 1, "name": "F1: Saudi Arabian Grand Prix Practice 1"}]
+        result = matcher.match_all(streams, target_date)
+        assert result.results[0].event.id == p1.id
+
+        # Match Practice 2
+        streams = [{"id": 2, "name": "F1: Saudi Arabian Grand Prix Practice 2"}]
+        result = matcher.match_all(streams, target_date)
+        assert result.results[0].event.id == p2.id
+
+    def test_unrelated_racing_event(self, service, db_factory):
+        """Nascar stream should NOT match F1 event if categorized as EVENT but names differ too much."""
+        target_date = date(2026, 3, 1)
+        event = _make_tournament_event("Bahrain Grand Prix", datetime(2026, 3, 1, 15, 0, tzinfo=UTC))
+        service.get_events.return_value = [event]
+
+        matcher = StreamMatcher(
+            service=service,
+            db_factory=db_factory,
+            group_id=1,
+            search_leagues=["f1"],
+        )
+
+        # "Nascar Cup Series" is classified as EVENT because "nascar" is in EVENT_TYPE_KEYWORDS
+        streams = [{"id": 1, "name": "Nascar Cup Series"}]
+        result = matcher.match_all(streams, target_date)
+
+        assert result.matched_count == 0
+        assert result.results[0].matched is False

--- a/tests/test_f1_team_channel.py
+++ b/tests/test_f1_team_channel.py
@@ -1,0 +1,102 @@
+"""Tests for Formula 1 team-based EPG support.
+
+Validates that Formula 1 can be treated as a "Team" for persistent channels,
+returning the full league schedule.
+"""
+
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from teamarr.core import LeagueMapping, LeagueMappingSource
+from teamarr.providers.espn.client import ESPNClient
+from teamarr.providers.espn.provider import ESPNProvider
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestF1TeamChannel:
+    """Tests for F1 team channel support in ESPNProvider."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return MagicMock(spec=ESPNClient)
+
+    @pytest.fixture
+    def mock_mapping_source(self):
+        source = MagicMock(spec=LeagueMappingSource)
+        # Mock F1 mapping
+        source.get_mapping.return_value = LeagueMapping(
+            league_code="f1",
+            provider="espn",
+            provider_league_id="racing/f1",
+            provider_league_name="Formula 1",
+            sport="Racing",
+            display_name="Formula 1",
+            logo_url="https://a.espncdn.com/i/teamlogos/leagues/500/f1.png",
+        )
+        return source
+
+    @pytest.fixture
+    def provider(self, mock_client, mock_mapping_source):
+        return ESPNProvider(client=mock_client, league_mapping_source=mock_mapping_source)
+
+    def test_get_league_teams_returns_virtual_f1_team(self, provider):
+        """get_league_teams should return a virtual 'Formula 1' team for the f1 league."""
+        teams = provider.get_league_teams("f1")
+        
+        assert len(teams) == 1
+        f1_team = teams[0]
+        assert f1_team.id == "f1"
+        assert f1_team.name == "Formula 1"
+        assert f1_team.league == "f1"
+        assert f1_team.sport == "Racing"
+
+    def test_get_team_returns_virtual_f1_team(self, provider):
+        """get_team should return the virtual F1 team."""
+        f1_team = provider.get_team("f1", "f1")
+        
+        assert f1_team is not None
+        assert f1_team.id == "f1"
+        assert f1_team.name == "Formula 1"
+
+    def test_get_team_schedule_returns_all_f1_events(self, provider, mock_client):
+        """get_team_schedule for the F1 team should return all events in the league."""
+        # Mock scoreboard responses for 2 days
+        today = date.today()
+        tomorrow = today + timedelta(days=1)
+        
+        event1 = {
+            "id": "1",
+            "name": "Bahrain Grand Prix - Practice 1",
+            "date": today.strftime("%Y-%m-%dT15:00:00Z"),
+            "competitions": [{"venue": {"fullName": "Bahrain International Circuit"}}]
+        }
+        event2 = {
+            "id": "2",
+            "name": "Bahrain Grand Prix - Practice 2",
+            "date": tomorrow.strftime("%Y-%m-%dT18:00:00Z"),
+            "competitions": [{"venue": {"fullName": "Bahrain International Circuit"}}]
+        }
+        
+        # mock_client.get_scoreboard is called for each day
+        def get_scoreboard_side_effect(league, date_str, sport_league=None):
+            if date_str == today.strftime("%Y%m%d"):
+                return {"events": [event1]}
+            if date_str == tomorrow.strftime("%Y%m%d"):
+                return {"events": [event2]}
+            return {"events": []}
+            
+        mock_client.get_scoreboard.side_effect = get_scoreboard_side_effect
+
+        # Request 2 days of schedule
+        events = provider.get_team_schedule("f1", "f1", days_ahead=2)
+        
+        assert len(events) == 2
+        assert events[0].name == "Bahrain Grand Prix - Practice 1"
+        assert events[1].name == "Bahrain Grand Prix - Practice 2"
+        # Verify both are from the 'f1' league
+        assert events[0].league == "f1"
+        assert events[1].league == "f1"


### PR DESCRIPTION
This expands Teamarr's matching capabilities beyond "Team vs. Team" and "Event Cards" by introducing a third category: Tournament Events. This specifically enables support for Formula 1 where events consist of multiple sessions (Practice, Qualifying, Sprints, and Races) rather than head-to-head match-ups. This should set the groundwork for other events such as Nascar or Motogp.

   * F1 Session Parsing: Updated the ESPN provider to expand a single Grand Prix event into its constituent sessions. This ensures that users can track specific sessions and that the EPG correctly reflects what is airing on a given date.
   * Virtual F1 Team: Created a virtual "f1" team in the ESPN provider. This satisfies the system's "team-based" architecture, allowing users to add "Formula 1" as a team to
     their library and receive the full league schedule on a persistent channel.
   * 2026 Format Readiness: Verified and implemented support for ESPN's upcoming 2026 F1 data format, including the new "Sprint" and "SR" abbreviations.


  Supported Sessions
   * Free Practice 1, 2, and 3
   * Sprint Qualifying 
   * Sprint Race
   * Qualifying
   * Race
   
This was coded with Gemini but I verified EPG output and verified API outputs. 