### PR TITLE
Add feed separation templates to the EPG template

### DIFF
--- a/teamarr/api/routes/backup.py
+++ b/teamarr/api/routes/backup.py
@@ -367,6 +367,11 @@ async def update_backup_settings(update: BackupSettingsUpdate):
             path=update.path,
         )
 
+    # Restart backup sub-scheduler with new settings
+    from teamarr.consumers.scheduler import restart_scheduler_sub_task
+
+    restart_scheduler_sub_task("backup")
+
     # Return updated settings
     with get_db() as conn:
         settings = get_backup_settings(conn)

--- a/teamarr/api/routes/settings/lifecycle.py
+++ b/teamarr/api/routes/settings/lifecycle.py
@@ -162,6 +162,12 @@ def update_scheduler_settings(update: SchedulerSettingsUpdate):
         if update.enabled:
             start_lifecycle_scheduler(get_db)
 
+    # Restart channel reset sub-scheduler if its settings changed
+    if update.channel_reset_enabled is not None or update.channel_reset_cron is not None:
+        from teamarr.consumers.scheduler import restart_scheduler_sub_task
+
+        restart_scheduler_sub_task("channel_reset")
+
     with get_db() as conn:
         settings = get_scheduler_settings(conn)
 

--- a/teamarr/consumers/event_epg.py
+++ b/teamarr/consumers/event_epg.py
@@ -414,6 +414,7 @@ class EventEPGGenerator:
                 league=event.league,
                 card_segment=segment,
             )
+            context.feed_team = match.get("feed_team")
             context.extra_vars = {"exception_keyword": keyword_value}
 
             # Generate channel name from template

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -1069,7 +1069,9 @@ class ChannelLifecycleService:
         delete_time = self._timing_manager.calculate_delete_time(event)
 
         # Resolve logo URL from template (supports template variables including {exception_keyword})
-        logo_url = self._resolve_logo_url(event, template, matched_keyword, segment)
+        logo_url = self._resolve_logo_url(
+            event, template, matched_keyword, segment, feed_team=feed_team,
+        )
 
         # Create in Dispatcharr
         dispatcharr_channel_id = None
@@ -1274,7 +1276,10 @@ class ChannelLifecycleService:
 
         # Resolve using full template engine with extra variables
         # Unknown variables stay literal (e.g., {bad_var}) so user can identify issues
-        base_name = self._resolve_template(name_format, event, extra_vars, card_segment=segment)
+        base_name = self._resolve_template(
+            name_format, event, extra_vars,
+            card_segment=segment, feed_team=feed_team,
+        )
 
         # Clean up empty wrappers when {exception_keyword} resolves to ""
         # e.g., "Team A @ Team B ()" → "Team A @ Team B"
@@ -1365,6 +1370,7 @@ class ChannelLifecycleService:
         template,
         exception_keyword: str | None = None,
         segment: str | None = None,
+        feed_team=None,
     ) -> str | None:
         """Resolve logo URL from template.
 
@@ -1376,6 +1382,7 @@ class ChannelLifecycleService:
             template: Can be dict, EventTemplateConfig dataclass, or None
             exception_keyword: Optional keyword for {exception_keyword} variable
             segment: UFC card segment code (e.g., "prelims", "main_card")
+            feed_team: Team object for feed separation (if detected)
         """
         logo_url = None
         if template:
@@ -1395,7 +1402,8 @@ class ChannelLifecycleService:
                     "exception_keyword": exception_keyword if exception_keyword else "",
                 }
                 return self._resolve_template(
-                    logo_url, event, extra_vars, card_segment=segment
+                    logo_url, event, extra_vars, card_segment=segment,
+                    feed_team=feed_team,
                 )
             return logo_url
 
@@ -1407,6 +1415,7 @@ class ChannelLifecycleService:
         event: Event,
         extra_variables: dict[str, str] | None = None,
         card_segment: str | None = None,
