### PR TITLE
Edge case with detect_sport_hint() returning list instead of string

### DIFF
--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -1702,8 +1702,15 @@ def get_raw_streams(group_id: int):
         if is_placeholder(name):
             return "placeholder"
         sport = detect_sport_hint(name)
-        if sport and sport in UNSUPPORTED_SPORTS:
-            return f"unsupported_sport:{sport}"
+
+        # detect_sport_hint may return a string or a list depending on match results
+        if isinstance(sport, list):
+            for s in sport:
+                if isinstance(s, str) and s in UNSUPPORTED_SPORTS:
+                    return f"unsupported_sport:{s}"
+        elif isinstance(sport, str):
+            if sport in UNSUPPORTED_SPORTS:
+                return f"unsupported_sport:{sport}"
         if not is_event_stream(name):
             return "not_event"
         return None


### PR DESCRIPTION
fix(groups): handle list return from detect_sport_hint in builtin stream filter

detect_sport_hint() can return either a string or a list depending on regex matches (notably with streams with custom regex titles). The previous implementation assumed a string and attempted membership checks against UNSUPPORTED_SPORTS, causing:

TypeError: unhashable type: 'list'

The builtin filter logic now safely handles both string and list values and checks each sport hint individually.