### PR TITLE
Fix HockeyTech team schedule always returning empty results

### DIFF
--- a/teamarr/providers/hockeytech/client.py
+++ b/teamarr/providers/hockeytech/client.py
@@ -318,7 +318,7 @@ class HockeyTechClient:
         team_games = []
         for game in schedule:
             # Check if team is home or away
-            if game.get("home_team") == team_id or game.get("visiting_team") == team_id:
+            if str(game.get("home_team", "")) == str(team_id) or str(game.get("visiting_team", "")) == str(team_id):
                 # Check date is within range (includes past games)
                 game_date_str = game.get("date_played")
                 if game_date_str:


### PR DESCRIPTION
I don't think he ever filed an issue, but this resolves an issue
Jonezy/Bootcamppanda was having where AHL/ECHL team-channels would not
generate EPG. This ended up being an issue with all hockeytech-provided-leagues.

The HockeyTech API returns `home_team` / `visiting_team` as integers,
but `team_id` is always a string (SQLite stores it as TEXT). Comparing
int to str is always False in Python, so no game ever matched and every
HockeyTech team channel produced no EPG.

Stringifies both sides before comparing, matching the pattern already
used in `get_team()` in the same file.
