### PR TITLE
Fix feed_team always resolving from home team perspective

### DIFF
--- a/teamarr/consumers/event_epg.py
+++ b/teamarr/consumers/event_epg.py
@@ -405,16 +405,20 @@ class EventEPGGenerator:
             tvg_id = generate_event_tvg_id(event.id, event.provider, segment, exception_keyword)
             stream_name = stream.get("name", "")
 
-            # Build context using home team perspective
             # Inject exception_keyword into extra_vars so it resolves in all template fields
             keyword_value = exception_keyword if exception_keyword else ""
+            # When feed separation is active, build context from the feed team's
+            # perspective so {team}, {opponent}, {is_home}, etc. resolve correctly.
+            feed_team = match.get("feed_team")
+            team_id = (feed_team.id if feed_team
+                       else event.home_team.id if event.home_team else "")
             context = self._context_builder.build_for_event(
                 event=event,
-                team_id=event.home_team.id,
+                team_id=team_id,
                 league=event.league,
                 card_segment=segment,
             )
-            context.feed_team = match.get("feed_team")
+            context.feed_team = feed_team
             context.extra_vars = {"exception_keyword": keyword_value}
 
             # Generate channel name from template

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -1437,9 +1437,13 @@ class ChannelLifecycleService:
             for var_name, value in extra_variables.items():
                 template_str = template_str.replace(f"{{{var_name}}}", value)
 
+        # When feed separation is active, build context from the feed team's
+        # perspective so {team}, {opponent}, {is_home}, etc. resolve correctly.
+        team_id = (feed_team.id if feed_team
+                   else event.home_team.id if event.home_team else "")
         context = self._context_builder.build_for_event(
             event=event,
-            team_id=event.home_team.id if event.home_team else "",
+            team_id=team_id,
             league=event.league,
             card_segment=card_segment,
         )

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -250,18 +250,19 @@ def extract_away_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -
 
 # --- Feed team variables (stream-level home/away feed separation) ---
 # These resolve to the team whose broadcast feed this channel carries.
-# Empty string when no feed separation is active (graceful disappear).
+# Name/abbrev variables return "National" when no feed team is set (national broadcast).
+# Directional variables (is_home_feed, is_away_feed, feed_home_away) stay empty.
 
 
 @register_variable(
     name="feed_team",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.BASE_ONLY,
-    description="Feed team full name (e.g., 'Baltimore Orioles')",
+    description="Feed team full name, or 'National' for national broadcasts",
 )
 def extract_feed_team(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:
-        return ""
+        return "National"
     return ctx.feed_team.name
 
 
@@ -269,11 +270,11 @@ def extract_feed_team(ctx: TemplateContext, game_ctx: GameContext | None) -> str
     name="feed_team_short",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.BASE_ONLY,
-    description="Feed team short name (e.g., 'Orioles')",
+    description="Feed team short name, or 'National' for national broadcasts",
 )
 def extract_feed_team_short(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:
-        return ""
+        return "National"
     return ctx.feed_team.short_name or ctx.feed_team.name
 
 
@@ -281,11 +282,11 @@ def extract_feed_team_short(ctx: TemplateContext, game_ctx: GameContext | None) 
     name="feed_team_abbrev",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.BASE_ONLY,
-    description="Feed team abbreviation uppercase (e.g., 'BAL')",
+    description="Feed team abbreviation uppercase, or 'NATL' for national broadcasts",
 )
 def extract_feed_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:
-        return ""
+        return "NATL"
     return ctx.feed_team.abbreviation.upper()
 
 
@@ -293,11 +294,11 @@ def extract_feed_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None)
     name="feed_team_abbrev_lower",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.BASE_ONLY,
-    description="Feed team abbreviation lowercase (e.g., 'bal')",
+    description="Feed team abbreviation lowercase, or 'natl' for national broadcasts",
 )
 def extract_feed_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:
-        return ""
+        return "natl"
     return ctx.feed_team.abbreviation.lower()
 
 
@@ -305,7 +306,7 @@ def extract_feed_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext |
     name="feed_team_logo",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.BASE_ONLY,
-    description="Feed team logo URL",
+    description="Feed team logo URL (empty for national broadcasts)",
 )
 def extract_feed_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:

--- a/tests/test_feed_team_variables.py
+++ b/tests/test_feed_team_variables.py
@@ -89,28 +89,28 @@ def _context_with_feed(
 
 
 # =============================================================================
-# No feed team = all empty
+# No feed team = "National" for name/abbrev, empty for directional
 # =============================================================================
 
 
 class TestNoFeedTeam:
-    """All feed variables return empty string when feed_team is None."""
+    """Name/abbrev variables return 'National'; directional variables stay empty."""
 
     def test_feed_team(self):
         ctx, gc = _context_with_feed(None, _make_event())
-        assert extract_feed_team(ctx, gc) == ""
+        assert extract_feed_team(ctx, gc) == "National"
 
     def test_feed_team_short(self):
         ctx, gc = _context_with_feed(None, _make_event())
-        assert extract_feed_team_short(ctx, gc) == ""
+        assert extract_feed_team_short(ctx, gc) == "National"
 
     def test_feed_team_abbrev(self):
         ctx, gc = _context_with_feed(None, _make_event())
-        assert extract_feed_team_abbrev(ctx, gc) == ""
+        assert extract_feed_team_abbrev(ctx, gc) == "NATL"
 
     def test_feed_team_abbrev_lower(self):
         ctx, gc = _context_with_feed(None, _make_event())
-        assert extract_feed_team_abbrev_lower(ctx, gc) == ""
+        assert extract_feed_team_abbrev_lower(ctx, gc) == "natl"
 
     def test_feed_team_logo(self):
         ctx, gc = _context_with_feed(None, _make_event())
@@ -226,6 +226,13 @@ class TestFeedTeamEdgeCases:
         assert extract_feed_team_short(ctx, None) == "Orioles"
         assert extract_feed_team_abbrev(ctx, None) == "BAL"
         assert extract_feed_team_logo(ctx, None) == "https://example.com/bal.png"
+
+    def test_no_feed_team_no_game_context_returns_national(self):
+        """Without feed_team or game_ctx, name vars return 'National'."""
+        ctx, _ = _context_with_feed(None)
+        assert extract_feed_team(ctx, None) == "National"
+        assert extract_feed_team_short(ctx, None) == "National"
+        assert extract_feed_team_abbrev(ctx, None) == "NATL"
 
     def test_no_game_context_home_away_empty(self):
         """is_home/is_away/home_away need game_ctx to determine direction."""


### PR DESCRIPTION
I realized the previous PR the home team was always considered the feed team. This fixes that.

I also added a default "National" fallback for non-feed channels. This way if you wanted to say "{feed_team) feed" it would resolve National if no team. Open to thoughts about this.