### PR TITLE
Add EPG competition filter for team channels

### DIFF
--- a/docs/guide/settings/channels.md
+++ b/docs/guide/settings/channels.md
@@ -91,6 +91,20 @@ When Group Mode is set to **Custom**, a pattern field appears where you can ente
 {: .note }
 Per-league overrides take precedence over the defaults in [Settings > Dispatcharr](dispatcharr). Use the **X** button to clear an override and revert to the default.
 
+### League Fixtures Only (Soccer)
+
+Soccer leagues have an additional **League fixtures only** toggle. When enabled, team channel EPG is restricted to that league's own fixtures — other competitions (cups, continental tournaments, etc.) are excluded.
+
+This is useful when team channels are backed by league-specific streams that only carry domestic league matches. Without the filter, Teamarr's multi-league discovery includes all competitions a team plays in (FA Cup, Carabao Cup, Champions League, etc.), which can result in EPG entries for events the stream doesn't carry.
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| **Off** | Yes | Team EPG includes all competitions the team plays in |
+| **On** | — | Team EPG only includes fixtures from the team's primary league |
+
+{: .note }
+This setting only appears for soccer leagues. Other sports (NFL, NBA, NHL, etc.) don't use multi-league discovery, so there's nothing to filter.
+
 ### Filtering
 
 Use the search field to find specific leagues, and toggle "Subscribed only" to hide leagues you haven't enabled.

--- a/docs/guide/teams.md
+++ b/docs/guide/teams.md
@@ -64,3 +64,7 @@ When Dispatcharr integration is configured, Teamarr creates and manages channels
 - Channel numbers follow the configured numbering mode (auto or manual)
 
 Channels persist even when no game is scheduled — they show idle filler content instead.
