### PR TITLE
Add Supabase provider with CBL league

### DIFF
--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -235,7 +235,7 @@ TZ_ABBREVIATION_MAP = {
     "NDT": "America/St_Johns",
     # === UTC/GMT ===
     "UTC": "UTC",
-    "GMT": "Europe/London",
+    "GMT": "UTC",
     "Z": "UTC",
     # === Europe ===
     # UK/Ireland

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -899,6 +899,7 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     ('college-baseball', 'espn', 'baseball/college-baseball', NULL, 'NCAA Baseball', 'baseball', 'https://www.ncaa.com/modules/custom/casablanca_core/img/sportbanners/baseball.png', NULL, 1, NULL, 'ncaabb', 'team_vs_team', 'College Baseball', NULL, NULL, NULL),
     ('college-softball', 'espn', 'baseball/college-softball', NULL, 'NCAA Softball', 'softball', 'https://www.ncaa.com/modules/custom/casablanca_core/img/sportbanners/softball.png', NULL, 1, NULL, 'ncaasbw', 'team_vs_team', 'College Softball', NULL, NULL, NULL),
     ('world-baseball-classic', 'espn', 'baseball/world-baseball-classic', NULL, 'World Baseball Classic', 'baseball', 'https://a.espncdn.com/i/teamlogos/leagues/500/3454.png', NULL, 1, 'WBC', 'wbc', 'team_vs_team', 'World Baseball Classic', NULL, NULL, NULL),
+    ('cbl', 'supabase', 'https://cbl.ca', NULL, 'Canadian Baseball League', 'baseball', 'https://upload.wikimedia.org/wikipedia/en/thumb/1/1e/Canadian_Baseball_League.svg/1280px-Canadian_Baseball_League.svg.png', NULL, 1, 'CBL', 'cbl', 'team_vs_team', NULL, NULL, NULL, NULL),
 
     -- Soccer (ESPN)
     ('usa.1', 'espn', 'soccer/usa.1', NULL, 'Major League Soccer', 'soccer', 'https://a.espncdn.com/i/leaguelogos/soccer/500/19.png', NULL, 1, 'MLS', 'mls', 'team_vs_team', 'MLS Soccer', NULL, NULL, NULL),

--- a/teamarr/providers/__init__.py
+++ b/teamarr/providers/__init__.py
@@ -19,6 +19,7 @@ from teamarr.providers.espn import ESPNClient, ESPNProvider
 from teamarr.providers.hockeytech import HockeyTechClient, HockeyTechProvider
 from teamarr.providers.mlbstats import MLBStatsClient, MLBStatsProvider
 from teamarr.providers.registry import ProviderConfig, ProviderRegistry
+from teamarr.providers.supabase import SupabaseLeagueClient, SupabaseProvider
 from teamarr.providers.tsdb import RateLimitStats, TSDBClient, TSDBProvider
 
 # =============================================================================
@@ -87,6 +88,13 @@ def _create_hockeytech_provider() -> HockeyTechProvider:
     )
 
 
