### PR TITLE
Serialize Dispatcharr token acquisition

### DIFF
--- a/teamarr/dispatcharr/auth.py
+++ b/teamarr/dispatcharr/auth.py
@@ -5,7 +5,9 @@ and session management for Dispatcharr API integration.
 """
 
 import logging
+import re
 import threading
+import time
 from datetime import datetime, timedelta
 
 import httpx
@@ -32,6 +34,8 @@ class TokenManager:
     # Class-level session storage for multi-instance support
     # Key: "{url}_{username}" -> session dict
     _sessions: dict[str, dict] = {}
+    _session_locks: dict[str, threading.Lock] = {}
+    _registry_lock = threading.Lock()
 
     # Token refresh buffer (refresh this many minutes before expiry)
     TOKEN_REFRESH_BUFFER_MINUTES = 1
@@ -59,15 +63,20 @@ class TokenManager:
         self._password = password
         self._timeout = timeout
         self._session_key = f"{self._base_url}_{self._username}"
-        self._lock = threading.Lock()
-
-        # Initialize session if not exists
-        if self._session_key not in self._sessions:
-            self._sessions[self._session_key] = {
-                "access_token": None,
-                "refresh_token": None,
-                "token_expiry": None,
-            }
+        # Initialize shared session state and lock if they do not exist.
+        # Multiple DispatcharrClient instances can be created during concurrent
+        # API requests, so auth locking must be shared per URL/user pair.
+        with self._registry_lock:
+            if self._session_key not in self._sessions:
+                self._sessions[self._session_key] = {
+                    "access_token": None,
+                    "refresh_token": None,
+                    "token_expiry": None,
+                    "auth_retry_after": None,
+                }
+            if self._session_key not in self._session_locks:
+                self._session_locks[self._session_key] = threading.Lock()
+            self._lock = self._session_locks[self._session_key]
 
     @property
     def _session(self) -> dict:
@@ -87,6 +96,15 @@ class TokenManager:
             if self._is_valid():
                 return self._session["access_token"]
 
+            retry_after = self._session.get("auth_retry_after")
+            if retry_after and datetime.now() < retry_after:
+                wait_seconds = (retry_after - datetime.now()).total_seconds()
+                logger.warning("[AUTH] Waiting %.1fs for authentication throttle", wait_seconds)
+                time.sleep(max(0.0, wait_seconds))
+
+                if self._is_valid():
+                    return self._session["access_token"]
+
             # Try to refresh token
             if self._session["refresh_token"] and self._refresh():
                 return self._session["access_token"]
@@ -103,6 +121,7 @@ class TokenManager:
             self._session["access_token"] = None
             self._session["refresh_token"] = None
             self._session["token_expiry"] = None
+            self._session["auth_retry_after"] = None
 
     def _is_valid(self) -> bool:
         """Check if current access token is still valid."""
@@ -131,6 +150,7 @@ class TokenManager:
             if response.status_code == 200:
                 data = response.json()
                 self._session["access_token"] = data.get("access")
+                self._session["auth_retry_after"] = None
                 self._session["token_expiry"] = datetime.now() + timedelta(
                     minutes=self.TOKEN_VALIDITY_MINUTES - self.TOKEN_REFRESH_BUFFER_MINUTES
                 )
@@ -166,6 +186,7 @@ class TokenManager:
                 data = response.json()
                 self._session["access_token"] = data.get("access")
                 self._session["refresh_token"] = data.get("refresh")
+                self._session["auth_retry_after"] = None
                 self._session["token_expiry"] = datetime.now() + timedelta(
                     minutes=self.TOKEN_VALIDITY_MINUTES - self.TOKEN_REFRESH_BUFFER_MINUTES
                 )
@@ -180,6 +201,14 @@ class TokenManager:
                 logger.error("[AUTH] Forbidden: %s", response.text)
                 return False
 
+            if response.status_code == 429:
+                wait_seconds = self._parse_retry_delay(response)
+                self._session["auth_retry_after"] = datetime.now() + timedelta(
+                    seconds=wait_seconds
+                )
+                logger.error("[AUTH] Throttled; retry after %.1fs", wait_seconds)
+                return False
+
             logger.error("[AUTH] Failed: %d - %s", response.status_code, response.text)
             return False
 
@@ -187,7 +216,28 @@ class TokenManager:
             logger.error("[AUTH] Request failed: %s", e)
             return False
 
+    def _parse_retry_delay(self, response: httpx.Response) -> float:
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return max(1.0, float(retry_after))
+            except ValueError:
+                pass
+
+        try:
+            detail = response.json().get("detail", "")
+        except Exception:
+            detail = response.text
+
+        match = re.search(r"available in (\d+(?:\.\d+)?) seconds", detail)
+        if match:
+            return max(1.0, float(match.group(1)))
+
+        return 30.0
+
     @classmethod
     def clear_all_sessions(cls) -> None:
         """Clear all cached sessions (useful for testing)."""
-        cls._sessions.clear()
+        with cls._registry_lock:
+            cls._sessions.clear()
+            cls._session_locks.clear()

--- a/teamarr/dispatcharr/client.py
+++ b/teamarr/dispatcharr/client.py
@@ -363,11 +363,15 @@ class DispatcharrClient:
             }
 
     def close(self) -> None:
-        """Close HTTP client and clear auth."""
+        """Close HTTP client.
+
+        Auth tokens are shared across DispatcharrClient instances by TokenManager.
+        Closing a short-lived client must not clear the shared token because
+        concurrent API requests may be using it.
+        """
         if self._client:
             self._client.close()
             self._client = None
-        self._auth.clear()
 
     def __enter__(self) -> "DispatcharrClient":
         """Context manager entry."""

--- a/tests/test_dispatcharr_auth.py
+++ b/tests/test_dispatcharr_auth.py
@@ -1,0 +1,79 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from threading import Event, Lock
+from time import monotonic, sleep
+
+import httpx
+
+from teamarr.dispatcharr.auth import TokenManager
+from teamarr.dispatcharr.client import DispatcharrClient
+
+
+def test_token_authentication_is_serialized_per_session(monkeypatch):
+    TokenManager.clear_all_sessions()
+
+    authenticate_calls = 0
+    authenticate_lock = Lock()
+    release_auth = Event()
+
+    def fake_authenticate(self):
+        nonlocal authenticate_calls
+        with authenticate_lock:
+            authenticate_calls += 1
+
+        release_auth.wait(timeout=5)
+        self._session["access_token"] = "shared-token"
+        self._session["refresh_token"] = "refresh-token"
+        self._session["token_expiry"] = datetime.now() + timedelta(minutes=5)
+        return True
+
+    monkeypatch.setattr(TokenManager, "_authenticate", fake_authenticate)
+
+    managers = [
+        TokenManager("http://dispatcharr.example", "user", "password")
+        for _ in range(12)
+    ]
+    start = Event()
+
+    def get_token(manager):
+        start.wait(timeout=5)
+        return manager.get_token()
+
+    with ThreadPoolExecutor(max_workers=len(managers)) as executor:
+        futures = [executor.submit(get_token, manager) for manager in managers]
+        start.set()
+
+        deadline = monotonic() + 5
+        while authenticate_calls == 0 and monotonic() < deadline:
+            sleep(0.01)
+        assert authenticate_calls == 1
+        release_auth.set()
+
+        tokens = [future.result(timeout=5) for future in futures]
+
+    assert tokens == ["shared-token"] * len(managers)
+    assert authenticate_calls == 1
+
+
+def test_auth_retry_delay_uses_dispatcharr_throttle_detail():
+    manager = TokenManager("http://dispatcharr.example", "user", "password")
+    response = httpx.Response(
+        429,
+        json={"detail": "Request was throttled. Expected available in 12 seconds."},
+    )
+
+    assert manager._parse_retry_delay(response) == 12.0
+
+
+def test_client_close_preserves_shared_auth_session():
+    TokenManager.clear_all_sessions()
+
+    client = DispatcharrClient("http://dispatcharr.example", "user", "password")
+    client._auth._session["access_token"] = "cached-token"
+    client._auth._session["refresh_token"] = "refresh-token"
+    client._auth._session["token_expiry"] = datetime.now() + timedelta(minutes=5)
+
+    client.close()
+
+    next_manager = TokenManager("http://dispatcharr.example", "user", "password")
+    assert next_manager.get_token() == "cached-token"


### PR DESCRIPTION
## Summary

This PR makes Dispatcharr authentication caching safe under concurrent Teamarr API requests.

Root cause: `TokenManager` already shared token session state per Dispatcharr URL/user, but each `TokenManager` instance had its own lock. Concurrent short-lived clients could therefore authenticate in parallel. On top of that, `DispatcharrClient.close()` cleared the shared token, so connection/status checks could invalidate a token while other requests were actively fetching streams. When Dispatcharr returned HTTP 429, later callers retried authentication immediately and extended the throttle window.

## Changes

- Share the auth lock per Dispatcharr URL/user session.
- Preserve the shared token cache when closing a short-lived `DispatcharrClient`.
- Track Dispatcharr auth throttle responses via a shared `auth_retry_after` timestamp.
- Parse `Retry-After` or Dispatcharr's throttle detail text before retrying authentication.
- Add regression coverage for concurrent auth, throttle parsing, and close behavior.

## Validation

- `python -m pytest -q` -> 572 passed, 4 existing deprecation warnings.
- `python -m ruff check teamarr/dispatcharr/auth.py teamarr/dispatcharr/client.py tests/test_dispatcharr_auth.py` -> passed.
- Built a Docker image from this branch successfully.
- Read-only live pressure validation against a large Dispatcharr-backed library:
  - Test path: 108 Teamarr event groups fetched through the raw stream endpoint while polling Dispatcharr connectivity through Teamarr.
  - Before the final fix, the same read-only pattern produced repeated Dispatcharr auth throttling (`429`) and stream fetch failures.
  - After the fix: 108/108 group fetches succeeded, 0 operation errors, 0 auth throttle/error log lines during the run.
  - Stream-fetch operation timing after the fix: p50 88.3 ms, p95 203.0 ms, p99 258.8 ms, max 1129.0 ms, total 11.7 s.

p95/p99 here mean the 95th/99th percentile request durations, useful for showing tail latency rather than only the average case.