+        feed_team=None,
     ) -> str:
         """Resolve template string using full template engine.
 
@@ -1418,6 +1427,7 @@ class ChannelLifecycleService:
             extra_variables: Optional dict of additional variables to resolve
                 (e.g., {"exception_keyword": "Spanish"})
             card_segment: UFC card segment code (e.g., "prelims", "main_card")
+            feed_team: Team object for feed separation (if detected)
 
         Returns:
             Resolved string with variables replaced
@@ -1433,6 +1443,7 @@ class ChannelLifecycleService:
             league=event.league,
             card_segment=card_segment,
         )
+        context.feed_team = feed_team
         return self._resolver.resolve(template_str, context)
 
     def _get_next_channel_number(
@@ -1663,7 +1674,8 @@ class ChannelLifecycleService:
 
             # 8. Sync logo
             self._sync_channel_logo(
-                conn, existing, event, template, matched_keyword, segment, changes_made
+                conn, existing, event, template, matched_keyword, segment, changes_made,
+                feed_team=sync_feed_team,
             )
 
             # 9. Sync stream_profile_id
@@ -1824,11 +1836,14 @@ class ChannelLifecycleService:
         matched_keyword: str | None,
         segment: str | None,
         changes_made: list[str],
+        feed_team=None,
     ) -> None:
         """Sync logo — handles both updates and removals."""
         from teamarr.database.channels import update_managed_channel
 
-        logo_url = self._resolve_logo_url(event, template, matched_keyword, segment)
+        logo_url = self._resolve_logo_url(
+            event, template, matched_keyword, segment, feed_team=feed_team,
+        )
         current_logo_id = getattr(existing, "dispatcharr_logo_id", None)
         stored_logo_url = getattr(existing, "logo_url", None)
 

--- a/teamarr/consumers/scheduler.py
+++ b/teamarr/consumers/scheduler.py
@@ -21,6 +21,90 @@ from croniter import croniter
 logger = logging.getLogger(__name__)
 
 
+class SubTaskScheduler:
+    """Lightweight scheduler that runs a single task on its own cron.
+
+    Runs independently of the main EPG scheduler so tasks like backup
+    and channel reset fire at exactly the right time regardless of
+    EPG schedule alignment.
+    """
+
+    def __init__(self, name: str, task_fn: Any, cron_expression: str):
+        self._name = name
+        self._task_fn = task_fn
+        self._cron = cron_expression
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._running = False
+        self._next_run: datetime | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._running and self._thread is not None and self._thread.is_alive()
+
+    @property
+    def cron_expression(self) -> str:
+        return self._cron
+
+    @property
+    def next_run(self) -> datetime | None:
+        return self._next_run
+
+    def start(self) -> bool:
+        if self.is_running:
+            return False
+        try:
+            croniter(self._cron)
+        except (KeyError, ValueError) as e:
+            logger.error("[CRON:%s] Invalid expression '%s': %s", self._name, self._cron, e)
+            return False
+        self._stop_event.clear()
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name=f"cron-{self._name}",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("[CRON:%s] Started: %s", self._name, self._cron)
+        return True
+
+    def stop(self, timeout: float = 10.0) -> bool:
+        if not self.is_running:
+            return True
+        logger.debug("[CRON:%s] Stopping...", self._name)
+        self._stop_event.set()
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=timeout)
+            if self._thread.is_alive():
+                logger.warning("[CRON:%s] Thread did not stop in time", self._name)
+                return False
+        return True
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            cron = croniter(self._cron, datetime.now())
+            self._next_run = cron.get_next(datetime)
+            wait_seconds = (self._next_run - datetime.now()).total_seconds()
+            logger.debug(
+                "[CRON:%s] Next run: %s (%.0fs)",
+                self._name,
+                self._next_run.strftime("%Y-%m-%d %H:%M:%S"),
+                wait_seconds,
+            )
+            while wait_seconds > 0 and not self._stop_event.is_set():
+                time.sleep(min(1.0, wait_seconds))
+                wait_seconds = (self._next_run - datetime.now()).total_seconds()
+            if self._stop_event.is_set():
+                return
+            try:
+                logger.info("[CRON:%s] Running scheduled task", self._name)
+                self._task_fn()
+            except Exception as e:
+                logger.exception("[CRON:%s] Task failed: %s", self._name, e)
+
+
 class CronScheduler:
     """Background scheduler using cron expressions.
 
@@ -69,6 +153,7 @@ class CronScheduler:
         self._running = False
         self._last_run: datetime | None = None
         self._next_run: datetime | None = None
+        self._sub_schedulers: dict[str, SubTaskScheduler] = {}
 
     @property
     def is_running(self) -> bool:
