### PR TITLE
add feed separation templates to EPG data

### DIFF
--- a/teamarr/consumers/event_epg.py
+++ b/teamarr/consumers/event_epg.py
@@ -414,6 +414,7 @@ class EventEPGGenerator:
                 league=event.league,
                 card_segment=segment,
             )
+            context.feed_team = match.get("feed_team")
             context.extra_vars = {"exception_keyword": keyword_value}
 
             # Generate channel name from template

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -1069,7 +1069,9 @@ class ChannelLifecycleService:
         delete_time = self._timing_manager.calculate_delete_time(event)
 
         # Resolve logo URL from template (supports template variables including {exception_keyword})
-        logo_url = self._resolve_logo_url(event, template, matched_keyword, segment)
+        logo_url = self._resolve_logo_url(
+            event, template, matched_keyword, segment, feed_team=feed_team,
+        )
 
         # Create in Dispatcharr
         dispatcharr_channel_id = None
@@ -1274,7 +1276,10 @@ class ChannelLifecycleService:
 
         # Resolve using full template engine with extra variables
         # Unknown variables stay literal (e.g., {bad_var}) so user can identify issues
-        base_name = self._resolve_template(name_format, event, extra_vars, card_segment=segment)
+        base_name = self._resolve_template(
+            name_format, event, extra_vars,
+            card_segment=segment, feed_team=feed_team,
+        )
 
         # Clean up empty wrappers when {exception_keyword} resolves to ""
         # e.g., "Team A @ Team B ()" → "Team A @ Team B"
@@ -1365,6 +1370,7 @@ class ChannelLifecycleService:
         template,
         exception_keyword: str | None = None,
         segment: str | None = None,
+        feed_team=None,
     ) -> str | None:
         """Resolve logo URL from template.
 
@@ -1376,6 +1382,7 @@ class ChannelLifecycleService:
             template: Can be dict, EventTemplateConfig dataclass, or None
             exception_keyword: Optional keyword for {exception_keyword} variable
             segment: UFC card segment code (e.g., "prelims", "main_card")
+            feed_team: Team object for feed separation (if detected)
         """
         logo_url = None
         if template:
@@ -1395,7 +1402,8 @@ class ChannelLifecycleService:
                     "exception_keyword": exception_keyword if exception_keyword else "",
                 }
                 return self._resolve_template(
-                    logo_url, event, extra_vars, card_segment=segment
+                    logo_url, event, extra_vars, card_segment=segment,
+                    feed_team=feed_team,
                 )
             return logo_url
 
@@ -1407,6 +1415,7 @@ class ChannelLifecycleService:
         event: Event,
         extra_variables: dict[str, str] | None = None,
         card_segment: str | None = None,
+        feed_team=None,
     ) -> str:
         """Resolve template string using full template engine.
 
@@ -1418,6 +1427,7 @@ class ChannelLifecycleService:
             extra_variables: Optional dict of additional variables to resolve
                 (e.g., {"exception_keyword": "Spanish"})
             card_segment: UFC card segment code (e.g., "prelims", "main_card")
+            feed_team: Team object for feed separation (if detected)
 
         Returns:
             Resolved string with variables replaced
@@ -1433,6 +1443,7 @@ class ChannelLifecycleService:
             league=event.league,
             card_segment=card_segment,
         )
+        context.feed_team = feed_team
         return self._resolver.resolve(template_str, context)
 
     def _get_next_channel_number(
@@ -1663,7 +1674,8 @@ class ChannelLifecycleService:
 
             # 8. Sync logo
             self._sync_channel_logo(
-                conn, existing, event, template, matched_keyword, segment, changes_made
+                conn, existing, event, template, matched_keyword, segment, changes_made,
+                feed_team=sync_feed_team,
             )
 
             # 9. Sync stream_profile_id
@@ -1824,11 +1836,14 @@ class ChannelLifecycleService:
         matched_keyword: str | None,
         segment: str | None,
         changes_made: list[str],
+        feed_team=None,
     ) -> None:
         """Sync logo — handles both updates and removals."""
         from teamarr.database.channels import update_managed_channel
 
-        logo_url = self._resolve_logo_url(event, template, matched_keyword, segment)
+        logo_url = self._resolve_logo_url(
+            event, template, matched_keyword, segment, feed_team=feed_team,
+        )
         current_logo_id = getattr(existing, "dispatcharr_logo_id", None)
         stored_logo_url = getattr(existing, "logo_url", None)
 

--- a/teamarr/templates/context.py
+++ b/teamarr/templates/context.py
@@ -87,6 +87,10 @@ class TemplateContext:
     next_game: GameContext | None = None  # For .next suffix
     last_game: GameContext | None = None  # For .last suffix
 
+    # Feed separation: the team whose broadcast feed this channel carries
+    # Set when a stream is identified as a home/away feed (e.g., "Orioles Feed")
+    feed_team: Team | None = None
+
     # Extra variables injected at resolution time (override registered extractors)
     # Used for values that aren't derived from event data (e.g., exception_keyword)
     extra_vars: dict[str, str] = field(default_factory=dict)

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -1,6 +1,7 @@
-"""Home/Away variables: location context, team positions.
+"""Home/Away variables: location context, team positions, feed separation.
 
-These variables provide home/away context and positional team references.
+These variables provide home/away context, positional team references,
+and feed team data for streams broken out into home/away channels.
 """
 
 from teamarr.templates.context import GameContext, TemplateContext