+def _create_supabase_provider() -> SupabaseProvider:
+    """Factory for Supabase provider with injected dependencies."""
+    return SupabaseProvider(
+        league_mapping_source=ProviderRegistry.get_league_mapping_source(),
+    )
+
+
 def _create_mlbstats_provider() -> MLBStatsProvider:
     """Factory for MLB Stats provider with injected dependencies."""
     return MLBStatsProvider(
@@ -113,6 +121,14 @@ ProviderRegistry.register(
     provider_class=HockeyTechProvider,
     factory=_create_hockeytech_provider,
     priority=50,  # CHL leagues (OHL, WHL, QMJHL) + AHL, PWHL, USHL
+    enabled=True,
+)
+
+ProviderRegistry.register(
+    name="supabase",
+    provider_class=SupabaseProvider,
+    factory=_create_supabase_provider,
+    priority=55,  # Supabase-backed leagues (CBL, etc.)
     enabled=True,
 )
 
@@ -150,6 +166,9 @@ __all__ = [
     # MLB Stats
     "MLBStatsClient",
     "MLBStatsProvider",
+    # Supabase
+    "SupabaseLeagueClient",
+    "SupabaseProvider",
     # TheSportsDB
     "RateLimitStats",
     "TSDBClient",

--- a/teamarr/providers/mlbstats/provider.py
+++ b/teamarr/providers/mlbstats/provider.py
@@ -41,6 +41,10 @@ class MLBStatsProvider(SportsProvider):
     ):
         self._client = client or MLBStatsClient()
         self._league_mapping_source = league_mapping_source
+        # Populated by get_league_teams; used to fill in abbreviation when
+        # schedule hydration returns sparse team objects (id/name/link only).
+        self._team_abbrev_cache: dict[str, str] = {}
+        self._team_short_name_cache: dict[str, str] = {}
 
     @property
     def name(self) -> str:
@@ -150,6 +154,10 @@ class MLBStatsProvider(SportsProvider):
             team = self._parse_team(team_data, league)
             if team:
                 teams.append(team)
+                if team.abbreviation:
+                    self._team_abbrev_cache[team.id] = team.abbreviation
+                if team.short_name and team.short_name != team.name:
+                    self._team_short_name_cache[team.id] = team.short_name
 
         logger.info("[MLBSTATS] Loaded %d teams for league=%s", len(teams), league)
         return teams
@@ -169,13 +177,23 @@ class MLBStatsProvider(SportsProvider):
         location = team_data.get("locationName", "") or ""
         team_name = team_data.get("teamName", "") or ""
         full_name = team_data.get("name") or f"{location} {team_name}".strip()
-        abbrev = team_data.get("abbreviation", "") or team_name[:3].upper()
+
+        abbrev = (
+            team_data.get("abbreviation", "")
+            or self._team_abbrev_cache.get(team_id, "")
+            or team_name[:3].upper()
+        )
+        short_name = (
+            team_name
+            or self._team_short_name_cache.get(team_id, "")
+            or full_name
+        )
 
         return Team(
             id=team_id,
             provider=self.name,
             name=full_name,
-            short_name=team_name or full_name,
+            short_name=short_name,
             abbreviation=abbrev,
             league=league,
             sport="baseball",

--- a/teamarr/providers/supabase/__init__.py
+++ b/teamarr/providers/supabase/__init__.py
@@ -1,0 +1,15 @@
+"""Supabase-backed sports data provider.
+
+Generic provider for leagues whose backend is Supabase. Credentials (URL +
+API key) are extracted dynamically from the league's public website so they
+never need to be hardcoded. CBL is the first supported league.
+
+Adding a new Supabase-backed league requires only a new row in schema.sql:
+    provider = 'supabase'
+    provider_league_id = '<website URL to scrape>'
+"""
+
+from teamarr.providers.supabase.client import SupabaseLeagueClient
+from teamarr.providers.supabase.provider import SupabaseProvider
+
+__all__ = ["SupabaseLeagueClient", "SupabaseProvider"]

--- a/teamarr/providers/supabase/client.py
+++ b/teamarr/providers/supabase/client.py
@@ -1,0 +1,555 @@
+"""Supabase league HTTP client.
+
+Extracts Supabase credentials (URL + API key) dynamically from each league's
+public website so they never need to be hardcoded. The extraction result is
+cached for 7 days; team logos (embedded in the Vite bundle as hashed assets)
+are extracted in the same pass.
+
+Per-league env var overrides skip the website fetch entirely:
+    {LEAGUE_CODE_UPPER}_SUPABASE_URL=https://xxx.supabase.co
+    {LEAGUE_CODE_UPPER}_SUPABASE_API_KEY=sb_publishable_...
+
+Currently models the CBL (Canadian Baseball League) table schema:
+    teams                   — team roster
+    schedule_game_overrides — full season schedule (past + future)
+    games                   — completed box scores
+
+A second Supabase-backed league needs only a new leagues row in schema.sql
+(provider='supabase', provider_league_id='<site URL>'). If that league uses
+a different table schema the client will need extension, but credential/logo
+extraction is fully reusable.
+"""
+
+import logging
+import os
+import re
+import threading
+from datetime import date, timedelta
+
+import httpx
+
+from teamarr.core.interfaces import LeagueMappingSource
+from teamarr.utilities.cache import TTLCache, make_cache_key
+
+logger = logging.getLogger(__name__)
+
+# Cache TTLs (seconds)
+CACHE_TTL_CREDENTIALS = 7 * 24 * 3600   # 7 days — Vite hash changes on deploy
+CACHE_TTL_TEAMS = 72 * 3600             # 72 hours
+CACHE_TTL_SCHEDULE = 30 * 60            # 30 minutes
+CACHE_TTL_GAMES = 5 * 60                # 5 minutes (live scores)
+
+SUPABASE_TIMEOUT = float(os.environ.get("SUPABASE_TIMEOUT", 10.0))
+SUPABASE_RETRY_COUNT = int(os.environ.get("SUPABASE_RETRY_COUNT", 3))
+
+# Browser User-Agent to avoid bot-rejection on league sites
+_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+
+# Days to look back for .last template variable resolution
+DAYS_BACK = 7
+
+
+class SupabaseLeagueClient:
+    """HTTP client for Supabase-backed league websites.
+
+    Handles credential extraction, logo map extraction, and Supabase REST
+    API calls. League routing uses LeagueMappingSource; provider_league_id
+    in the database holds the website URL to scrape for credentials.
+    """
+
+    def __init__(
+        self,
+        league_mapping_source: LeagueMappingSource | None = None,
+        timeout: float = SUPABASE_TIMEOUT,
+        retry_count: int = SUPABASE_RETRY_COUNT,
+    ):
+        self._league_mapping_source = league_mapping_source
+        self._timeout = timeout
+        self._retry_count = retry_count
+        self._client: httpx.Client | None = None
+        self._client_lock = threading.Lock()
+        self._cache = TTLCache()
+
+    # ------------------------------------------------------------------
+    # HTTP client
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> httpx.Client:
+        if self._client is None:
+            with self._client_lock:
+                if self._client is None:
+                    self._client = httpx.Client(
+                        timeout=self._timeout,
+                        limits=httpx.Limits(
+                            max_connections=20,
+                            max_keepalive_connections=10,
+                        ),
+                        headers={"User-Agent": _USER_AGENT},
+                    )
+        return self._client
+
+    def _get(self, url: str, **kwargs) -> httpx.Response | None:
+        for attempt in range(self._retry_count):
+            try:
+                return self._get_client().get(url, **kwargs)
+            except (httpx.RequestError, RuntimeError, OSError) as e:
+                logger.warning(
+                    "[SUPABASE] GET %s failed (attempt %d/%d): %s",
+                    url,
+                    attempt + 1,
+                    self._retry_count,
+                    e,
+                )
+                if attempt < self._retry_count - 1:
+                    continue
+        return None
+
+    # ------------------------------------------------------------------
+    # League config
+    # ------------------------------------------------------------------
+
+    def supports_league(self, league: str) -> bool:
+        if not self._league_mapping_source:
+            return False
+        return self._league_mapping_source.supports_league(league, "supabase")
+
+    def get_league_config(self, league: str) -> tuple[str, str, str] | None:
+        """Return (website_url, supabase_url, api_key) for a league.
+
+        website_url comes from provider_league_id in the database.
+        supabase_url and api_key are extracted from that site (or env vars).
+        """
+        if not self._league_mapping_source:
+            return None
+
+        mapping = self._league_mapping_source.get_mapping(league, "supabase")
+        if not mapping:
+            logger.warning("[SUPABASE] No mapping for league: %s", league)
+            return None
+
+        website_url = mapping.provider_league_id
+        creds = self._get_credentials(website_url, league)
+        if not creds:
+            logger.warning(
+                "[SUPABASE] Could not obtain credentials for %s (%s)",
+                league,
+                website_url,
+            )
+            return None
+
+        supabase_url, api_key = creds
+        return (website_url, supabase_url, api_key)
+
+    def get_sport(self, league: str) -> str:
+        if not self._league_mapping_source:
+            return "baseball"
+        mapping = self._league_mapping_source.get_mapping(league, "supabase")
+        if mapping and mapping.sport:
+            return mapping.sport
+        cached = self._league_mapping_source.get_league_sport(league)
+        return cached if cached else "baseball"
+
+    # ------------------------------------------------------------------
+    # Credential extraction
+    # ------------------------------------------------------------------
+
+    def _get_credentials(
+        self, website_url: str, league: str
+    ) -> tuple[str, str] | None:
+        """Return (supabase_url, api_key).
+
+        Checks {LEAGUE_UPPER}_SUPABASE_URL / _API_KEY env vars first, then
+        the in-memory cache, then extracts from the live website.
+        """
+        league_upper = league.upper()
+        env_url = os.environ.get(f"{league_upper}_SUPABASE_URL", "")
+        env_key = os.environ.get(f"{league_upper}_SUPABASE_API_KEY", "")
+
+        if env_url and env_key:
+            logger.debug("[SUPABASE] Using env var credentials for %s", league)
+            return (env_url, env_key)
+
+        cache_key = make_cache_key("supabase", "creds", website_url)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            url, key = cached
+            return (env_url or url, env_key or key)
+
+        extracted = self._extract_from_website(website_url)
+        if extracted:
+            self._cache.set(cache_key, extracted, CACHE_TTL_CREDENTIALS)
+            url, key = extracted
+            return (env_url or url, env_key or key)
+
+        return None
+
+    def _extract_from_website(self, website_url: str) -> tuple[str, str] | None:
+        """Fetch the league website, find the Vite JS bundle, and extract
+        the Supabase URL + API key. Also caches the team logo map as a
+        side effect so both are extracted in one HTTP pass.
+        """
+        logger.info("[SUPABASE] Extracting credentials from %s", website_url)
+
+        resp = self._get(website_url)
+        if not resp or resp.status_code != 200:
+            logger.error(
+                "[SUPABASE] Failed to fetch %s: %s",
+                website_url,
+                resp.status_code if resp else "no response",
+            )
+            return None
+
+        # Find all <script src="..."> tags
+        script_urls = re.findall(r'src="(/assets/[^"]+\.js[^"]*)"', resp.text)
+        if not script_urls:
+            logger.error("[SUPABASE] No JS bundles found on %s", website_url)
+            return None
+
+        base = website_url.rstrip("/")
+        for script_path in script_urls:
+            bundle_url = f"{base}{script_path}"
+            bundle_resp = self._get(bundle_url)
+            if not bundle_resp or bundle_resp.status_code != 200:
+                continue
+
+            bundle = bundle_resp.text
+
+            supabase_url = self._extract_supabase_url(bundle)
+            api_key = self._extract_api_key(bundle)
+
+            if supabase_url and api_key:
+                logger.info(
+                    "[SUPABASE] Extracted credentials from %s (key: %s...)",
+                    bundle_url,
+                    api_key[:20],
+                )
+                # Extract and cache logo map as a side effect
+                logo_map = self._extract_logo_map(bundle, base)
+                if logo_map:
+                    logo_key = make_cache_key("supabase", "logos", website_url)
+                    self._cache.set(logo_key, logo_map, CACHE_TTL_CREDENTIALS)
+                    logger.debug(
+                        "[SUPABASE] Cached %d team logos for %s",
+                        len(logo_map),
+                        website_url,
+                    )
+                return (supabase_url, api_key)
+
+        logger.error(
+            "[SUPABASE] Could not extract credentials from any bundle on %s",
+            website_url,
+        )
+        return None
+
+    def _extract_supabase_url(self, bundle: str) -> str | None:
+        m = re.search(r'(https://[a-z0-9]+\.supabase\.co)', bundle)
+        return m.group(1) if m else None
+
+    def _extract_api_key(self, bundle: str) -> str | None:
+        # Try new publishable key format first
+        m = re.search(r'(sb_publishable_[A-Za-z0-9_-]+)', bundle)
+        if m:
+            return m.group(1)
+        # Fallback: JWT anon key (base64 middle segment must have "anon" role)
+        for m in re.finditer(
+            r'(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)',
+            bundle,
+        ):
+            token = m.group(1)
+            try:
+                import base64
+                payload_b64 = token.split(".")[1]
+                # Pad to multiple of 4
+                padding = 4 - len(payload_b64) % 4
+                payload = base64.b64decode(payload_b64 + "=" * padding)
+                if b'"anon"' in payload or b'"role":"anon"' in payload:
+                    return token
+            except Exception:
+                continue
+        return None
+
+    # ------------------------------------------------------------------
+    # Logo extraction
+    # ------------------------------------------------------------------
+
+    def _get_logo_map(self, website_url: str) -> dict[str, str]:
+        """Return {team_id: full_logo_url} map for a league website."""
+        logo_key = make_cache_key("supabase", "logos", website_url)
+        cached = self._cache.get(logo_key)
+        if cached is not None:
+            return cached
+
+        # Trigger a full website extraction which caches the logo map
+        self._extract_from_website(website_url)
+
+        cached = self._cache.get(logo_key)
+        return cached if cached is not None else {}
+
+    def _extract_logo_map(self, bundle: str, base_url: str) -> dict[str, str]:
+        """Extract {TEAMID: logo_url} map from a Vite bundle.
+
+        The bundle contains a const block assigning asset paths to variables:
+          VarA="/assets/barrie-baycats-HASH.png"
+          VarB="/assets/toronto-HASH.png"
+          ...
+          MAP={BARRIEBAYCATS:VarA, TORONTOMAPLELEAFS:VarB, ...}
+
+        The map variable name (VX, XX, etc.) changes on every deploy so we
+        search for any object literal with 3+ ALL_CAPS team-ID keys rather
+        than hard-coding a name.
+        """
+        # Find any assignment of the form VARNAME={ALL_CAPS_KEY:var, ...}
+        map_match = re.search(
+            r'[A-Za-z_$][A-Za-z0-9_$]*=\{((?:[A-Z]{3,}[A-Z0-9]*:[A-Za-z_$][A-Za-z0-9_$]*,?\s*){3,})\}',
+            bundle,
+        )
+        if not map_match:
+            logger.debug("[SUPABASE] Logo map pattern not found in bundle")
+            return {}
+
+        map_body = map_match.group(1)
+        # Parse TEAMID:VarName pairs
+        team_var_pairs = re.findall(r'([A-Z]{3,}[A-Z0-9]*):([A-Za-z_$][A-Za-z0-9_$]*)', map_body)
+        if not team_var_pairs:
+            return {}
+
+        # Resolve variable names to asset paths in the region before the map
+        map_start = map_match.start()
+        search_region = bundle[max(0, map_start - 5000): map_start]
+
+        logo_map: dict[str, str] = {}
+        for team_id, var_name in team_var_pairs:
+            pattern = (
+                r'(?<![A-Za-z0-9_$])'
+                + re.escape(var_name)
+                + r'="(/assets/[^"]+\.(?:png|jpg|svg|webp))"'
+            )
+            asset_match = re.search(pattern, search_region)
+            if asset_match:
+                logo_map[team_id] = f"{base_url}{asset_match.group(1)}"
+
+        return logo_map
+
+    # ------------------------------------------------------------------
+    # Supabase REST
+    # ------------------------------------------------------------------
+
+    def _supabase_get(
+        self, supabase_url: str, api_key: str, path: str
+    ) -> list[dict]:
+        """Make an authenticated Supabase REST GET request."""
+        url = f"{supabase_url}/rest/v1/{path}"
+        headers = {
+            "apikey": api_key,
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+        }
+        resp = self._get(url, headers=headers)
+        if not resp:
+            return []
+        if resp.status_code != 200:
+            logger.warning(
+                "[SUPABASE] REST %s returned HTTP %d", path, resp.status_code
+            )
+            return []
+        try:
+            data = resp.json()
+            return data if isinstance(data, list) else []
+        except Exception as e:
+            logger.warning("[SUPABASE] Failed to parse JSON from %s: %s", path, e)
+            return []
+
+    def _current_season_year(self) -> int:
+        from datetime import datetime
+        return datetime.now().year
+
+    # ------------------------------------------------------------------
+    # League data methods
+    # ------------------------------------------------------------------
+
+    def get_teams(self, league: str) -> list[dict]:
+        config = self.get_league_config(league)
+        if not config:
+            return []
+        _, supabase_url, api_key = config
+
+        cache_key = make_cache_key("supabase", "teams", league)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[SUPABASE] Cache hit: %s", cache_key)
+            return cached
+
+        data = self._supabase_get(supabase_url, api_key, "teams?select=*")
+        if data:
+            self._cache.set(cache_key, data, CACHE_TTL_TEAMS)
+            logger.debug("[SUPABASE] Cached %d teams for %s", len(data), league)
+        return data
+
+    def get_schedule(self, league: str) -> list[dict]:
+        """Get full season schedule from schedule_game_overrides."""
+        config = self.get_league_config(league)
+        if not config:
+            return []
+        _, supabase_url, api_key = config
+
+        year = self._current_season_year()
+        cache_key = make_cache_key("supabase", "schedule", league, str(year))
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[SUPABASE] Cache hit: %s", cache_key)
+            return cached
+
+        path = (
+            f"schedule_game_overrides?select=*"
+            f"&season_year=eq.{year}"
+            f"&order=game_date_override.asc"
+        )
+        data = self._supabase_get(supabase_url, api_key, path)
+        if data:
+            self._cache.set(cache_key, data, CACHE_TTL_SCHEDULE)
+            logger.debug(
+                "[SUPABASE] Cached %d schedule entries for %s %d",
+                len(data),
+                league,
+                year,
+            )
+        return data
+
+    def get_completed_games(self, league: str) -> list[dict]:
+        """Get completed box scores from the games table."""
+        config = self.get_league_config(league)
+        if not config:
+            return []
+        _, supabase_url, api_key = config
+
+        year = self._current_season_year()
+        cache_key = make_cache_key("supabase", "games", league, str(year))
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        path = (
+            f"games?select=id,game_date,away_team_name,home_team_name,"
+            f"away_score,home_score"
+            f"&season_year=eq.{year}"
+        )
+        data = self._supabase_get(supabase_url, api_key, path)
+        if data:
+            self._cache.set(cache_key, data, CACHE_TTL_GAMES)
+        return data
+
+    def get_logo_map(self, league: str) -> dict[str, str]:
+        """Return {team_id: logo_url} for a league."""
+        config = self.get_league_config(league)
+        if not config:
+            return {}
+        website_url, _, _ = config
+        return self._get_logo_map(website_url)
+
+    def build_score_map(self, games: list[dict]) -> dict[tuple, dict]:
+        """Build (game_date_str, home_city_lower) -> game_dict lookup."""
+        score_map: dict[tuple, dict] = {}
+        for game in games:
+            game_date = game.get("game_date")
+            home_name = game.get("home_team_name", "")
+            if game_date and home_name:
+                # First word of full name is the city ("Barrie Baycats" -> "barrie")
+                city = home_name.split()[0].lower() if home_name else ""
+                score_map[(game_date, city)] = game
+        return score_map
+
+    def get_events_by_date(self, league: str, target_date: date) -> list[dict]:
+        """Get schedule entries for a specific date, merged with scores."""
+        schedule = self.get_schedule(league)
+        date_str = target_date.strftime("%Y-%m-%d")
+        day_entries = [
+            g for g in schedule
+            if g.get("game_date_override") == date_str
+            and g.get("status") != "postponed"
+        ]
+        if not day_entries:
+            return []
+
+        completed = self.get_completed_games(league)
+        score_map = self.build_score_map(completed)
+        return self._merge_scores(day_entries, score_map)
+
+    def get_team_schedule(
+        self, league: str, team_id: str, days_ahead: int = 14
+    ) -> list[dict]:
+        """Get schedule for a team, including DAYS_BACK past games."""
+        teams = self.get_teams(league)
+        city = ""
+        for t in teams:
+            if t.get("id") == team_id:
+                city = (t.get("city") or "").lower()
+                break
+        if not city:
+            logger.warning(
+                "[SUPABASE] Team %s not found in league %s", team_id, league
+            )
+            return []
+
+        today = date.today()
+        start_date = today - timedelta(days=DAYS_BACK)
+        end_date = today + timedelta(days=days_ahead)
+
+        schedule = self.get_schedule(league)
+        team_entries = []
+        for entry in schedule:
+            away = (entry.get("away_team_override") or "").lower()
+            home = (entry.get("home_team_override") or "").lower()
+            if city not in (away, home):
+                continue
+            game_date_str = entry.get("game_date_override")
+            if not game_date_str:
+                continue
+            try:
+                game_date = date.fromisoformat(game_date_str)
+            except ValueError:
+                continue
+            if start_date <= game_date <= end_date:
+                team_entries.append(entry)
+
+        if not team_entries:
+            return []
+
+        completed = self.get_completed_games(league)
+        score_map = self.build_score_map(completed)
+        return self._merge_scores(team_entries, score_map)
+
+    def _merge_scores(
+        self, entries: list[dict], score_map: dict[tuple, dict]
+    ) -> list[dict]:
+        """Attach score data from score_map to each schedule entry."""
+        result = []
+        for entry in entries:
+            game_date = entry.get("game_date_override", "")
+            home_city = (entry.get("home_team_override") or "").lower()
+            score = score_map.get((game_date, home_city))
+            if score:
+                merged = dict(entry)
+                merged["_score"] = score
+                result.append(merged)
+            else:
+                result.append(entry)
+        return result
+
+    # ------------------------------------------------------------------
+    # Cache / lifecycle
+    # ------------------------------------------------------------------
+
+    def cache_stats(self) -> dict:
+        return self._cache.stats()
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    def close(self) -> None:
+        if self._client:
+            self._client.close()
+            self._client = None

--- a/teamarr/providers/supabase/provider.py
+++ b/teamarr/providers/supabase/provider.py
@@ -119,15 +119,48 @@ class SupabaseProvider(SportsProvider):
     # ------------------------------------------------------------------
 
     def _build_teams_by_city(self, league: str) -> dict[str, Team]:
-        """Build {city_lower: Team} map for resolving schedule entries."""
+        """Build {city_lower: Team} map for resolving schedule entries.
+
+        Two fallback layers handle common CBL data quirks:
+        - Hyphenated cities: "Chatham-Kent" also indexed as "chatham" so the
+          schedule's "Chatham" override resolves correctly.
+        - Missing city: teams with city=None are indexed by the first word of
+          their team name (e.g., "Hamilton Cardinals" → "hamilton").
+
+        Exact city matches take precedence; fallbacks only fill gaps.
+        """
         teams_data = self._client.get_teams(league)
         logo_map = self._client.get_logo_map(league)
         sport = self._client.get_sport(league)
-        result: dict[str, Team] = {}
+
+        primary: dict[str, Team] = {}   # exact city matches
+        fallback: dict[str, Team] = {}  # first-component / first-word
+
         for t in teams_data:
             team = self._parse_team(t, logo_map, league, sport)
-            if team and t.get("city"):
-                result[t["city"].lower()] = team
+            if not team:
+                continue
+
+            city = t.get("city")
+            team_name = t.get("team_name", "")
+
+            if city:
+                city_lower = city.lower()
+                primary[city_lower] = team
+                # Hyphenated cities (e.g., "Chatham-Kent") — also index by
+                # the part before the first hyphen so schedule abbreviations
+                # like "Chatham" still resolve.
+                first = city.split("-")[0].lower()
+                if first != city_lower and first not in fallback:
+                    fallback[first] = team
+            elif team_name:
+                # No city on record — use first word of team name.
+                first = team_name.split()[0].lower()
+                if first and first not in fallback:
+                    fallback[first] = team
+
+        result = fallback.copy()
+        result.update(primary)  # exact matches win
         return result
 
     def _parse_team(

--- a/teamarr/providers/supabase/provider.py
+++ b/teamarr/providers/supabase/provider.py
@@ -1,0 +1,300 @@
+"""Supabase sports data provider.
+
+Implements SportsProvider for leagues backed by Supabase (CBL and future
+leagues). Data shape mirrors the CBL schema; extend if a future league
+uses different table names or field layouts.
+"""
+
+import logging
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from teamarr.core import (
+    SEASON_REGULAR,
+    Event,
+    EventStatus,
+    LeagueMappingSource,
+    SportsProvider,
+    Team,
+    TeamStats,
+    Venue,
+)
+from teamarr.providers.supabase.client import SupabaseLeagueClient
+
+logger = logging.getLogger(__name__)
+
+# CBL games are played in Ontario — all schedule times are Eastern
+_EASTERN = ZoneInfo("America/Toronto")
+
+
+class SupabaseProvider(SportsProvider):
+    """SportsProvider implementation for Supabase-backed leagues (e.g. CBL)."""
+
+    def __init__(
+        self,
+        league_mapping_source: LeagueMappingSource | None = None,
+        client: SupabaseLeagueClient | None = None,
+    ):
+        self._league_mapping_source = league_mapping_source
+        self._client = client or SupabaseLeagueClient(
+            league_mapping_source=league_mapping_source,
+        )
+
+    @property
+    def name(self) -> str:
+        return "supabase"
+
+    def supports_league(self, league: str) -> bool:
+        return self._client.supports_league(league)
+
+    def get_events(self, league: str, target_date: date) -> list[Event]:
+        entries = self._client.get_events_by_date(league, target_date)
+        teams_by_city = self._build_teams_by_city(league)
+        events = []
+        for entry in entries:
+            event = self._parse_event(entry, teams_by_city, league)
+            if event:
+                events.append(event)
+        return events
+
+    def get_team_schedule(
+        self,
+        team_id: str,
+        league: str,
+        days_ahead: int = 14,
+    ) -> list[Event]:
+        entries = self._client.get_team_schedule(league, team_id, days_ahead)
+        teams_by_city = self._build_teams_by_city(league)
+        events = []
+        for entry in entries:
+            event = self._parse_event(entry, teams_by_city, league)
+            if event:
+                events.append(event)
+        events.sort(key=lambda e: e.start_time)
+        return events
+
+    def get_team(self, team_id: str, league: str) -> Team | None:
+        teams_data = self._client.get_teams(league)
+        logo_map = self._client.get_logo_map(league)
+        sport = self._client.get_sport(league)
+        for t in teams_data:
+            if t.get("id") == team_id:
+                return self._parse_team(t, logo_map, league, sport)
+        return None
+
+    def get_event(self, event_id: str, league: str) -> Event | None:
+        schedule = self._client.get_schedule(league)
+        completed = self._client.get_completed_games(league)
+        score_map = self._client.build_score_map(completed)
+        teams_by_city = self._build_teams_by_city(league)
+
+        for entry in schedule:
+            if entry.get("id") == event_id:
+                merged = self._client._merge_scores([entry], score_map)
+                return self._parse_event(merged[0], teams_by_city, league)
+        return None
+
+    def get_team_stats(self, team_id: str, league: str) -> TeamStats | None:
+        return None
+
+    def get_league_teams(self, league: str) -> list[Team]:
+        teams_data = self._client.get_teams(league)
+        logo_map = self._client.get_logo_map(league)
+        sport = self._client.get_sport(league)
+        teams = []
+        for t in teams_data:
+            team = self._parse_team(t, logo_map, league, sport)
+            if team:
+                teams.append(team)
+        return teams
+
+    def get_supported_leagues(self) -> list[str]:
+        if not self._league_mapping_source:
+            return []
+        mappings = self._league_mapping_source.get_leagues_for_provider("supabase")
+        return [m.league_code for m in mappings]
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    def _build_teams_by_city(self, league: str) -> dict[str, Team]:
+        """Build {city_lower: Team} map for resolving schedule entries."""
+        teams_data = self._client.get_teams(league)
+        logo_map = self._client.get_logo_map(league)
+        sport = self._client.get_sport(league)
+        result: dict[str, Team] = {}
+        for t in teams_data:
+            team = self._parse_team(t, logo_map, league, sport)
+            if team and t.get("city"):
+                result[t["city"].lower()] = team
+        return result
+
+    def _parse_team(
+        self,
+        team_data: dict,
+        logo_map: dict[str, str],
+        league: str,
+        sport: str,
+    ) -> Team | None:
+        team_id = team_data.get("id")
+        if not team_id:
+            return None
+
+        name = team_data.get("team_name") or team_id
+        city = team_data.get("city") or ""
+        logo_url = logo_map.get(team_id)
+        color = self._normalize_color(team_data.get("team_colors"))
+
+        return Team(
+            id=team_id,
+            provider=self.name,
+            name=name,
+            short_name=city or name,
+            abbreviation=self._make_abbrev(name),
+            league=league,
+            sport=sport,
+            logo_url=logo_url,
+            color=color,
+        )
+
+    def _parse_event(
+        self,
+        entry: dict,
+        teams_by_city: dict[str, Team],
+        league: str,
+    ) -> Event | None:
+        try:
+            event_id = entry.get("id")
+            if not event_id:
+                return None
+
+            away_city = (entry.get("away_team_override") or "").lower()
+            home_city = (entry.get("home_team_override") or "").lower()
+
+            away_team = teams_by_city.get(away_city)
+            home_team = teams_by_city.get(home_city)
+            if not away_team or not home_team:
+                logger.debug(
+                    "[SUPABASE] Could not resolve teams for event %s "
+                    "(away=%s, home=%s)",
+                    event_id,
+                    away_city,
+                    home_city,
+                )
+                return None
+
+            start_time = self._parse_datetime(entry)
+            if not start_time:
+                return None
+
+            sport = self._client.get_sport(league)
+            score_data = entry.get("_score")
+            status = self._parse_status(entry, score_data)
+
+            home_score: int | None = None
+            away_score: int | None = None
+            if score_data:
+                home_score = self._parse_score(score_data.get("home_score"))
+                away_score = self._parse_score(score_data.get("away_score"))
+
+            venue = self._parse_venue(entry)
+
+            event_name = f"{away_team.name} at {home_team.name}"
+            short_name = f"{away_team.abbreviation} @ {home_team.abbreviation}"
+
+            return Event(
+                id=event_id,
+                provider=self.name,
+                name=event_name,
+                short_name=short_name,
+                start_time=start_time,
+                home_team=home_team,
+                away_team=away_team,
+                status=status,
+                league=league,
+                sport=sport,
+                home_score=home_score,
+                away_score=away_score,
+                venue=venue,
+                broadcasts=[],
+                season_type=SEASON_REGULAR,
+            )
+        except Exception as e:
+            logger.warning(
+                "[SUPABASE] Failed to parse event %s: %s",
+                entry.get("id", "unknown"),
+                e,
+            )
+            return None
+
+    def _parse_datetime(self, entry: dict) -> datetime | None:
+        """Parse game start time from schedule entry.
+
+        game_date_override is an ISO date string ("2026-05-14").
+        game_time_override is a 12-hour time string ("7:38 PM").
+        Times are Eastern (America/Toronto) — CBL is Ontario-based.
+        """
+        date_str = entry.get("game_date_override")
+        time_str = entry.get("game_time_override")
+        if not date_str:
+            return None
+
+        if time_str:
+            # Normalize: some entries use "7:05 PM", others "19:05"
+            time_str = time_str.strip()
+            for fmt in ("%I:%M %p", "%H:%M"):
+                try:
+                    dt = datetime.strptime(f"{date_str} {time_str}", f"%Y-%m-%d {fmt}")
+                    return dt.replace(tzinfo=_EASTERN)
+                except ValueError:
+                    continue
+
+        # Date only — use midnight Eastern
+        try:
+            dt = datetime.fromisoformat(date_str)
+            return dt.replace(tzinfo=_EASTERN)
+        except ValueError:
+            return None
+
+    def _parse_status(self, entry: dict, score_data: dict | None) -> EventStatus:
+        raw_status = (entry.get("status") or "").lower()
+
+        if raw_status == "postponed":
+            return EventStatus(state="postponed", detail="Postponed")
+
+        if raw_status == "cancelled":
+            return EventStatus(state="cancelled", detail="Cancelled")
+
+        if score_data:
+            return EventStatus(state="final", detail="Final")
+
+        return EventStatus(state="scheduled", detail=None)
+
+    def _parse_venue(self, entry: dict) -> Venue | None:
+        venue_name = entry.get("venue_override")
+        if not venue_name:
+            return None
+        return Venue(name=venue_name)
+
+    def _parse_score(self, score) -> int | None:
+        if score is None or score == "":
+            return None
+        try:
+            return int(score)
+        except (ValueError, TypeError):
+            return None
+
+    def _normalize_color(self, color: str | None) -> str | None:
+        if not color:
+            return None
+        color = color.strip()
+        if color and not color.startswith("#"):
+            color = f"#{color}"
+        return color or None
+
+    def _make_abbrev(self, team_name: str) -> str:
+        """Return first 3 characters of team name, uppercase."""
+        if not team_name:
+            return ""
+        return team_name[:3].upper()


### PR DESCRIPTION
## Summary

- Adds a generic `supabase` provider that dynamically extracts Supabase credentials (URL + API key) from a league's public website JS bundle, so credentials never need to be hardcoded
- Registers the Canadian Baseball League (CBL) as the first league using this provider
- Future Supabase-backed leagues require only a new row in `schema.sql` with `provider = 'supabase'` and the website URL as `provider_league_id`

## Technical Notes

- Credentials and logos are scraped from the Vite-bundled JS on each league site, cached for 7 days; per-league env var overrides (`{LEAGUE}_SUPABASE_URL` / `{LEAGUE}_SUPABASE_API_KEY`) skip website extraction
- CBL has two tables: `schedule_game_overrides` (all games, city-only team names) and `games` (completed box scores, full team names); merged by `(game_date, home_city)` at query time
- Logo map extraction uses a structural regex keyed on ALL_CAPS team-ID patterns rather than a hardcoded Vite variable name, so it survives bundle redeployments