@@ -116,6 +201,10 @@ class CronScheduler:
         )
         self._thread.start()
         logger.info("[CRON] Scheduler started: %s", self._cron_expression)
+
+        # Start independent sub-schedulers for backup and channel reset
+        self._start_sub_schedulers()
+
         return True
 
     def stop(self, timeout: float = 30.0) -> bool:
@@ -130,6 +219,11 @@ class CronScheduler:
         if not self.is_running:
             return True
 
+        # Stop sub-schedulers first
+        for _name, sub in self._sub_schedulers.items():
+            sub.stop(timeout=5.0)
+        self._sub_schedulers.clear()
+
         logger.debug("[CRON] Stopping scheduler...")
         self._stop_event.set()
         self._running = False
@@ -143,13 +237,71 @@ class CronScheduler:
         logger.info("[CRON] Scheduler stopped")
         return True
 
+    def _start_sub_schedulers(self) -> None:
+        """Start independent sub-schedulers for backup and channel reset."""
+        from teamarr.database.settings import get_backup_settings, get_scheduler_settings
+
+        with self._db_factory() as conn:
+            backup_settings = get_backup_settings(conn)
+            scheduler_settings = get_scheduler_settings(conn)
+
+        if backup_settings.enabled:
+            sub = SubTaskScheduler("backup", self._task_backup, backup_settings.cron)
+            if sub.start():
+                self._sub_schedulers["backup"] = sub
+
+        if scheduler_settings.channel_reset_enabled and scheduler_settings.channel_reset_cron:
+            sub = SubTaskScheduler(
+                "channel-reset", self._task_channel_reset, scheduler_settings.channel_reset_cron
+            )
+            if sub.start():
+                self._sub_schedulers["channel_reset"] = sub
+
+    def restart_sub_task(self, task_name: str) -> None:
+        """Restart a sub-scheduler after settings change."""
+        # Stop existing if running
+        if task_name in self._sub_schedulers:
+            self._sub_schedulers[task_name].stop(timeout=5.0)
+            del self._sub_schedulers[task_name]
+
+        if task_name == "backup":
+            from teamarr.database.settings import get_backup_settings
+
+            with self._db_factory() as conn:
+                settings = get_backup_settings(conn)
+            if settings.enabled:
+                sub = SubTaskScheduler("backup", self._task_backup, settings.cron)
+                if sub.start():
+                    self._sub_schedulers["backup"] = sub
+        elif task_name == "channel_reset":
+            from teamarr.database.settings import get_scheduler_settings
+
+            with self._db_factory() as conn:
+                settings = get_scheduler_settings(conn)
+            if settings.channel_reset_enabled and settings.channel_reset_cron:
+                sub = SubTaskScheduler(
+                    "channel-reset", self._task_channel_reset, settings.channel_reset_cron
+                )
+                if sub.start():
+                    self._sub_schedulers["channel_reset"] = sub
+
     def run_once(self) -> dict:
         """Run all scheduled tasks once (for testing/manual trigger).
 
         Returns:
             Dict with task results
         """
-        return self._run_tasks()
+        results = self._run_tasks()
+        # Also run sub-tasks synchronously for manual trigger
+        try:
+            results["backup"] = self._task_backup()
+        except Exception as e:
+            results["backup"] = {"error": str(e)}
+        try:
+            results["channel_reset"] = self._task_channel_reset()
+        except Exception as e:
+            results["channel_reset"] = {"error": str(e)}
+        return results
 
     def _run_loop(self) -> None:
         """Main scheduler loop - runs in background thread."""
@@ -190,14 +342,10 @@ class CronScheduler:
                 logger.exception("[CRON] Error in scheduled run: %s", e)
 
     def _run_tasks(self) -> dict:
-        """Run all scheduled tasks.
+        """Run EPG-related scheduled tasks.
 
-        Tasks:
-        - Scheduled channel reset (if enabled and cron matches)
-        - Daily cache refresh (team/league data from ESPN/TSDB)
-        - EPG generation (teams, groups, XMLTV)
-        - Dispatcharr integration
-        - Channel lifecycle (deletions, reconciliation, cleanup)
+        Backup and channel reset run on their own independent sub-schedulers
+        and are NOT part of the EPG tick. They are only called here via run_once().
 
         Returns:
             Dict with task results
