### PR TITLE
Team stream source matching

### DIFF
--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -130,7 +130,7 @@ export interface ChannelNumberingSettingsUpdate {
 }
 
 export interface StreamOrderingRule {
-  type: "m3u" | "group" | "regex"
+  type: "m3u" | "group" | "regex" | "stream_type"
   value: string
   priority: number  // 1-99, lower = higher priority
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -53,6 +53,7 @@ export interface EventGroup {
   custom_regex_event_name: string | null
   custom_regex_event_name_enabled: boolean
   skip_builtin_filter: boolean
+  team_streams_enabled: boolean
   // Team filtering (canonical team selection, inherited by children)
   include_teams: TeamFilterEntry[] | null
   exclude_teams: TeamFilterEntry[] | null
@@ -122,6 +123,7 @@ export interface EventGroupCreate {
   custom_regex_event_name?: string | null
   custom_regex_event_name_enabled?: boolean
   skip_builtin_filter?: boolean
+  team_streams_enabled?: boolean
   // Team filtering (canonical team selection, inherited by children)
   include_teams?: TeamFilterEntry[] | null
   exclude_teams?: TeamFilterEntry[] | null

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -172,6 +172,7 @@ export interface BulkGroupUpdateRequest {
   leagues?: string[]
   stream_timezone?: string | null  // IANA timezone for interpreting stream dates
   clear_stream_timezone?: boolean
+  team_streams_enabled?: boolean | null
   // Team filtering
   include_teams?: TeamFilterEntry[] | null
   exclude_teams?: TeamFilterEntry[] | null

--- a/frontend/src/components/StreamOrderingManager.tsx
+++ b/frontend/src/components/StreamOrderingManager.tsx
@@ -21,14 +21,20 @@ const RULE_TYPES = [
   { value: "m3u", label: "M3U Account", description: "Match streams by M3U account name" },
   { value: "group", label: "Event Group", description: "Match streams by event group name" },
   { value: "regex", label: "Regex Pattern", description: "Match streams by regex against stream name" },
+  { value: "stream_type", label: "Stream Type", description: "Match by stream type: event stream or team stream" },
 ] as const
+
+const STREAM_TYPE_OPTIONS = [
+  { value: "event", label: "Event stream" },
+  { value: "team", label: "Team stream" },
+]
 
 interface RuleFormData {
   // Stable client-side id so rows keep their identity across re-sorts.
   // Without this, keying by array index causes focus to follow DOM position
   // instead of the rule, breaking double-digit priority entry (#198).
   _id: number
-  type: "m3u" | "group" | "regex"
+  type: "m3u" | "group" | "regex" | "stream_type"
   value: string
   priority: number
 }
@@ -130,6 +136,16 @@ function RuleRow({
               <option value="">Select event group...</option>
               {groupNames.map(name => (
                 <option key={name} value={name}>{name}</option>
+              ))}
+            </Select>
+          ) : rule.type === "stream_type" ? (
+            <Select
+              value={rule.value}
+              onChange={(e) => onUpdate(index, { ...rule, value: e.target.value })}
+            >
+              <option value="">Select stream type...</option>
+              {STREAM_TYPE_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
               ))}
             </Select>
           ) : (

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -61,7 +61,7 @@ export function EventGroupForm() {
   )
 
   // Collapsible section states
-  const [basicSettingsExpanded, setBasicSettingsExpanded] = useState(false)
+  const [basicSettingsExpanded, setBasicSettingsExpanded] = useState(true)
   const [subscriptionOverrideExpanded, setSubscriptionOverrideExpanded] = useState(false)
   const [streamTimezoneExpanded, setStreamTimezoneExpanded] = useState(false)
   const [regexExpanded, setRegexExpanded] = useState(false)

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -391,7 +391,7 @@ export function EventGroupForm() {
                 <div>
                   <Label className="font-normal">Team stream source</Label>
                   <p className="text-xs text-muted-foreground">
-                    Allow team-branded streams (e.g. "NHL | Toronto Maple Leafs") to match events where that team plays.
+                    Allow team-branded streams (e.g. "NHL | Toronto Maple Leafs") to match events where that team plays. Built-in stream filtering is automatically bypassed for this group.
                   </p>
                 </div>
               </div>

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -162,6 +162,7 @@ export function EventGroupForm() {
         custom_regex_event_name: group.custom_regex_event_name,
         custom_regex_event_name_enabled: group.custom_regex_event_name_enabled,
         skip_builtin_filter: group.skip_builtin_filter,
+        team_streams_enabled: group.team_streams_enabled,
         // Team filtering
         include_teams: group.include_teams,
         exclude_teams: group.exclude_teams,
@@ -380,6 +381,19 @@ export function EventGroupForm() {
                   onCheckedChange={(checked) => setFormData({ ...formData, enabled: checked })}
                 />
                 <Label className="font-normal">Enabled</Label>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={formData.team_streams_enabled || false}
+                  onCheckedChange={(checked) => setFormData({ ...formData, team_streams_enabled: checked })}
+                />
+                <div>
+                  <Label className="font-normal">Team stream source</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Allow team-branded streams (e.g. "NHL | Toronto Maple Leafs") to match events where that team plays.
+                  </p>
+                </div>
               </div>
             </CardContent>}
           </Card>}

--- a/frontend/src/pages/EventGroupImport.tsx
+++ b/frontend/src/pages/EventGroupImport.tsx
@@ -92,6 +92,7 @@ export function EventGroupImport() {
   const [showBulkModal, setShowBulkModal] = useState(false)
   const [bulkStreamTimezone, setBulkStreamTimezone] = useState<string | null>(null)
   const [bulkEnabled, setBulkEnabled] = useState(true)
+  const [bulkTeamStreams, setBulkTeamStreams] = useState(false)
   const [bulkImporting, setBulkImporting] = useState(false)
 
   // Queries
@@ -222,6 +223,7 @@ export function EventGroupImport() {
         settings: {
           stream_timezone: bulkStreamTimezone,
           enabled: bulkEnabled,
+          team_streams_enabled: bulkTeamStreams,
         },
       })
 
@@ -588,6 +590,18 @@ export function EventGroupImport() {
                       onCheckedChange={setBulkEnabled}
                     />
                     <span className="text-sm">{bulkEnabled ? "Yes" : "No"}</span>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs text-muted-foreground">Team stream source</Label>
+                  <div className="flex items-center gap-2 h-9">
+                    <Switch
+                      checked={bulkTeamStreams}
+                      onCheckedChange={setBulkTeamStreams}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      {bulkTeamStreams ? "Enabled" : "Disabled"}
+                    </span>
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -78,6 +78,7 @@ export function EventGroups() {
 
   // Drag-and-drop state
   const [draggedGroupId, setDraggedGroupId] = useState<number | null>(null)
+  const [dragOverGroupId, setDragOverGroupId] = useState<number | null>(null)
 
   // Preview modal state
   const [previewData, setPreviewData] = useState<PreviewGroupResponse | null>(null)
@@ -318,14 +319,16 @@ export function EventGroups() {
     e.dataTransfer.setData("text/plain", String(groupId))
   }
 
-  const handleDragOver = (e: React.DragEvent) => {
+  const handleDragOver = (e: React.DragEvent, targetGroupId: number) => {
     e.preventDefault()
     e.dataTransfer.dropEffect = "move"
+    setDragOverGroupId(targetGroupId)
   }
 
   const handleDrop = async (e: React.DragEvent, targetGroupId: number) => {
     e.preventDefault()
     setDraggedGroupId(null)
+    setDragOverGroupId(null)
 
     if (draggedGroupId === null || draggedGroupId === targetGroupId) return
 
@@ -354,6 +357,7 @@ export function EventGroups() {
 
   const handleDragEnd = () => {
     setDraggedGroupId(null)
+    setDragOverGroupId(null)
   }
 
   // Selection handlers
@@ -829,12 +833,16 @@ export function EventGroups() {
                   return (
                     <React.Fragment key={group.id}>
                       <TableRow
-                        className={`border-l-3 border-l-transparent hover:border-l-emerald-500 group/row ${
-                          draggedGroupId === group.id ? "opacity-50" : ""
+                        className={`border-l-3 group/row ${
+                          draggedGroupId === group.id
+                            ? "opacity-50 border-l-transparent"
+                            : dragOverGroupId === group.id
+                              ? "border-l-transparent border-t-2 border-t-emerald-500"
+                              : "border-l-transparent hover:border-l-emerald-500"
                         }`}
                         draggable={isDndActive}
                         onDragStart={(e) => isDndActive && handleDragStart(e, group.id)}
-                        onDragOver={(e) => isDndActive && handleDragOver(e)}
+                        onDragOver={(e) => isDndActive && handleDragOver(e, group.id)}
                         onDrop={(e) => isDndActive && handleDrop(e, group.id)}
                         onDragEnd={handleDragEnd}
                       >
@@ -903,16 +911,9 @@ export function EventGroups() {
                     {/* Matched Column with Progress Bar */}
                     <TableCell className="text-center">
                       {group.team_streams_enabled ? (
-                        // Team stream groups fan-out one stream to many events —
-                        // a match rate % is meaningless, show assignments instead
-                        <div className="flex flex-col items-center gap-0.5" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
-                          <span className="text-[0.65rem] text-muted-foreground">
-                            {group.stream_count ?? 0} streams
-                          </span>
-                          <span className="text-[0.65rem]">
-                            {group.matched_count ?? 0} assignments
-                          </span>
-                        </div>
+                        <span className="text-[0.65rem] text-muted-foreground" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
+                          {group.stream_count ?? 0} streams
+                        </span>
                       ) : group.stream_count && group.stream_count > 0 ? (
                         <div className="flex flex-col items-center gap-0.5" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
                           <div className="w-full h-1.5 bg-secondary rounded-full overflow-hidden">

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -880,6 +880,16 @@ export function EventGroups() {
                                 Regex
                               </Badge>
                             )}
+                            {/* Team Streams badge */}
+                            {group.team_streams_enabled && (
+                              <Badge
+                                variant="secondary"
+                                className="bg-emerald-500/15 text-emerald-400 border-emerald-500/30 text-xs"
+                                title="Team stream source: team-branded streams match events where that team plays"
+                              >
+                                Team Streams
+                              </Badge>
+                            )}
                           </div>
                         </TableCell>
                     {/* Matched Column with Progress Bar */}

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -107,6 +107,8 @@ export function EventGroups() {
   const [bulkEditTeamFilterMode, setBulkEditTeamFilterMode] = useState<"include" | "exclude">("include")
   const [bulkEditTeamFilterTeams, setBulkEditTeamFilterTeams] = useState<TeamFilterEntry[]>([])
   const [bulkEditBypassPlayoffs, setBulkEditBypassPlayoffs] = useState(false)
+  const [bulkEditTeamStreamsEnabled, setBulkEditTeamStreamsEnabled] = useState(false)
+  const [bulkEditTeamStreams, setBulkEditTeamStreams] = useState(false)
   // Column sorting state
   type SortColumn = "name" | "matched" | "status" | null
   type SortDirection = "asc" | "desc"
@@ -416,6 +418,8 @@ export function EventGroups() {
     setBulkEditTeamFilterMode("include")
     setBulkEditTeamFilterTeams([])
     setBulkEditBypassPlayoffs(false)
+    setBulkEditTeamStreamsEnabled(false)
+    setBulkEditTeamStreams(false)
   }
 
   const handleBulkEdit = async () => {
@@ -430,6 +434,10 @@ export function EventGroups() {
       } else if (bulkEditStreamTimezone) {
         request.stream_timezone = bulkEditStreamTimezone
       }
+    }
+
+    if (bulkEditTeamStreamsEnabled) {
+      request.team_streams_enabled = bulkEditTeamStreams
     }
 
     if (bulkEditTeamFilterEnabled) {
@@ -894,7 +902,18 @@ export function EventGroups() {
                         </TableCell>
                     {/* Matched Column with Progress Bar */}
                     <TableCell className="text-center">
-                      {group.stream_count && group.stream_count > 0 ? (
+                      {group.team_streams_enabled ? (
+                        // Team stream groups fan-out one stream to many events —
+                        // a match rate % is meaningless, show assignments instead
+                        <div className="flex flex-col items-center gap-0.5" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
+                          <span className="text-[0.65rem] text-muted-foreground">
+                            {group.stream_count ?? 0} streams
+                          </span>
+                          <span className="text-[0.65rem]">
+                            {group.matched_count ?? 0} assignments
+                          </span>
+                        </div>
+                      ) : group.stream_count && group.stream_count > 0 ? (
                         <div className="flex flex-col items-center gap-0.5" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
                           <div className="w-full h-1.5 bg-secondary rounded-full overflow-hidden">
                             <div
@@ -1211,6 +1230,28 @@ export function EventGroups() {
               )}
             </div>
 
+            {/* Team Stream Source */}
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <Checkbox
+                  checked={bulkEditTeamStreamsEnabled}
+                  onCheckedChange={(checked) => setBulkEditTeamStreamsEnabled(!!checked)}
+                />
+                <span className="text-sm font-medium">Team stream source</span>
+              </label>
+              {bulkEditTeamStreamsEnabled && (
+                <div className="flex items-center gap-3 pl-6">
+                  <Switch
+                    checked={bulkEditTeamStreams}
+                    onCheckedChange={setBulkEditTeamStreams}
+                  />
+                  <span className="text-sm text-muted-foreground">
+                    {bulkEditTeamStreams ? "Enabled — team-branded streams will match events where that team plays" : "Disabled"}
+                  </span>
+                </div>
+              )}
+            </div>
+
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowBulkEdit(false)}>
@@ -1218,7 +1259,7 @@ export function EventGroups() {
             </Button>
             <Button
               onClick={handleBulkEdit}
-              disabled={bulkUpdateMutation.isPending || !(bulkEditStreamTimezoneEnabled || bulkEditTeamFilterEnabled)}
+              disabled={bulkUpdateMutation.isPending || !(bulkEditStreamTimezoneEnabled || bulkEditTeamFilterEnabled || bulkEditTeamStreamsEnabled)}
             >
               {bulkUpdateMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               Apply to {selectedIds.size} groups

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -90,6 +90,7 @@ class GroupCreate(BaseModel):
     custom_regex_event_name: str | None = None
     custom_regex_event_name_enabled: bool = False
     skip_builtin_filter: bool = False
+    team_streams_enabled: bool = False
     # Team filtering (canonical team selection)
     include_teams: list[TeamFilterEntry] | None = None
     exclude_teams: list[TeamFilterEntry] | None = None
@@ -144,6 +145,7 @@ class GroupUpdate(BaseModel):
     custom_regex_event_name: str | None = None
     custom_regex_event_name_enabled: bool | None = None
     skip_builtin_filter: bool | None = None
+    team_streams_enabled: bool | None = None
     # Team filtering (canonical team selection)
     include_teams: list[TeamFilterEntry] | None = None
     exclude_teams: list[TeamFilterEntry] | None = None
@@ -226,6 +228,7 @@ class GroupResponse(BaseModel):
     custom_regex_event_name: str | None = None
     custom_regex_event_name_enabled: bool = False
     skip_builtin_filter: bool = False
+    team_streams_enabled: bool = False
     # Team filtering (canonical team selection, inherited by children)
     include_teams: list[TeamFilterEntry] | None = None
     exclude_teams: list[TeamFilterEntry] | None = None
@@ -667,6 +670,7 @@ def create_group(request: GroupCreate):
             custom_regex_event_name=request.custom_regex_event_name,
             custom_regex_event_name_enabled=request.custom_regex_event_name_enabled,
             skip_builtin_filter=request.skip_builtin_filter,
+            team_streams_enabled=request.team_streams_enabled,
             include_teams=[t.model_dump() for t in request.include_teams]
             if request.include_teams is not None
             else None,
@@ -730,6 +734,7 @@ def create_group(request: GroupCreate):
         custom_regex_event_name=group.custom_regex_event_name,
         custom_regex_event_name_enabled=group.custom_regex_event_name_enabled,
         skip_builtin_filter=group.skip_builtin_filter,
+        team_streams_enabled=group.team_streams_enabled,
         include_teams=[TeamFilterEntry(**t) for t in group.include_teams]
         if group.include_teams
         else None,
@@ -1074,6 +1079,7 @@ def get_group_by_id(group_id: int):
         custom_regex_event_name=group.custom_regex_event_name,
         custom_regex_event_name_enabled=group.custom_regex_event_name_enabled,
         skip_builtin_filter=group.skip_builtin_filter,
+        team_streams_enabled=group.team_streams_enabled,
         include_teams=[TeamFilterEntry(**t) for t in group.include_teams]
         if group.include_teams
         else None,
@@ -1191,6 +1197,7 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
                 custom_regex_event_name=request.custom_regex_event_name,
                 custom_regex_event_name_enabled=request.custom_regex_event_name_enabled,
                 skip_builtin_filter=request.skip_builtin_filter,
+                team_streams_enabled=request.team_streams_enabled,
                 include_teams=[t.model_dump() for t in request.include_teams]
                 if request.include_teams is not None
                 else None,
@@ -1290,6 +1297,7 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
         custom_regex_event_name=group.custom_regex_event_name,
         custom_regex_event_name_enabled=group.custom_regex_event_name_enabled,
         skip_builtin_filter=group.skip_builtin_filter,
+        team_streams_enabled=group.team_streams_enabled,
         include_teams=[TeamFilterEntry(**t) for t in group.include_teams]
         if group.include_teams
         else None,

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -568,6 +568,7 @@ def list_groups(
                 custom_regex_event_name=g.custom_regex_event_name,
                 custom_regex_event_name_enabled=g.custom_regex_event_name_enabled,
                 skip_builtin_filter=g.skip_builtin_filter,
+                team_streams_enabled=g.team_streams_enabled,
                 include_teams=[TeamFilterEntry(**t) for t in g.include_teams]
                 if g.include_teams
                 else None,

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -316,6 +316,7 @@ class BulkGroupSettings(BaseModel):
     channel_sort_order: str = "time"
     overlap_handling: str = "add_stream"
     enabled: bool = True
+    team_streams_enabled: bool = False
 
 
 class BulkGroupCreateRequest(BaseModel):
@@ -363,6 +364,7 @@ class BulkGroupUpdateRequest(BaseModel):
     channel_sort_order: str | None = None
     overlap_handling: str | None = None
     enabled: bool | None = None
+    team_streams_enabled: bool | None = None
 
     # Team filtering
     include_teams: list[TeamFilterEntry] | None = None
@@ -829,6 +831,7 @@ def create_groups_bulk(request: BulkGroupCreateRequest):
                     m3u_account_id=item.m3u_account_id,
                     m3u_account_name=item.m3u_account_name,
                     enabled=request.settings.enabled,
+                    team_streams_enabled=request.settings.team_streams_enabled,
                 )
 
                 results.append(
@@ -914,6 +917,7 @@ def update_groups_bulk(request: BulkGroupUpdateRequest):
                     channel_sort_order=request.channel_sort_order,
                     overlap_handling=request.overlap_handling,
                     enabled=request.enabled,
+                    team_streams_enabled=request.team_streams_enabled,
                     clear_stream_timezone=request.clear_stream_timezone,
                     clear_soccer_mode=request.clear_soccer_mode,
                     clear_soccer_followed_teams=request.clear_soccer_followed_teams,

--- a/teamarr/api/routes/settings/stream_ordering.py
+++ b/teamarr/api/routes/settings/stream_ordering.py
@@ -13,7 +13,7 @@ from .models import (
 router = APIRouter()
 
 # Valid rule types
-VALID_RULE_TYPES = {"m3u", "group", "regex"}
+VALID_RULE_TYPES = {"m3u", "group", "regex", "stream_type"}
 
 
 @router.get("/settings/stream-ordering", response_model=StreamOrderingSettingsModel)
@@ -69,6 +69,11 @@ def update_stream_ordering_settings(update: StreamOrderingSettingsUpdate):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Rule value cannot be empty",
+            )
+        if rule.type == "stream_type" and rule.value.strip() not in {"event", "team"}:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="stream_type value must be 'event' or 'team'",
             )
 
     # Convert to dict format for database function

--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -38,7 +38,7 @@ from teamarr.consumers.filler.event_filler import (
     EventFillerResult,
     template_to_event_filler_config,
 )
-from teamarr.consumers.matching import BatchMatchResult, StreamMatcher
+from teamarr.consumers.matching import BatchMatchResult, StreamCategory, StreamMatcher
 from teamarr.core import SEASON_POSTSEASON, Event
 from teamarr.database.groups import (
     EventEPGGroup,
@@ -1217,7 +1217,10 @@ class EventGroupProcessor:
             # Group-specific team extraction
             custom_teams_regex=group.custom_regex_teams,
             custom_teams_enabled=group.custom_regex_teams_enabled,
-            skip_builtin=group.skip_builtin_filter,
+            # team_streams_enabled implicitly skips all builtin filtering — team-branded
+            # streams (e.g. "NHL | Maple Leafs") have no vs/@ separator and would
+            # otherwise be rejected; the classifier and matcher gate what actually matches.
+            skip_builtin=group.skip_builtin_filter or group.team_streams_enabled,
             team_streams_enabled=group.team_streams_enabled,
         )
 
@@ -1458,6 +1461,9 @@ class EventGroupProcessor:
                             "event": result.event,
                             "card_segment": result.card_segment,  # UFC segment from classifier
                             "feed_hint": result.feed_hint,  # "home", "away", or None
+                            "match_type": (
+                                "team" if result.category == StreamCategory.TEAM_ONLY else "event"
+                            ),
                         }
                     )
 

--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -1218,6 +1218,7 @@ class EventGroupProcessor:
             custom_teams_regex=group.custom_regex_teams,
             custom_teams_enabled=group.custom_regex_teams_enabled,
             skip_builtin=group.skip_builtin_filter,
+            team_streams_enabled=group.team_streams_enabled,
         )
 
         stream_filter = StreamFilter(config)
@@ -1405,6 +1406,7 @@ class EventGroupProcessor:
             stream_timezone=group.stream_timezone,  # TZ for interpreting stream dates
             feed_home_terms=feed_home_terms,
             feed_away_terms=feed_away_terms,
+            team_streams_enabled=group.team_streams_enabled,
         )
 
         result = matcher.match_all(

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -568,6 +568,9 @@ class ChannelLifecycleService:
                         feed_team = matched.get("feed_team")
                         feed_team_id = feed_team.id if feed_team else None
 
+                        # Stream type tag ('event' or 'team') for ordering rules
+                        match_type = matched.get("match_type", "event")
+
                         # Check if event should be excluded based on timing
                         logger.debug(
                             "[LIFECYCLE] Checking stream '%s' for event %s (status=%s)",
@@ -648,6 +651,7 @@ class ChannelLifecycleService:
                                 group_config=group_config,
                                 template=event_template,
                                 segment=segment,
+                                match_type=match_type,
                             )
                             # None means Dispatcharr channel missing - fall through to create new
                             if channel_result is not None:
@@ -724,6 +728,7 @@ class ChannelLifecycleService:
                             feed_team_id=feed_team_id,
                             feed_team=feed_team,
                             feed_label_style=feed_label_style,
+                            match_type=match_type,
                         )
 
                         if channel_result.success:
@@ -827,6 +832,7 @@ class ChannelLifecycleService:
         group_config: dict,
         template: dict | None,
         segment: str | None = None,
+        match_type: str = "event",
     ) -> StreamProcessResult | None:
         """Handle an existing channel based on duplicate mode.
 
@@ -925,6 +931,7 @@ class ChannelLifecycleService:
                     m3u_account_id=stream.get("m3u_account_id"),
                     m3u_account_name=m3u_account_name,
                     source_group_id=source_group_id,
+                    match_type=match_type,
                 )
 
                 # Sync with Dispatcharr - use ordered stream list to respect rules
@@ -1037,6 +1044,7 @@ class ChannelLifecycleService:
         feed_team_id: str | None = None,
         feed_team=None,
         feed_label_style: str | None = None,
+        match_type: str = "event",
     ) -> ChannelCreationResult:
         """Create a new channel in DB and Dispatcharr.
 
@@ -1198,6 +1206,7 @@ class ChannelLifecycleService:
                 m3u_account_id=stream.get("m3u_account_id"),
                 m3u_account_name=group_config.get("m3u_account_name"),
                 source_group_id=group_id,
+                match_type=match_type,
             )
 
             # Commit immediately so next channel number query sees this channel

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -25,6 +25,7 @@ class StreamCategory(Enum):
 
     TEAM_VS_TEAM = "team_vs_team"  # Standard team matchup (vs/@/at)
     EVENT_CARD = "event_card"  # Combat sports (UFC, Boxing)
+    TEAM_ONLY = "team_only"  # Single-team branded stream (e.g., "NHL | Toronto Maple Leafs")
     PLACEHOLDER = "placeholder"  # No event info, skip
 
 
@@ -1245,6 +1246,7 @@ def classify_stream(
     2. Check for event card keywords/type → EVENT_CARD
     3. Try custom regex for team extraction (if configured) → TEAM_VS_TEAM
     4. Check for game separator (vs/@/at) → TEAM_VS_TEAM
+    4.5. Check for single-team content (no separator, no date/time) → TEAM_ONLY
     5. Default → PLACEHOLDER (can't classify)
 
     Note: Placeholder pattern detection is now handled by StreamFilter before
@@ -1439,6 +1441,25 @@ def classify_stream(
                         team1=team1,
                         team2=team2,
                         separator_found=separator,
+                        league_hint=league_hint,
+                        sport_hint=sport_hint,
+                        feed_hint=feed_hint,
+                    )
+
+        # Step 4.5: Check for single-team stream (TEAM_ONLY)
+        # Applies when no separator was found (would otherwise be PLACEHOLDER).
+        # A stream qualifies as TEAM_ONLY when:
+        #   - No date or time was extracted (stream is not event-specific)
+        #   - After stripping league/sport/noise prefixes, a non-trivial candidate remains
+        # The matcher validates the candidate against the team cache; a miss → NO_MATCH.
+        if result is None:
+            if normalized.extracted_date is None and normalized.extracted_time is None:
+                candidate = _clean_team_name(text)
+                if candidate and len(candidate) >= 3:
+                    result = ClassifiedStream(
+                        category=StreamCategory.TEAM_ONLY,
+                        normalized=normalized,
+                        team1=candidate,
                         league_hint=league_hint,
                         sport_hint=sport_hint,
                         feed_hint=feed_hint,

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -192,6 +192,7 @@ class StreamMatcher:
         stream_timezone: str | None = None,
         feed_home_terms: list[str] | None = None,
         feed_away_terms: list[str] | None = None,
+        team_streams_enabled: bool = False,
     ):
         """Initialize the matcher.
 
@@ -281,6 +282,7 @@ class StreamMatcher:
         # Feed separation terms
         self._feed_home_terms = feed_home_terms
         self._feed_away_terms = feed_away_terms
+        self._team_streams_enabled = team_streams_enabled
 
         # Initialize cache
         self._cache = StreamMatchCache(db_factory)
@@ -355,23 +357,26 @@ class StreamMatcher:
             stream_id = stream.get("id", 0)
             stream_name = stream.get("name", "")
 
-            match_result = self._match_single(
+            match_results = self._match_single(
                 stream_id=stream_id,
                 stream_name=stream_name,
                 target_date=target_date,
             )
 
-            # Track cache stats
-            if match_result.from_cache:
-                result.cache_hits += 1
-            else:
-                result.cache_misses += 1
+            # Track cache stats and accumulate (TEAM_ONLY may return multiple results)
+            any_matched = False
+            for match_result in match_results:
+                if match_result.from_cache:
+                    result.cache_hits += 1
+                else:
+                    result.cache_misses += 1
+                result.results.append(match_result)
+                if match_result.matched:
+                    any_matched = True
 
-            result.results.append(match_result)
-
-            # Report per-stream progress
+            # Report per-stream progress (report once per source stream)
             if progress_callback:
-                progress_callback(idx, total_streams, stream_name, match_result.matched)
+                progress_callback(idx, total_streams, stream_name, any_matched)
 
         logger.info(
             "[COMPLETED] Stream matching: %d/%d matched (%d included), cache_hit_rate=%.1f%%",
@@ -496,8 +501,9 @@ class StreamMatcher:
         stream_id: int,
         stream_name: str,
         target_date: date,
-    ) -> MatchedStreamResult:
-        """Match a single stream."""
+    ) -> list[MatchedStreamResult]:
+        """Match a single stream. Returns a list — usually one element, but TEAM_ONLY
+        streams can fan out to multiple results (one per matched event)."""
         # Step 1: Classify the stream
         # Determine event type from configured leagues
         league_event_type = self._get_dominant_event_type()
@@ -513,14 +519,14 @@ class StreamMatcher:
         # This handles streams that passed filtering but still can't be classified
         # (e.g., no separator found, no custom regex match).
         if classified.category == StreamCategory.PLACEHOLDER:
-            return MatchedStreamResult(
+            return [MatchedStreamResult(
                 stream_name=stream_name,
                 stream_id=stream_id,
                 matched=False,
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="unclassifiable",
-            )
+            )]
 
         # Step 3: Route to appropriate matcher based on category
         if classified.category == StreamCategory.EVENT_CARD:
@@ -529,20 +535,51 @@ class StreamMatcher:
                 stream_id=stream_id,
                 target_date=target_date,
             )
-        else:  # TEAM_VS_TEAM
-            outcome = self._match_team_vs_team(
+            return [self._outcome_to_result(
+                outcome=outcome,
+                stream_id=stream_id,
+                stream_name=stream_name,
+                classified=classified,
+            )]
+
+        if classified.category == StreamCategory.TEAM_ONLY and not self._team_streams_enabled:
+            return [MatchedStreamResult(
+                stream_name=stream_name,
+                stream_id=stream_id,
+                matched=False,
+                included=False,
+                category=StreamCategory.PLACEHOLDER,
+                exclusion_reason="team_streams_disabled",
+            )]
+
+        if classified.category == StreamCategory.TEAM_ONLY:
+            outcomes = self._match_team_only(
                 classified=classified,
                 stream_id=stream_id,
                 target_date=target_date,
             )
+            return [
+                self._outcome_to_result(
+                    outcome=o,
+                    stream_id=stream_id,
+                    stream_name=stream_name,
+                    classified=classified,
+                )
+                for o in outcomes
+            ]
 
-        # Step 4: Convert outcome to result
-        return self._outcome_to_result(
+        # TEAM_VS_TEAM
+        outcome = self._match_team_vs_team(
+            classified=classified,
+            stream_id=stream_id,
+            target_date=target_date,
+        )
+        return [self._outcome_to_result(
             outcome=outcome,
             stream_id=stream_id,
             stream_name=stream_name,
             classified=classified,
-        )
+        )]
 
     def _match_team_vs_team(
         self,
@@ -587,6 +624,33 @@ class StreamMatcher:
                 prefetched_events=self._prefetched_events,
                 stream_tz=stream_tz,
             )
+
+    def _match_team_only(
+        self,
+        classified: ClassifiedStream,
+        stream_id: int,
+        target_date: date,
+    ) -> list[MatchOutcome]:
+        """Match a single-team branded stream, returning one outcome per matched event."""
+        stream_tz = self._stream_tz
+        if classified.normalized.extracted_tz:
+            try:
+                stream_tz = ZoneInfo(classified.normalized.extracted_tz)
+            except (KeyError, ValueError):
+                pass
+
+        return self._team_matcher.match_team_only(
+            classified=classified,
+            enabled_leagues=list(self._include_leagues),
+            target_date=target_date,
+            group_id=self._group_id,
+            stream_id=stream_id,
+            generation=self._generation,
+            user_tz=self._user_tz,
+            sport_durations=self._sport_durations,
+            prefetched_events=self._prefetched_events,
+            stream_tz=stream_tz,
+        )
 
     def _match_event_card(
         self,

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -369,6 +369,149 @@ class TeamMatcher:
 
         return result
 
+    def match_team_only(
+        self,
+        classified: ClassifiedStream,
+        enabled_leagues: list[str],
+        target_date: date,
+        group_id: int,
+        stream_id: int,
+        generation: int,
+        user_tz: ZoneInfo,
+        sport_durations: dict[str, float] | None = None,
+        prefetched_events: dict[str, list[Event]] | None = None,
+        stream_tz: ZoneInfo | None = None,
+    ) -> list[MatchOutcome]:
+        """Match a single-team branded stream (TEAM_ONLY) to all its events in the window.
+
+        Unlike TEAM_VS_TEAM, the stream carries one team's brand (e.g.
+        "NHL | Toronto Maple Leafs") and should be added to every event where
+        that team plays within the date window. Returns one MatchOutcome per
+        matched event so the caller can fan out to multiple channels.
+
+        Args:
+            classified: Pre-classified stream (category must be TEAM_ONLY)
+            enabled_leagues: League codes subscribed for this group
+            target_date: Date to anchor the search window
+            group_id: Event group ID (for caching)
+            stream_id: Stream ID (for caching)
+            generation: Cache generation counter
+            user_tz: User timezone for date validation
+            sport_durations: Sport duration settings
+            prefetched_events: Optional pre-fetched events by league
+            stream_tz: Timezone for interpreting stream dates
+
+        Returns:
+            List of MatchOutcome — one per matched event, or a single
+            filtered/failed outcome if nothing matched.
+        """
+        if classified.category != StreamCategory.TEAM_ONLY:
+            return [MatchOutcome.filtered(
+                FilteredReason.NOT_EVENT,
+                stream_name=classified.normalized.original,
+                stream_id=stream_id,
+            )]
+
+        stream_name = classified.normalized.original
+
+        # Narrow search by league hint (same logic as match_multi_league)
+        league_hint = classified.league_hint
+        if league_hint:
+            hint_leagues = [league_hint] if isinstance(league_hint, str) else league_hint
+            valid_leagues = [lg for lg in hint_leagues if lg in enabled_leagues]
+            if not valid_leagues:
+                hint_display = (
+                    league_hint if isinstance(league_hint, str) else ", ".join(league_hint)
+                )
+                return [MatchOutcome.filtered(
+                    FilteredReason.LEAGUE_NOT_INCLUDED,
+                    stream_name=stream_name,
+                    stream_id=stream_id,
+                    detail=f"League '{hint_display}' not in enabled leagues",
+                )]
+            leagues_to_search = valid_leagues
+        else:
+            leagues_to_search = enabled_leagues
+
+        # Narrow date window to ±2 days to minimise false positives.
+        window_days = 2
+        all_events: list[tuple[str, Event]] = []
+        if prefetched_events:
+            for league in leagues_to_search:
+                for event in prefetched_events.get(league, []):
+                    event_date = event.start_time.astimezone(user_tz).date()
+                    if abs((event_date - target_date).days) <= window_days:
+                        all_events.append((league, event))
+        else:
+            is_tsdb_map = {
+                lg: self._service.get_provider_name(lg) == "tsdb"
+                for lg in leagues_to_search
+            }
+            for league in leagues_to_search:
+                for offset in range(-window_days, window_days + 1):
+                    fetch_date = target_date + timedelta(days=offset)
+                    cache_only = is_tsdb_map[league] or offset < 0
+                    events = self._service.get_events(league, fetch_date, cache_only=cache_only)
+                    for event in events:
+                        all_events.append((league, event))
+
+        if not all_events:
+            return [MatchOutcome.failed(
+                FailedReason.NO_EVENT_FOUND,
+                stream_name=stream_name,
+                stream_id=stream_id,
+                detail=f"No events in window ±{window_days}d for {target_date}",
+                parsed_team1=classified.team1,
+            )]
+
+        team_norm = normalize_for_matching(classified.team1) if classified.team1 else None
+        if not team_norm:
+            return [MatchOutcome.failed(
+                FailedReason.TEAMS_NOT_PARSED,
+                stream_name=stream_name,
+                stream_id=stream_id,
+                detail="No team candidate extracted",
+            )]
+
+        matched_outcomes: list[MatchOutcome] = []
+        seen_event_ids: set[str] = set()
+
+        for league, event in all_events:
+            if event.id in seen_event_ids:
+                continue
+            score, _side = self._score_single_team_against_event(team_norm, event)
+            if score is None:
+                continue
+            seen_event_ids.add(event.id)
+            logger.debug(
+                "[TEAM_ONLY] Matched: stream_id=%d team='%s' event=%s league=%s conf=%.0f%%",
+                stream_id,
+                classified.team1,
+                event.id,
+                league,
+                score,
+            )
+            matched_outcomes.append(MatchOutcome.matched(
+                MatchMethod.FUZZY,
+                event,
+                detected_league=league,
+                confidence=score / 100.0,
+                stream_name=stream_name,
+                stream_id=stream_id,
+                parsed_team1=classified.team1,
+            ))
+
+        if matched_outcomes:
+            return matched_outcomes
+
+        return [MatchOutcome.failed(
+            FailedReason.NO_EVENT_FOUND,
+            stream_name=stream_name,
+            stream_id=stream_id,
+            detail=f"No event found for team '{classified.team1}'",
+            parsed_team1=classified.team1,
+        )]
+
     # =========================================================================
     # PRIVATE METHODS
     # =========================================================================
@@ -983,6 +1126,42 @@ class TeamMatcher:
             return None
 
         return None
+
+    def _score_single_team_against_event(
+        self,
+        team_norm: str,
+        event: "Event",
+    ) -> tuple[float, str] | tuple[None, None]:
+        """Score a single team name against an event's home and away teams.
+
+        For TEAM_ONLY streams. Returns the best score and which side matched,
+        but only when the team clearly matches ONE side and not the other.
+        This guards against the (practically impossible) case where the same
+        team name scores high on both sides of an event.
+
+        Args:
+            team_norm: Normalized candidate team name from the stream
+            event: Event to match against
+
+        Returns:
+            (score, side) where side is "home" or "away", or (None, None)
+        """
+        home_norm = normalize_text(event.home_team.name)
+        away_norm = normalize_text(event.away_team.name)
+
+        home_score = fuzz.token_set_ratio(team_norm, home_norm)
+        away_score = fuzz.token_set_ratio(team_norm, away_norm)
+
+        home_matches = home_score >= HIGH_CONFIDENCE_THRESHOLD
+        away_matches = away_score >= HIGH_CONFIDENCE_THRESHOLD
+
+        # Require exactly one side to match (not both)
+        if home_matches and not away_matches:
+            return home_score, "home"
+        if away_matches and not home_matches:
+            return away_score, "away"
+
+        return None, None
 
     def _resolve_alias(self, team_name: str, league: str | None) -> str | None:
         """Resolve a team name to its canonical form via alias lookup.

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -1607,6 +1607,7 @@ class TeamMatcher:
                 status=status,
                 league=cached_data.get("league", ""),
                 sport=cached_data.get("sport", ""),
+                season_type=cached_data.get("season_type"),
                 venue=venue,
                 broadcasts=broadcasts,
                 segment_times=segment_times,

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -45,6 +45,7 @@ def add_stream_to_channel(
         "m3u_account_id",
         "m3u_account_name",
         "exception_keyword",
+        "match_type",
     ]
 
     for field_name in allowed_fields:

--- a/teamarr/database/channels/types.py
+++ b/teamarr/database/channels/types.py
@@ -117,6 +117,7 @@ class ManagedChannelStream:
     m3u_account_id: int | None = None
     m3u_account_name: str | None = None
     exception_keyword: str | None = None
+    match_type: str = "event"
     added_at: datetime | None = None
     removed_at: datetime | None = None
 
@@ -134,6 +135,7 @@ class ManagedChannelStream:
             m3u_account_id=row.get("m3u_account_id"),
             m3u_account_name=row.get("m3u_account_name"),
             exception_keyword=row.get("exception_keyword"),
+            match_type=row.get("match_type", "event"),
             added_at=row.get("added_at"),
             removed_at=row.get("removed_at"),
         )

--- a/teamarr/database/groups.py
+++ b/teamarr/database/groups.py
@@ -116,6 +116,7 @@ class EventEPGGroup:
     exclude_teams: list[dict] | None = None
     team_filter_mode: str = "include"
     bypass_filter_for_playoffs: bool | None = None  # NULL=use default, True/False=override
+    team_streams_enabled: bool = False
     # Per-group subscription overrides (NULL = inherit global)
     subscription_leagues: list[str] | None = None
     subscription_soccer_mode: str | None = None
@@ -245,6 +246,9 @@ def _row_to_group(row) -> EventEPGGroup:
             if "bypass_filter_for_playoffs" in row.keys()
             and row["bypass_filter_for_playoffs"] is not None
             else None
+        ),
+        team_streams_enabled=(
+            bool(row["team_streams_enabled"]) if "team_streams_enabled" in row.keys() else False
         ),
         # Per-group subscription overrides
         subscription_leagues=(
@@ -448,6 +452,7 @@ def create_group(
     custom_regex_event_name: str | None = None,
     custom_regex_event_name_enabled: bool = False,
     skip_builtin_filter: bool = False,
+    team_streams_enabled: bool = False,
     # Team filtering
     include_teams: list[dict] | None = None,
     exclude_teams: list[dict] | None = None,
@@ -507,11 +512,11 @@ def create_group(
             custom_regex_league, custom_regex_league_enabled,
             custom_regex_fighters, custom_regex_fighters_enabled,
             custom_regex_event_name, custom_regex_event_name_enabled,
-            skip_builtin_filter,
+            skip_builtin_filter, team_streams_enabled,
             include_teams, exclude_teams, team_filter_mode,
             channel_sort_order, overlap_handling, enabled,
             subscription_leagues, subscription_soccer_mode, subscription_soccer_followed_teams
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
         (
             name,
             display_name,
@@ -550,6 +555,7 @@ def create_group(
             custom_regex_event_name,
             int(custom_regex_event_name_enabled),
             int(skip_builtin_filter),
+            int(team_streams_enabled),
             json.dumps(include_teams) if include_teams else None,
             json.dumps(exclude_teams) if exclude_teams else None,
             team_filter_mode,
@@ -613,6 +619,7 @@ def update_group(
     custom_regex_event_name: str | None = None,
     custom_regex_event_name_enabled: bool | None = None,
     skip_builtin_filter: bool | None = None,
+    team_streams_enabled: bool | None = None,
     # Team filtering
     include_teams: list[dict] | None = None,
     exclude_teams: list[dict] | None = None,
@@ -717,6 +724,7 @@ def update_group(
     )
     builder.set_("custom_regex_event_name_enabled", custom_regex_event_name_enabled, encoder=int)
     builder.set_("skip_builtin_filter", skip_builtin_filter, encoder=int)
+    builder.set_("team_streams_enabled", team_streams_enabled, encoder=int)
 
     # Team filtering — empty list semantics: empty list also means "clear".
     builder.set_list_or_clear("include_teams", include_teams, clear=clear_include_teams)

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -483,6 +483,7 @@ CREATE TABLE IF NOT EXISTS event_epg_groups (
     team_filter_mode TEXT DEFAULT 'include'      -- 'include' (whitelist) or 'exclude' (blacklist)
         CHECK(team_filter_mode IN ('include', 'exclude')),
     bypass_filter_for_playoffs BOOLEAN,          -- NULL=use default, 0=disabled, 1=enabled (include all playoff games)
+    team_streams_enabled BOOLEAN DEFAULT 0,      -- Allow team-branded streams (e.g. "NHL | Toronto Maple Leafs") to match events
 
     -- Processing Stats (updated by EPG generation)
     -- Three categories: FILTERED (pre-match), FAILED (match attempted), EXCLUDED (matched but excluded)

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1245,6 +1245,8 @@ CREATE TABLE IF NOT EXISTS managed_channel_streams (
     source_group_id INTEGER,                 -- Which M3U group provided this stream
     source_group_type TEXT DEFAULT 'parent'  -- 'parent', 'child', 'cross_group'
         CHECK(source_group_type IN ('parent', 'child', 'cross_group')),
+    match_type TEXT DEFAULT 'event'          -- 'event' (TEAM_VS_TEAM) or 'team' (TEAM_ONLY)
+        CHECK(match_type IN ('event', 'team')),
 
     -- Priority (0 = primary, higher = failover)
     priority INTEGER DEFAULT 0,

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -534,7 +534,7 @@ def update_stream_ordering_rules(
     from .types import StreamOrderingRule as RuleType
 
     # Validate rules structure
-    valid_types = {"m3u", "group", "regex"}
+    valid_types = {"m3u", "group", "regex", "stream_type"}
     validated_rules = []
 
     for rule in rules:

--- a/teamarr/services/stream_filter.py
+++ b/teamarr/services/stream_filter.py
@@ -19,6 +19,16 @@ from teamarr.services.detection_keywords import DetectionKeywordService
 
 logger = logging.getLogger(__name__)
 
+
+def _has_league_hint(stream_name: str) -> bool:
+    """Return True if the stream name contains a recognisable league hint.
+
+    Used to identify potential TEAM_ONLY candidates (e.g. "NHL | Toronto Maple
+    Leafs") before the full classifier runs, so they can pass the not_event
+    filter when team_streams_enabled is active.
+    """
+    return DetectionKeywordService.detect_league(stream_name) is not None
+
 # Try to import 'regex' module which supports advanced features
 try:
     import regex
@@ -178,6 +188,9 @@ class StreamFilterConfig:
     # Inclusion filter: only process streams that look like events (vs, @, date/time)
     # Disabled by default - rely on matching to filter non-events
     require_event_pattern: bool = False
+    # Allow team-branded streams (e.g. "NHL | Toronto Maple Leafs") to pass the
+    # not_event filter so the classifier can identify them as TEAM_ONLY.
+    team_streams_enabled: bool = False
 
 
 @dataclass
@@ -341,10 +354,15 @@ class StreamFilter:
                     continue
 
                 # 2c. Event pattern filter: stream must look like an event (vs, @, date/time)
+                # Exception: when team_streams_enabled, streams with a league hint are
+                # passed through so the classifier can identify them as TEAM_ONLY.
                 if self._event_pattern:
                     if not self._event_pattern.search(name):
-                        result.filtered_not_event += 1
-                        continue
+                        if self.config.team_streams_enabled and _has_league_hint(name):
+                            pass  # Potential TEAM_ONLY candidate — let classifier decide
+                        else:
+                            result.filtered_not_event += 1
+                            continue
 
             # 3. Include filter: stream must match (user-defined, always applies if enabled)
             if self._include_pattern:

--- a/teamarr/services/stream_ordering.py
+++ b/teamarr/services/stream_ordering.py
@@ -147,6 +147,8 @@ class StreamOrderingService:
             return self._match_group(stream, rule.value, source_group_name)
         elif rule.type == "regex":
             return self._match_regex(stream, rule.value)
+        elif rule.type == "stream_type":
+            return stream.match_type == rule.value
         return False
 
     def _match_m3u(self, stream: ManagedChannelStream, account_name: str) -> bool:


### PR DESCRIPTION
Closes #65

Adds a "team stream source" mode for event groups, designed for team-branded M3U streams like "NHL | Toronto Maple Leafs" that don't follow the standard `Team A vs Team B` format.

When enabled on a group, the classifier recognizes single-team streams as a new `TEAM_ONLY` category and routes them through a dedicated `TeamMatcher` that checks whether the named team is a participant in each scheduled event. Builtin stream filtering is automatically bypassed for these groups since the streams have no vs/@ separator.

A new `stream_type` ordering rule lets you prioritize or deprioritize team streams relative to regular event streams. The `match_type` field is persisted on each managed channel stream so ordering rules have something to evaluate against.

`team_streams_enabled` is exposed in the group form, bulk edit, and bulk import flows. The groups table shows a "streams / events" breakdown instead of a match-rate percentage for team stream groups, since one stream fans out to multiple events.