+
+### Competition Filtering
+
+By default, soccer team channels include fixtures from all competitions the team plays in (domestic league, cups, continental tournaments). If your team channels are backed by league-specific streams, you can enable the **League fixtures only** toggle in [Settings > Channels > Per-League Channel Config](settings/channels#league-fixtures-only-soccer) to restrict EPG to the team's primary league only.

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -499,6 +499,25 @@ export async function deleteLeagueConfig(leagueCode: string): Promise<void> {
   return api.delete(`/league-configs/${encodeURIComponent(leagueCode)}`)
 }
 
+// Competition Filter API
+export interface CompetitionFilterResponse {
+  league_code: string
+  competition_filter: string[] | null
+}
+
+export async function getCompetitionFilter(leagueCode: string): Promise<CompetitionFilterResponse> {
+  return api.get(`/leagues/${encodeURIComponent(leagueCode)}/competition-filter`)
+}
+
+export async function setCompetitionFilter(
+  leagueCode: string,
+  competitionFilter: string[] | null
+): Promise<CompetitionFilterResponse> {
+  return api.put(`/leagues/${encodeURIComponent(leagueCode)}/competition-filter`, {
+    competition_filter: competitionFilter,
+  })
+}
+
 // Emby Settings API
 export async function getEmbySettings(): Promise<EmbySettings> {
   return api.get("/settings/emby")

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -37,6 +37,8 @@ import {
   getLeagueConfigs,
   upsertLeagueConfig,
   deleteLeagueConfig,
+  getCompetitionFilter,
+  setCompetitionFilter,
   getEmbySettings,
   updateEmbySettings,
   testEmbyConnection,
@@ -415,6 +417,34 @@ export function useDeleteLeagueConfig() {
     mutationFn: (leagueCode: string) => deleteLeagueConfig(leagueCode),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["league-configs"] })
+    },
+  })
+}
+
+// Competition Filter Hooks
+export function useCompetitionFilter(leagueCode: string | null) {
+  return useQuery({
+    queryKey: ["competition-filter", leagueCode],
+    queryFn: () => getCompetitionFilter(leagueCode!),
+    enabled: !!leagueCode,
+  })
+}
+
+export function useSetCompetitionFilter() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      leagueCode,
+      competitionFilter,
+    }: {
+      leagueCode: string
+      competitionFilter: string[] | null
+    }) => setCompetitionFilter(leagueCode, competitionFilter),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["competition-filter", variables.leagueCode],
+      })
     },
   })
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -832,9 +832,8 @@ function LeagueConfigRow({
                     <span className="text-sm font-medium">League fixtures only</span>
                   </label>
                   <p className="text-xs text-muted-foreground mt-1">
-                    When enabled, team channel EPG only shows {leagueName} fixtures — cup
-                    games (FA Cup, Carabao Cup, etc.) are excluded since those streams
-                    don't carry them.
+                    When enabled, team channel EPG only includes {leagueName} fixtures.
+                    Other competitions (cups, continental, etc.) are excluded.
                   </p>
                 </div>
               )}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -67,6 +67,8 @@ import {
   useLeagueConfigs,
   useUpsertLeagueConfig,
   useDeleteLeagueConfig,
+  useCompetitionFilter,
+  useSetCompetitionFilter,
   useEmbySettings,
   useUpdateEmbySettings,
   useTestEmbyConnection,
@@ -575,24 +577,30 @@ function BackupRestoreCard() {
 // Per-League Config Row Component
 function LeagueConfigRow({
   leagueName,
+  leagueSlug,
   sportName,
+  sport,
   config,
   isExpanded,
   hasOverride,
   channelProfiles,
   channelGroups,
+  soccerLeagues,
   dispatcharrConnected,
   onToggleExpand,
   onSave,
   onClear,
 }: {
   leagueName: string
+  leagueSlug: string
   sportName: string
+  sport: string
   config: SubscriptionLeagueConfig | null
   isExpanded: boolean
   hasOverride: boolean
   channelProfiles: { id: number; name: string }[]
   channelGroups: { id: number; name: string }[]
+  soccerLeagues: { slug: string; name: string }[]
   dispatcharrConnected: boolean
   onToggleExpand: () => void
   onSave: (data: {
@@ -605,7 +613,12 @@ function LeagueConfigRow({
   const [localProfileIds, setLocalProfileIds] = useState<(number | string)[]>([])
   const [localGroupId, setLocalGroupId] = useState<number | null>(null)
   const [localGroupMode, setLocalGroupMode] = useState<string | null>(null)
+  const [localCompetitionFilter, setLocalCompetitionFilter] = useState<string[] | null>(null)
   const [saving, setSaving] = useState(false)
+
+  const isSoccer = sport === "soccer"
+  const { data: competitionFilterData } = useCompetitionFilter(isSoccer && isExpanded ? leagueSlug : null)
+  const setCompetitionFilterMutation = useSetCompetitionFilter()
 
   // Sync local state when config changes or row expands
   useEffect(() => {
@@ -623,6 +636,13 @@ function LeagueConfigRow({
       setLocalGroupMode(null)
     }
   }, [isExpanded, config])
+
+  // Sync competition filter when data loads
+  useEffect(() => {
+    if (isExpanded && competitionFilterData) {
+      setLocalCompetitionFilter(competitionFilterData.competition_filter)
+    }
+  }, [isExpanded, competitionFilterData])
 
   const profileSummary = (() => {
     if (!config?.channel_profile_ids) return "Default"
@@ -658,6 +678,13 @@ function LeagueConfigRow({
         channel_group_id: localGroupId,
         channel_group_mode: localGroupMode,
       })
+      // Save competition filter separately (different API/table)
+      if (isSoccer) {
+        await setCompetitionFilterMutation.mutateAsync({
+          leagueCode: leagueSlug,
+          competitionFilter: localCompetitionFilter,
+        })
+      }
     } finally {
       setSaving(false)
     }
@@ -793,6 +820,63 @@ function LeagueConfigRow({
                   />
                 )}
               </div>
+
+              {/* Competition Filter (soccer only) */}
+              {isSoccer && (
+                <div>
+                  <Label className="text-sm font-medium">Team EPG Competition Filter</Label>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Restrict team channel EPG to specific competitions. When set, only fixtures from
+                    selected competitions appear — preventing cup games (FA Cup, Carabao Cup, etc.)
+                    from showing on channels whose streams only carry league matches.
+                    Leave unchecked to include all competitions.
+                  </p>
+                  <div className="border rounded-md p-2 max-h-40 overflow-y-auto space-y-1">
+                    {soccerLeagues.map((lg) => {
+                      const isChecked = localCompetitionFilter?.includes(lg.slug) ?? false
+                      const isFilterActive = localCompetitionFilter !== null && localCompetitionFilter.length > 0
+                      return (
+                        <label
+                          key={lg.slug}
+                          className="flex items-center gap-2 px-1 py-0.5 rounded hover:bg-muted/50 cursor-pointer text-sm"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                // Add to filter (create filter array if null)
+                                const current = localCompetitionFilter ?? []
+                                setLocalCompetitionFilter([...current, lg.slug])
+                              } else {
+                                // Remove from filter
+                                const updated = (localCompetitionFilter ?? []).filter((s) => s !== lg.slug)
+                                // If nothing left, clear the filter entirely
+                                setLocalCompetitionFilter(updated.length > 0 ? updated : null)
+                              }
+                            }}
+                            className="rounded"
+                          />
+                          <span className={!isFilterActive || isChecked ? "" : "text-muted-foreground"}>
+                            {lg.name}
+                          </span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                  {localCompetitionFilter && localCompetitionFilter.length > 0 && (
+                    <button
+                      className="text-xs text-muted-foreground hover:text-foreground mt-1 underline"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setLocalCompetitionFilter(null)
+                      }}
+                    >
+                      Clear filter (include all competitions)
+                    </button>
+                  )}
+                </div>
+              )}
 
               {/* Actions */}
               <div className="flex gap-2 pt-1">
@@ -2379,12 +2463,19 @@ export function Settings() {
                       <LeagueConfigRow
                         key={league.slug}
                         leagueName={league.name}
+                        leagueSlug={league.slug}
                         sportName={getSportDisplayName(league.sport, sportsMap)}
+                        sport={league.sport}
                         config={config ?? null}
                         isExpanded={isExpanded}
                         hasOverride={hasOverride}
                         channelProfiles={channelProfilesQuery.data ?? []}
                         channelGroups={channelGroupsQuery.data ?? []}
+                        soccerLeagues={
+                          (leaguesData?.leagues ?? [])
+                            .filter((l) => l.sport === "soccer")
+                            .map((l) => ({ slug: l.slug, name: l.name }))
+                        }
                         dispatcharrConnected={dispatcharrStatus.data?.connected ?? false}
                         onToggleExpand={() =>
                           setExpandedLeagueConfig(isExpanded ? null : league.slug)

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -585,7 +585,6 @@ function LeagueConfigRow({
   hasOverride,
   channelProfiles,
   channelGroups,
-  soccerLeagues,
   dispatcharrConnected,
   onToggleExpand,
   onSave,
@@ -600,7 +599,6 @@ function LeagueConfigRow({
   hasOverride: boolean
   channelProfiles: { id: number; name: string }[]
   channelGroups: { id: number; name: string }[]
-  soccerLeagues: { slug: string; name: string }[]
   dispatcharrConnected: boolean
   onToggleExpand: () => void
   onSave: (data: {
@@ -824,57 +822,20 @@ function LeagueConfigRow({
               {/* Competition Filter (soccer only) */}
               {isSoccer && (
                 <div>
-                  <Label className="text-sm font-medium">Team EPG Competition Filter</Label>
-                  <p className="text-xs text-muted-foreground mb-2">
-                    Restrict team channel EPG to specific competitions. When set, only fixtures from
-                    selected competitions appear — preventing cup games (FA Cup, Carabao Cup, etc.)
-                    from showing on channels whose streams only carry league matches.
-                    Leave unchecked to include all competitions.
-                  </p>
-                  <div className="border rounded-md p-2 max-h-40 overflow-y-auto space-y-1">
-                    {soccerLeagues.map((lg) => {
-                      const isChecked = localCompetitionFilter?.includes(lg.slug) ?? false
-                      const isFilterActive = localCompetitionFilter !== null && localCompetitionFilter.length > 0
-                      return (
-                        <label
-                          key={lg.slug}
-                          className="flex items-center gap-2 px-1 py-0.5 rounded hover:bg-muted/50 cursor-pointer text-sm"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={isChecked}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                // Add to filter (create filter array if null)
-                                const current = localCompetitionFilter ?? []
-                                setLocalCompetitionFilter([...current, lg.slug])
-                              } else {
-                                // Remove from filter
-                                const updated = (localCompetitionFilter ?? []).filter((s) => s !== lg.slug)
-                                // If nothing left, clear the filter entirely
-                                setLocalCompetitionFilter(updated.length > 0 ? updated : null)
-                              }
-                            }}
-                            className="rounded"
-                          />
-                          <span className={!isFilterActive || isChecked ? "" : "text-muted-foreground"}>
-                            {lg.name}
-                          </span>
-                        </label>
-                      )
-                    })}
-                  </div>
-                  {localCompetitionFilter && localCompetitionFilter.length > 0 && (
-                    <button
-                      className="text-xs text-muted-foreground hover:text-foreground mt-1 underline"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setLocalCompetitionFilter(null)
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <Switch
+                      checked={localCompetitionFilter !== null && localCompetitionFilter.length > 0}
+                      onCheckedChange={(checked) => {
+                        setLocalCompetitionFilter(checked ? [leagueSlug] : null)
                       }}
-                    >
-                      Clear filter (include all competitions)
-                    </button>
-                  )}
+                    />
+                    <span className="text-sm font-medium">League fixtures only</span>
+                  </label>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    When enabled, team channel EPG only shows {leagueName} fixtures — cup
+                    games (FA Cup, Carabao Cup, etc.) are excluded since those streams
+                    don't carry them.
+                  </p>
                 </div>
               )}
 
@@ -2471,11 +2432,6 @@ export function Settings() {
                         hasOverride={hasOverride}
                         channelProfiles={channelProfilesQuery.data ?? []}
                         channelGroups={channelGroupsQuery.data ?? []}
-                        soccerLeagues={
-                          (leaguesData?.leagues ?? [])
-                            .filter((l) => l.sport === "soccer")
-                            .map((l) => ({ slug: l.slug, name: l.name }))
-                        }
                         dispatcharrConnected={dispatcharrStatus.data?.connected ?? false}
                         onToggleExpand={() =>
                           setExpandedLeagueConfig(isExpanded ? null : league.slug)

--- a/teamarr/api/routes/subscription.py
+++ b/teamarr/api/routes/subscription.py
@@ -343,3 +343,63 @@ def delete_league_config_endpoint(league_code: str):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No config found for league '{league_code}'",
         )
+
+
+# =============================================================================
+# TEAM EPG COMPETITION FILTER
+# =============================================================================
+
+
+class CompetitionFilterUpdate(BaseModel):
+    """Set the EPG competition filter for a league.
+
+    competition_filter: list of league codes to allow in team channel EPG,
+    or null/empty to include all competitions (clear the filter).
+    """
+
+    competition_filter: list[str] | None = None
+
+
+class CompetitionFilterResponse(BaseModel):
+    league_code: str
+    competition_filter: list[str] | None
+
+
+@router.get(
+    "/leagues/{league_code}/competition-filter",
+    response_model=CompetitionFilterResponse,
+)
+def get_competition_filter(league_code: str):
+    """Get the EPG competition filter for a league's team channels."""
+    from teamarr.database.leagues import get_league_competition_filter
+
+    with get_db() as conn:
+        f = get_league_competition_filter(conn, league_code)
+
+    return CompetitionFilterResponse(league_code=league_code, competition_filter=f)
+
+
+@router.put(
+    "/leagues/{league_code}/competition-filter",
+    response_model=CompetitionFilterResponse,
+)
+def set_competition_filter(league_code: str, request: CompetitionFilterUpdate):
+    """Set (or clear) the EPG competition filter for a league's team channels.
+
+    Pass competition_filter as a list of league codes to restrict team EPG to
+    only those competitions. Pass null or an empty list to remove the filter
+    and restore default behaviour (all competitions included).
+
+    Example — restrict EPL team channels to EPL fixtures only:
+        PUT /api/v1/leagues/eng.1/competition-filter
+        {"competition_filter": ["eng.1"]}
+    """
+    from teamarr.database.leagues import set_league_competition_filter
+
+    # Treat empty list the same as null (clear the filter)
+    codes = request.competition_filter if request.competition_filter else None
+
+    with get_db() as conn:
+        set_league_competition_filter(conn, league_code, codes)
+
+    return CompetitionFilterResponse(league_code=league_code, competition_filter=codes)

--- a/teamarr/consumers/team_epg.py
+++ b/teamarr/consumers/team_epg.py
@@ -64,6 +64,12 @@ class TeamEPGOptions:
     # for events with status.state == "postponed"
     prepend_postponed_label: bool = True
 
+    # Competition filter: restrict team EPG to specific league codes.
+    # None = include all competitions (default).
+    # Example: ["eng.1"] restricts an EPL team channel to EPL fixtures only,
+    # suppressing FA Cup, Carabao Cup, Champions League, etc.
+    competition_filter: list[str] | None = None
+
     # Backwards compatibility
     @property
     def days_ahead(self) -> int:
@@ -135,6 +141,12 @@ class TeamEPGGenerator:
 
             # Remove primary league from additional (will be added back in generate)
             additional_leagues = [lg for lg in additional_leagues if lg != primary_league]
+
+            # Drop leagues excluded by the competition filter early to avoid
+            # unnecessary API fetches (primary_league is always kept).
+            if options and options.competition_filter:
+                allowed = set(options.competition_filter)
+                additional_leagues = [lg for lg in additional_leagues if lg in allowed]
 
         return self.generate(
             team_id=team_id,
@@ -243,6 +255,21 @@ class TeamEPGGenerator:
                         if event.id not in seen_event_ids:
                             seen_event_ids.add(event.id)
                             all_events.append(event)
+
+        # Apply competition filter: drop events from unwanted leagues.
+        # Primary league is always included even if not explicitly listed,
+        # since the primary league is what the team channel represents.
+        if options.competition_filter:
+            allowed = set(options.competition_filter) | {league}
+            before = len(all_events)
+            all_events = [e for e in all_events if e.league in allowed]
+            dropped = before - len(all_events)
+            if dropped:
+                logger.debug(
+                    "[COMPETITION_FILTER] %s: dropped %d events from excluded competitions",
+                    team_id,
+                    dropped,
+                )
 
         # Fetch team stats once for all events
         team_stats = self._service.get_team_stats(team_id, league)

--- a/teamarr/consumers/team_processor.py
+++ b/teamarr/consumers/team_processor.py
@@ -449,6 +449,7 @@ class TeamProcessor:
         in the EPG generator, which is critical for thread-safety during
         parallel processing.
         """
+        from teamarr.database.leagues import get_league_competition_filter
         from teamarr.database.settings import get_all_settings
         from teamarr.database.templates import (
             get_template,
@@ -480,6 +481,10 @@ class TeamProcessor:
         else:
             logger.warning("[TEMPLATE] None assigned: %s", team.team_name)
 
+        # Look up competition filter for this team's primary league.
+        # Pre-loaded here (not in the generator) for thread-safety.
+        competition_filter = get_league_competition_filter(conn, team.primary_league)
+
         return TeamEPGOptions(
             schedule_days_ahead=all_settings.epg.team_schedule_days_ahead,
             output_days_ahead=all_settings.epg.epg_output_days_ahead,
@@ -493,6 +498,7 @@ class TeamProcessor:
             filler_config=filler_config,  # Pre-loaded filler config
             filler_enabled=True,
             include_final_events=all_settings.epg.include_final_events,
+            competition_filter=competition_filter,
         )
 
     def _get_team(self, conn: Connection, team_id: int) -> TeamConfig | None:

--- a/teamarr/database/leagues.py
+++ b/teamarr/database/leagues.py
@@ -196,6 +196,53 @@ def get_leagues_for_provider(conn: sqlite3.Connection, provider: str) -> list[Le
     ]
 
 
+def get_league_competition_filter(
+    conn: sqlite3.Connection, league_code: str
+) -> list[str] | None:
+    """Get the EPG competition filter for a league.
+
+    Args:
+        conn: Database connection
+        league_code: League code (e.g., 'eng.1')
+
+    Returns:
+        List of allowed league codes, or None if no filter is set (include all).
+    """
+    import json
+
+    cursor = conn.execute(
+        "SELECT epg_competition_filter FROM leagues WHERE league_code = ?",
+        (league_code,),
+    )
+    row = cursor.fetchone()
+    if not row or row["epg_competition_filter"] is None:
+        return None
+    try:
+        return json.loads(row["epg_competition_filter"])
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def set_league_competition_filter(
+    conn: sqlite3.Connection, league_code: str, filter_codes: list[str] | None
+) -> None:
+    """Set the EPG competition filter for a league.
+
+    Args:
+        conn: Database connection
+        league_code: League code (e.g., 'eng.1')
+        filter_codes: List of allowed league codes, or None to clear the filter.
+    """
+    import json
+
+    value = json.dumps(filter_codes) if filter_codes is not None else None
+    conn.execute(
+        "UPDATE leagues SET epg_competition_filter = ? WHERE league_code = ?",
+        (value, league_code),
+    )
+    conn.commit()
+
+
 def get_all_leagues(conn: sqlite3.Connection) -> list[dict]:
     """Get all enabled leagues.
 

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -788,6 +788,13 @@ CREATE TABLE IF NOT EXISTS leagues (
     event_type TEXT DEFAULT 'team_vs_team'
         CHECK(event_type IN ('team_vs_team', 'event', 'event_card')),
 
+    -- Team EPG Competition Filter
+    -- JSON array of league_codes to include in team channel EPG.
+    -- NULL = include all competitions (default, backwards-compatible).
+    -- Example: '["eng.1"]' restricts EPL team channels to EPL fixtures only,
+    -- excluding FA Cup, Carabao Cup, Champions League etc.
+    epg_competition_filter TEXT DEFAULT NULL,
+
     -- Cache Metadata (updated by cache refresh)
     cached_team_count INTEGER DEFAULT 0,
     last_cache_refresh TIMESTAMP


### PR DESCRIPTION
Closes #193

## Problem

Soccer teams play in multiple competitions — EPL, FA Cup, Carabao Cup, Champions League, etc. `generate_auto_discover()` discovers all leagues a team participates in and includes events from all of them in the team channel EPG.

For setups where team channels are backed by league-specific IPTV streams (e.g. a provider's "EPL" group that only carries Premier League fixtures), cup games appear in the EPG but the stream has no matching content for those competitions.

## Solution

Add an `epg_competition_filter` column to the `leagues` table. When set, team EPG generation restricts events to only the allowed competitions. Default `NULL` = all competitions (fully backwards compatible).

### Frontend

A "League fixtures only" toggle in **Settings → Channels → Per-League Channel Config** (soccer leagues only). When enabled, sets the filter to the league's own code. Simple on/off — no complex multi-select.

### API

```
GET  /api/v1/leagues/{league_code}/competition-filter
PUT  /api/v1/leagues/{league_code}/competition-filter
     {"competition_filter": ["eng.1"]}   // restrict
     {"competition_filter": null}        // clear (all competitions)
```

## Changes

### Backend
- **`schema.sql`**: Add `epg_competition_filter TEXT DEFAULT NULL` to `leagues` table. Schema reconciliation handles existing databases automatically.
- **`database/leagues.py`**: `get_league_competition_filter()` and `set_league_competition_filter()` helpers.
- **`consumers/team_epg.py`**: `competition_filter` field on `TeamEPGOptions`. Applied at two points:
  1. `generate_auto_discover()` — skips fetching schedules from filtered-out leagues (avoids unnecessary provider API calls)
  2. `generate()` — drops events from excluded competitions after collection. Primary league always kept.
- **`consumers/team_processor.py`**: Looks up filter from `leagues` table in `_build_options()`, pre-loaded for thread-safety.
- **`api/routes/subscription.py`**: `GET` and `PUT` endpoints.

### Frontend
- **`api/settings.ts`**: `getCompetitionFilter()` and `setCompetitionFilter()` API client functions.
- **`hooks/useSettings.ts`**: `useCompetitionFilter()` query and `useSetCompetitionFilter()` mutation hooks.
- **`pages/Settings.tsx`**: "League fixtures only" toggle in `LeagueConfigRow`, only shown for soccer leagues. Saves via competition filter API on the existing Save action.

### Documentation
- **`docs/guide/settings/channels.md`**: Added League Fixtures Only section.
- **`docs/guide/teams.md`**: Updated Team Channels in Dispatcharr section.

## Testing

- 321 existing tests pass, no regressions
- Verified end-to-end: 91 team channels across EPL/Championship/L1/L2, zero cup entries with filter enabled
- Frontend builds clean
- All changes are backwards compatible — `NULL` filter = current behavior unchanged