@@ -205,25 +353,9 @@ class CronScheduler:
         self._last_run = datetime.now()
         results = {
             "started_at": self._last_run.isoformat(),
-            "backup": {},
-            "channel_reset": {},
             "cache_refresh": {},
             "epg_generation": {},
         }
-
-        # Scheduled backup (runs on its own cron, checked each tick)
-        try:
-            results["backup"] = self._task_backup()
-        except Exception as e:
-            logger.warning("[CRON] Backup task failed: %s", e)
-            results["backup"] = {"error": str(e)}
-
-        # Scheduled channel reset (runs before EPG generation if due)
-        try:
-            results["channel_reset"] = self._task_channel_reset()
-        except Exception as e:
-            logger.warning("[CRON] Channel reset task failed: %s", e)
-            results["channel_reset"] = {"error": str(e)}
 
         # Daily cache refresh (only refreshes if > 1 day old)
         try:
@@ -243,11 +375,10 @@ class CronScheduler:
         return results
 
     def _task_channel_reset(self) -> dict:
-        """Reset all Teamarr channels if scheduled.
+        """Reset all Teamarr channels.
 
-        Checks if channel reset is enabled and if the reset cron schedule
-        has fired since the last scheduler run. If so, purges all Teamarr
-        channels from Dispatcharr.
+        Called by its own sub-scheduler at the configured cron time.
+        Purges all Teamarr channels from Dispatcharr.
 
         This helps users with Jellyfin logo caching issues - by scheduling
         reset right before Jellyfin's guide refresh, channel logos get
@@ -267,25 +398,6 @@ class CronScheduler:
         if not settings.channel_reset_cron:
             return {"skipped": True, "reason": "No reset cron expression configured"}
 
-        # Check if reset cron has fired since last scheduler run
-        # We use a 1-hour window to catch the reset even if scheduler timing drifts
-        try:
-            reset_cron = croniter(settings.channel_reset_cron, datetime.now())
-            last_reset_time = reset_cron.get_prev(datetime)
-
-            # If last reset time was within the last hour, run the reset
-            time_since_reset = (datetime.now() - last_reset_time).total_seconds()
-            if time_since_reset > 3600:  # More than 1 hour ago
-                return {
-                    "skipped": True,
-                    "reason": "Reset not due yet",
-                    "last_scheduled": last_reset_time.isoformat(),
-                }
-        except (KeyError, ValueError) as e:
-            logger.warning("[CRON] Invalid channel reset cron: %s", e)
-            return {"skipped": True, "reason": f"Invalid cron: {e}"}
-
-        # Perform the reset
         logger.info("[CRON] Running scheduled channel reset")
 
         from teamarr.dispatcharr import ChannelManager, get_dispatcharr_client
@@ -330,10 +442,9 @@ class CronScheduler:
         }
 
     def _task_backup(self) -> dict:
-        """Run scheduled backup if enabled and due.
+        """Run scheduled backup.
 
-        Checks its own cron expression (separate from the main EPG cron).
-        Uses the same 1-hour window approach as channel reset.
+        Called by its own sub-scheduler at the configured cron time.
 
         Returns:
             Dict with backup status
@@ -346,23 +457,6 @@ class CronScheduler:
         if not settings.enabled:
             return {"skipped": True, "reason": "Scheduled backups not enabled"}
 
-        # Check if backup cron has fired since last scheduler run
-        try:
-            backup_cron = croniter(settings.cron, datetime.now())
-            last_backup_time = backup_cron.get_prev(datetime)
-
-            time_since_backup = (datetime.now() - last_backup_time).total_seconds()
-            if time_since_backup > 3600:  # More than 1 hour ago
-                return {
-                    "skipped": True,
-                    "reason": "Backup not due yet",
-                    "last_scheduled": last_backup_time.isoformat(),
-                }
-        except (KeyError, ValueError) as e:
-            logger.warning("[CRON] Invalid backup cron: %s", e)
-            return {"skipped": True, "reason": f"Invalid cron: {e}"}
-
-        # Perform the backup
         logger.info("[CRON] Running scheduled backup")
 
         from teamarr.services.backup_service import create_backup_service
@@ -603,11 +697,36 @@ def get_scheduler_status() -> dict:
     if not _scheduler:
         return {"running": False}
 