@@ -245,3 +246,116 @@ def extract_away_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -
     if not game_ctx or not game_ctx.event:
         return ""
     return game_ctx.event.away_team.logo_url or ""
+
+
+# --- Feed team variables (stream-level home/away feed separation) ---
+# These resolve to the team whose broadcast feed this channel carries.
+# Empty string when no feed separation is active (graceful disappear).
+
+
+@register_variable(
+    name="feed_team",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team full name (e.g., 'Baltimore Orioles')",
+)
+def extract_feed_team(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.name
+
+
+@register_variable(
+    name="feed_team_short",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team short name (e.g., 'Orioles')",
+)
+def extract_feed_team_short(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.short_name or ctx.feed_team.name
+
+
+@register_variable(
+    name="feed_team_abbrev",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team abbreviation uppercase (e.g., 'BAL')",
+)
+def extract_feed_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.abbreviation.upper()
+
+
+@register_variable(
+    name="feed_team_abbrev_lower",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team abbreviation lowercase (e.g., 'bal')",
+)
+def extract_feed_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.abbreviation.lower()
+
+
+@register_variable(
+    name="feed_team_logo",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="Feed team logo URL",
+)
+def extract_feed_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return ctx.feed_team.logo_url or ""
+
+
+@register_variable(
+    name="is_home_feed",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'true' if this is the home team's feed, 'false' if away, '' if no feed",
+)
+def extract_is_home_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_home = (
+        game_ctx.event.home_team
+        and game_ctx.event.home_team.id == ctx.feed_team.id
+    )
+    return "true" if is_home else "false"
+
+
+@register_variable(
+    name="is_away_feed",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'true' if this is the away team's feed, 'false' if home, '' if no feed",
+)
+def extract_is_away_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_away = (
+        game_ctx.event.away_team
+        and game_ctx.event.away_team.id == ctx.feed_team.id
+    )
+    return "true" if is_away else "false"
+
+
+@register_variable(
+    name="feed_home_away",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'Home' if home feed, 'Away' if away feed, '' if no feed",
+)
+def extract_feed_home_away(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team or not game_ctx or not game_ctx.event:
+        return ""
+    is_home = (
+        game_ctx.event.home_team
+        and game_ctx.event.home_team.id == ctx.feed_team.id
+    )
+    return "Home" if is_home else "Away"


### PR DESCRIPTION
Adds the following values to the EPG templates 

Variable | Example | Description
-- | -- | --
{feed_team} | Baltimore Orioles | Feed team full name
{feed_team_short} | Orioles | Feed team short name
{feed_team_abbrev} | BAL | Feed team abbreviation (uppercase)
{feed_team_abbrev_lower} | bal | Feed team abbreviation (lowercase)
{feed_team_logo} | https://... | Feed team logo URL
{is_home_feed} | true/false | Whether this is the home team's feed
{is_away_feed} | true/false | Whether this is the away team's feed
{feed_home_away} | Home/Away | Text label for feed direction