-    return {
+    status = {
         "running": _scheduler.is_running,
         "cron_expression": _scheduler.cron_expression,
         "last_run": _scheduler.last_run.isoformat() if _scheduler.last_run else None,
         "next_run": _scheduler.next_run.isoformat() if _scheduler.next_run else None,
+        "sub_tasks": {},
     }
+
+    for name, sub in _scheduler._sub_schedulers.items():
+        status["sub_tasks"][name] = {
+            "running": sub.is_running,
+            "cron_expression": sub.cron_expression,
+            "next_run": sub.next_run.isoformat() if sub.next_run else None,
+        }
+
+    return status
+
+
+def restart_scheduler_sub_task(task_name: str) -> bool:
+    """Restart a sub-scheduler task (e.g., after settings change).
+
+    Args:
+        task_name: "backup" or "channel_reset"
+
+    Returns:
+        True if restarted, False if scheduler not running
+    """
+    if not _scheduler or not _scheduler.is_running:
+        return False
+    _scheduler.restart_sub_task(task_name)
+    return True
 
 

--- a/teamarr/templates/context.py
+++ b/teamarr/templates/context.py
@@ -87,6 +87,10 @@ class TemplateContext:
     next_game: GameContext | None = None  # For .next suffix
     last_game: GameContext | None = None  # For .last suffix
 
+    # Feed separation: the team whose broadcast feed this channel carries
+    # Set when a stream is identified as a home/away feed (e.g., "Orioles Feed")
+    feed_team: Team | None = None
+
     # Extra variables injected at resolution time (override registered extractors)
     # Used for values that aren't derived from event data (e.g., exception_keyword)
     extra_vars: dict[str, str] = field(default_factory=dict)

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -1,6 +1,7 @@
-"""Home/Away variables: location context, team positions.
+"""Home/Away variables: location context, team positions, feed separation.
 
-These variables provide home/away context and positional team references.
+These variables provide home/away context, positional team references,
+and feed team data for streams broken out into home/away channels.
 """
 
 from teamarr.templates.context import GameContext, TemplateContext
@@ -245,3 +246,116 @@ def extract_away_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -
     if not game_ctx or not game_ctx.event:
         return ""
     return game_ctx.event.away_team.logo_url or ""
+
+
+# --- Feed team variables (stream-level home/away feed separation) ---
+# These resolve to the team whose broadcast feed this channel carries.
+# Empty string when no feed separation is active (graceful disappear).
+
+
+@register_variable(
+    name="feed_team",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team full name (e.g., 'Baltimore Orioles')",
+)
+def extract_feed_team(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.name
+
+
+@register_variable(
+    name="feed_team_short",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team short name (e.g., 'Orioles')",
+)
+def extract_feed_team_short(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.short_name or ctx.feed_team.name
+
+
+@register_variable(
+    name="feed_team_abbrev",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team abbreviation uppercase (e.g., 'BAL')",
+)
+def extract_feed_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.abbreviation.upper()
+
+
+@register_variable(
+    name="feed_team_abbrev_lower",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team abbreviation lowercase (e.g., 'bal')",
+)
+def extract_feed_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.abbreviation.lower()
+
+
+@register_variable(
+    name="feed_team_logo",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team logo URL",
+)
+def extract_feed_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.logo_url or ""
+
+
+@register_variable(
+    name="is_home_feed",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'true' if this is the home team's feed, 'false' if away, '' if no feed",
+)
+def extract_is_home_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_home = (
+        game_ctx.event.home_team
+        and game_ctx.event.home_team.id == ctx.feed_team.id
+    )
+    return "true" if is_home else "false"
+
+
+@register_variable(
+    name="is_away_feed",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'true' if this is the away team's feed, 'false' if home, '' if no feed",
+)
+def extract_is_away_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_away = (
+        game_ctx.event.away_team
+        and game_ctx.event.away_team.id == ctx.feed_team.id
+    )
+    return "true" if is_away else "false"
+
+
+@register_variable(
+    name="feed_home_away",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'Home' if home feed, 'Away' if away feed, '' if no feed",
+)
+def extract_feed_home_away(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_home = (
+        game_ctx.event.home_team
+        and game_ctx.event.home_team.id == ctx.feed_team.id
+    )
+    return "Home" if is_home else "Away"

--- a/tests/test_sub_scheduler.py
+++ b/tests/test_sub_scheduler.py
@@ -1,0 +1,230 @@
+"""Tests for SubTaskScheduler and independent backup/channel-reset scheduling."""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teamarr.consumers.scheduler import CronScheduler, SubTaskScheduler
+
+
+class TestSubTaskScheduler:
+    """Tests for the SubTaskScheduler class."""
+
+    def test_start_stop_lifecycle(self):
+        """SubTaskScheduler starts and stops cleanly."""
+        task_fn = MagicMock()
+        # Use a far-future cron so it doesn't fire during test
+        sub = SubTaskScheduler("test", task_fn, "0 0 1 1 *")
+
+        assert not sub.is_running
+        assert sub.start()
+        assert sub.is_running
+        assert sub.cron_expression == "0 0 1 1 *"
+
+        assert sub.stop(timeout=2.0)
+        assert not sub.is_running
+        task_fn.assert_not_called()
+
+    def test_start_rejects_invalid_cron(self):
+        """SubTaskScheduler rejects invalid cron expressions."""
+        sub = SubTaskScheduler("test", MagicMock(), "not a cron")
+        assert not sub.start()
+        assert not sub.is_running
+
+    def test_start_rejects_double_start(self):
+        """SubTaskScheduler rejects starting twice."""
+        sub = SubTaskScheduler("test", MagicMock(), "0 0 1 1 *")
+        assert sub.start()
+        assert not sub.start()  # Already running
+        sub.stop(timeout=2.0)
+
+    def test_stop_when_not_running(self):
+        """Stopping a non-running scheduler returns True."""
+        sub = SubTaskScheduler("test", MagicMock(), "0 0 1 1 *")
+        assert sub.stop()
+
+    def test_task_fires_on_cron(self):
+        """SubTaskScheduler fires the task at the cron time."""
+        fired = threading.Event()
+
+        def task():
+            fired.set()
+
+        # Fire every minute — we'll wait for it
+        sub = SubTaskScheduler("test", task, "* * * * *")
+        sub.start()
+        try:
+            # Should fire within ~61 seconds
+            assert fired.wait(timeout=65), "Task did not fire within 65 seconds"
+        finally:
+            sub.stop(timeout=2.0)
+
+    def test_thread_is_daemon(self):
+        """SubTaskScheduler thread is a daemon thread."""
+        sub = SubTaskScheduler("test", MagicMock(), "0 0 1 1 *")
+        sub.start()
+        assert sub._thread.daemon
+        sub.stop(timeout=2.0)
+
+    def test_next_run_is_set(self):
+        """SubTaskScheduler sets next_run after starting."""
+        sub = SubTaskScheduler("test", MagicMock(), "0 3 * * *")
+        assert sub.next_run is None
+        sub.start()
+        # Give the thread a moment to compute next_run
+        time.sleep(0.2)
+        assert sub.next_run is not None
+        sub.stop(timeout=2.0)
+
+
+class TestCronSchedulerSubTasks:
+    """Tests for CronScheduler sub-task management."""
+
+    def _make_scheduler(self):
+        """Create a CronScheduler with mocked db_factory."""
+        db_factory = MagicMock()
+        return CronScheduler(
+            db_factory=db_factory,
+            cron_expression="0 0 1 1 *",  # Never fires
+            run_on_start=False,
+        )
+
+    def test_sub_schedulers_dict_initialized(self):
+        """CronScheduler initializes with empty sub_schedulers dict."""
+        sched = self._make_scheduler()
+        assert sched._sub_schedulers == {}
+
+    def test_run_tasks_excludes_backup_and_channel_reset(self):
+        """_run_tasks should not include backup or channel_reset."""
+        sched = self._make_scheduler()
+        # Patch the tasks that _run_tasks DOES call so they don't fail
+        with (
+            patch.object(sched, "_task_refresh_cache", return_value={"skipped": True}),
+            patch.object(sched, "_task_generate_epg", return_value={"success": True}),
+        ):
+            results = sched._run_tasks()
+
+        assert "backup" not in results
+        assert "channel_reset" not in results
+        assert "cache_refresh" in results
+        assert "epg_generation" in results
+
+    def test_run_once_includes_backup_and_channel_reset(self):
+        """run_once should include backup and channel_reset for manual trigger."""
+        sched = self._make_scheduler()
+        with (
+            patch.object(sched, "_task_refresh_cache", return_value={"skipped": True}),
+            patch.object(sched, "_task_generate_epg", return_value={"success": True}),
+            patch.object(sched, "_task_backup", return_value={"skipped": True}),
+            patch.object(sched, "_task_channel_reset", return_value={"skipped": True}),
+        ):
+            results = sched.run_once()
+
+        assert "backup" in results
+        assert "channel_reset" in results
+
+    def test_restart_sub_task_stops_and_starts(self):
+        """restart_sub_task stops existing and starts new sub-scheduler."""
+        sched = self._make_scheduler()
+
+        # Manually add a mock sub-scheduler
+        mock_sub = MagicMock()
+        mock_sub.stop.return_value = True
+        sched._sub_schedulers["backup"] = mock_sub
+
+        # Mock settings to return disabled backup
+        mock_settings = MagicMock()
+        mock_settings.enabled = False
+
+        mock_conn = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        sched._db_factory.return_value = mock_ctx
+
+        with patch(
+            "teamarr.database.settings.get_backup_settings", return_value=mock_settings
+        ):
+            sched.restart_sub_task("backup")
+
+        # Old sub-scheduler should have been stopped
+        mock_sub.stop.assert_called_once_with(timeout=5.0)
+        # Since disabled, no new sub-scheduler should be created
+        assert "backup" not in sched._sub_schedulers
+
+
+class TestTaskBackupSimplified:
+    """Tests for the simplified _task_backup (no window check)."""
+
+    def test_backup_skips_when_disabled(self):
+        """_task_backup returns skip when backups disabled."""
+        sched = CronScheduler(
+            db_factory=MagicMock(),
+            cron_expression="0 0 1 1 *",
+            run_on_start=False,
+        )
+
+        mock_settings = MagicMock()
+        mock_settings.enabled = False
+
+        mock_conn = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        sched._db_factory.return_value = mock_ctx
+
+        with patch(
+            "teamarr.database.settings.get_backup_settings", return_value=mock_settings
+        ):
+            result = sched._task_backup()
+
+        assert result["skipped"] is True
+
+    def test_backup_runs_without_window_check(self):
+        """_task_backup runs immediately when enabled (no 1-hour window)."""
+        sched = CronScheduler(
+            db_factory=MagicMock(),
+            cron_expression="0 0 1 1 *",
+            run_on_start=False,
+        )
+
+        mock_settings = MagicMock()
+        mock_settings.enabled = True
+        mock_settings.path = "/tmp/backups"
+        mock_settings.max_count = 7
+
+        mock_conn = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+        sched._db_factory.return_value = mock_ctx
+
+        mock_backup_result = MagicMock()
+        mock_backup_result.success = True
+        mock_backup_result.filename = "test.db"
+        mock_backup_result.size_bytes = 1234
+
+        mock_rotation = MagicMock()
+        mock_rotation.deleted_count = 0
+
+        mock_service = MagicMock()
+        mock_service.create_backup.return_value = mock_backup_result
+        mock_service.rotate_backups.return_value = mock_rotation
+
+        with (
+            patch(
+                "teamarr.database.settings.get_backup_settings",
+                return_value=mock_settings,
+            ),
+            patch(
+                "teamarr.services.backup_service.create_backup_service",
+                return_value=mock_service,
+            ),
+        ):
+            result = sched._task_backup()
+
+        assert result["executed"] is True
+        assert result["success"] is True
+        mock_service.create_backup.assert_called_once_with(manual=False)


### PR DESCRIPTION
Adds the follow values to the EPG templates 

Variable | Example | Description
-- | -- | --
{feed_team} | Baltimore Orioles | Feed team full name
{feed_team_short} | Orioles | Feed team short name
{feed_team_abbrev} | BAL | Feed team abbreviation (uppercase)
{feed_team_abbrev_lower} | bal | Feed team abbreviation (lowercase)
{feed_team_logo} | https://... | Feed team logo URL
{is_home_feed} | true/false | Whether this is the home team's feed
{is_away_feed} | true/false | Whether this is the away team's feed
{feed_home_away} | Home/Away | Text label for feed direction