### PR TITLE
feat: add CricAPI provider for free cricket fixture data

### DIFF
--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -87,6 +87,8 @@ export interface DisplaySettings {
   xmltv_generator_name: string
   xmltv_generator_url: string
   tsdb_api_key: string | null  // Optional TheSportsDB premium API key
+  cricapi_api_key: string | null  // Optional CricAPI key for cricket data
+  cricket_provider: "cricapi" | "tsdb"  // Cricket data provider toggle
 }
 
 export interface TSDBKeyValidationResult {
@@ -97,6 +99,17 @@ export interface TSDBKeyValidationResult {
 
 export async function validateTSDBKey(apiKey: string): Promise<TSDBKeyValidationResult> {
   return api.post("/settings/tsdb/validate-key", { api_key: apiKey })
+}
+
+export interface CricAPIKeyValidationResult {
+  valid: boolean
+  message: string
+  hits_today: number
+  hits_limit: number
+}
+
+export async function validateCricAPIKey(apiKey: string): Promise<CricAPIKeyValidationResult> {
+  return api.post("/settings/cricapi/validate-key", { api_key: apiKey })
 }
 
 export interface TeamFilterEntry {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -113,8 +113,9 @@ import type {
   ChannelsDVRSettings,
   SubscriptionLeagueConfig,
   TSDBKeyValidationResult,
+  CricAPIKeyValidationResult,
 } from "@/api/settings"
-import { validateTSDBKey } from "@/api/settings"
+import { validateTSDBKey, validateCricAPIKey } from "@/api/settings"
 
 function formatRelativeTime(dateStr: string | null): string {
   if (!dateStr) return "Never"
@@ -988,6 +989,8 @@ export function Settings() {
   const [display, setDisplay] = useState<DisplaySettings | null>(null)
   const [tsdbValidation, setTsdbValidation] = useState<TSDBKeyValidationResult | null>(null)
   const [tsdbValidating, setTsdbValidating] = useState(false)
+  const [cricapiValidation, setCricapiValidation] = useState<CricAPIKeyValidationResult | null>(null)
+  const [cricapiValidating, setCricapiValidating] = useState(false)
   const [channelNumbering, setChannelNumbering] = useState<ChannelNumberingSettings>({
     global_channel_mode: "auto",
     league_channel_starts: {},
@@ -4180,6 +4183,120 @@ export function Settings() {
           </div>
 
           <Button onClick={() => handleSaveDisplay("TSDB API key saved")} disabled={updateDisplay.isPending}>
+            {updateDisplay.isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-1" />
+            )}
+            Save
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Cricket Data */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Cricket Data</CardTitle>
+            <Badge variant={display?.cricket_provider === "cricapi" ? "default" : "secondary"} className="text-xs">
+              {display?.cricket_provider === "cricapi" ? "CricAPI (Free)" : "TSDB"}
+            </Badge>
+          </div>
+          <CardDescription>
+            Cricket fixture data for IPL, BBL, and SA20 leagues
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Provider Toggle */}
+          <div className="space-y-2">
+            <Label>Data Provider</Label>
+            <div className="flex gap-2">
+              <Button
+                variant={display?.cricket_provider === "cricapi" ? "default" : "outline"}
+                size="sm"
+                onClick={() => display && setDisplay({ ...display, cricket_provider: "cricapi" })}
+              >
+                CricAPI (Free)
+              </Button>
+              <Button
+                variant={display?.cricket_provider === "tsdb" ? "default" : "outline"}
+                size="sm"
+                onClick={() => display && setDisplay({ ...display, cricket_provider: "tsdb" })}
+              >
+                TSDB Premium
+              </Button>
+            </div>
+            {display?.cricket_provider === "cricapi" ? (
+              <p className="text-xs text-muted-foreground">
+                Full fixture coverage via CricketData.org. Free tier includes 100 requests/day — more than enough with caching.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Uses your TSDB premium key for cricket data. TSDB free tier provides very limited coverage (~15 events per season).
+              </p>
+            )}
+          </div>
+
+          {/* CricAPI Key (shown when CricAPI selected) */}
+          {display?.cricket_provider === "cricapi" && (
+            <div className="space-y-2">
+              <Label htmlFor="cricapi-api-key">CricAPI Key</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="cricapi-api-key"
+                  type="password"
+                  value={display?.cricapi_api_key ?? ""}
+                  onChange={(e) => {
+                    display && setDisplay({ ...display, cricapi_api_key: e.target.value })
+                    setCricapiValidation(null)
+                  }}
+                  placeholder="Your CricketData.org API key"
+                  className="flex-1"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={cricapiValidating || !display?.cricapi_api_key}
+                  onClick={async () => {
+                    if (!display?.cricapi_api_key) return
+                    setCricapiValidating(true)
+                    setCricapiValidation(null)
+                    try {
+                      const result = await validateCricAPIKey(display.cricapi_api_key)
+                      setCricapiValidation(result)
+                    } catch {
+                      setCricapiValidation({ valid: false, message: "Connection error", hits_today: 0, hits_limit: 100 })
+                    } finally {
+                      setCricapiValidating(false)
+                    }
+                  }}
+                >
+                  {cricapiValidating ? <Loader2 className="h-4 w-4 animate-spin" /> : "Validate"}
+                </Button>
+              </div>
+              {cricapiValidation && (
+                <p className={`text-xs ${cricapiValidation.valid ? "text-green-500" : "text-red-500"}`}>
+                  {cricapiValidation.message}
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Sign up free at{" "}
+                <a href="https://cricketdata.org/" target="_blank" rel="noopener noreferrer" className="underline">
+                  cricketdata.org
+                </a>{" "}
+                to get your API key. Free tier includes 100 requests/day with full fixture schedules for IPL, BBL, and SA20.
+              </p>
+            </div>
+          )}
+
+          {/* TSDB note (shown when TSDB selected) */}
+          {display?.cricket_provider === "tsdb" && (
+            <p className="text-xs text-muted-foreground">
+              Cricket data will use your TSDB premium key from the section above. Make sure your TSDB key is configured and validated.
+            </p>
+          )}
+
+          <Button onClick={() => handleSaveDisplay("Cricket data settings saved")} disabled={updateDisplay.isPending}>
             {updateDisplay.isPending ? (
               <Loader2 className="h-4 w-4 mr-1 animate-spin" />
             ) : (

--- a/teamarr/api/routes/settings/__init__.py
+++ b/teamarr/api/routes/settings/__init__.py
@@ -137,6 +137,8 @@ def get_settings():
             xmltv_generator_name=settings.display.xmltv_generator_name,
             xmltv_generator_url=settings.display.xmltv_generator_url,
             tsdb_api_key=settings.display.tsdb_api_key,
+            cricapi_api_key=settings.display.cricapi_api_key,
+            cricket_provider=settings.display.cricket_provider,
         ),
         team_filter=TeamFilterSettingsModel(
             include_teams=settings.team_filter.include_teams,

--- a/teamarr/api/routes/settings/display.py
+++ b/teamarr/api/routes/settings/display.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, HTTPException, status
 from teamarr.database import get_db
 
 from .models import (
+    CricAPIKeyValidationRequest,
+    CricAPIKeyValidationResponse,
     DisplaySettingsModel,
     ReconciliationSettingsModel,
     TSDBKeyValidationRequest,
@@ -15,6 +17,14 @@ from .models import (
 )
 
 router = APIRouter()
+
+# TSDB provider IDs for cricket leagues (static, from TSDB's database).
+# Only needed when switching cricket_provider to 'tsdb'.
+_TSDB_CRICKET_IDS: dict[str, str] = {
+    "ipl": "4460",
+    "bbl": "4461",
+    "sa20": "5532",
+}
 
 
 # =============================================================================
@@ -143,6 +153,8 @@ def get_display_settings():
         xmltv_generator_name=settings.display.xmltv_generator_name,
         xmltv_generator_url=settings.display.xmltv_generator_url,
         tsdb_api_key=settings.display.tsdb_api_key,
+        cricapi_api_key=settings.display.cricapi_api_key,
+        cricket_provider=settings.display.cricket_provider,
     )
 
 
@@ -160,6 +172,13 @@ def update_display_settings_endpoint(update: DisplaySettingsModel):
         )
 
     with get_db() as conn:
+        # Detect cricket_provider change before updating
+        prev = conn.execute(
+            "SELECT cricket_provider FROM settings WHERE id = 1"
+        ).fetchone()
+        old_cricket_provider = prev["cricket_provider"] if prev else None
+        cricket_provider_changed = update.cricket_provider != old_cricket_provider
+
         update_display_settings(
             conn,
             time_format=update.time_format,
@@ -168,7 +187,37 @@ def update_display_settings_endpoint(update: DisplaySettingsModel):
             xmltv_generator_name=update.xmltv_generator_name,
             xmltv_generator_url=update.xmltv_generator_url,
             tsdb_api_key=unmask_or_skip(update.tsdb_api_key),
+            cricapi_api_key=unmask_or_skip(update.cricapi_api_key),
+            cricket_provider=update.cricket_provider,
         )
+
+        # Update league entries only when the cricket provider actually changed
+        if cricket_provider_changed:
+            rows = conn.execute(
+                "SELECT league_code FROM leagues WHERE sport = 'cricket'"
+            ).fetchall()
+            cricket_league_codes = [r["league_code"] for r in rows]
+
+            if update.cricket_provider == "tsdb":
+                for league_code in cricket_league_codes:
+                    tsdb_id = _TSDB_CRICKET_IDS.get(league_code)
+                    if not tsdb_id:
+                        continue
+                    conn.execute(
+                        "UPDATE leagues SET provider = 'tsdb', provider_league_id = ?, "
+                        "provider_league_name = NULL, tsdb_tier = 'premium' "
+                        "WHERE league_code = ? AND provider != 'tsdb'",
+                        (tsdb_id, league_code),
+                    )
+            else:
+                for league_code in cricket_league_codes:
+                    conn.execute(
+                        "UPDATE leagues SET provider = 'cricapi', provider_league_id = NULL, "
+                        "provider_league_name = NULL, tsdb_tier = NULL "
+                        "WHERE league_code = ? AND provider != 'cricapi'",
+                        (league_code,),
+                    )
+            conn.commit()
 
     # Update cached display settings so new values are used immediately
     set_config_display(
@@ -179,12 +228,22 @@ def update_display_settings_endpoint(update: DisplaySettingsModel):
         xmltv_generator_url=update.xmltv_generator_url,
     )
 
-    # Reinitialize TSDB provider so it picks up the new API key
-    # without requiring a restart. The factory re-reads the key from DB.
-    if unmask_or_skip(update.tsdb_api_key) is not None:
-        from teamarr.providers.registry import ProviderRegistry
+    # Reinitialize providers only when relevant settings change
+    from teamarr.providers.registry import ProviderRegistry
+    from teamarr.services.league_mappings import get_league_mapping_service
 
+    if unmask_or_skip(update.tsdb_api_key) is not None:
         ProviderRegistry.reinitialize_provider("tsdb")
+
+    if unmask_or_skip(update.cricapi_api_key) is not None:
+        ProviderRegistry.reinitialize_provider("cricapi")
+
+    # Reinitialize league mappings when cricket provider changed so
+    # provider routing picks up the new league-to-provider assignments.
+    if cricket_provider_changed:
+        mapping_service = get_league_mapping_service()
+        mapping_service.reload()
+        ProviderRegistry.initialize(mapping_service)
 
     with get_db() as conn:
         settings = get_all_settings(conn)
@@ -196,6 +255,8 @@ def update_display_settings_endpoint(update: DisplaySettingsModel):
         xmltv_generator_name=settings.display.xmltv_generator_name,
         xmltv_generator_url=settings.display.xmltv_generator_url,
         tsdb_api_key=settings.display.tsdb_api_key,
+        cricapi_api_key=settings.display.cricapi_api_key,
+        cricket_provider=settings.display.cricket_provider,
     )
 
 
@@ -265,4 +326,64 @@ def validate_tsdb_key(request: TSDBKeyValidationRequest):
     except Exception as e:
         return TSDBKeyValidationResponse(
             valid=False, is_premium=False, message=f"Connection error: {e}"
+        )
+
+
+# =============================================================================
+# CRICAPI KEY VALIDATION
+# =============================================================================
+
+
+@router.post("/settings/cricapi/validate-key", response_model=CricAPIKeyValidationResponse)
+def validate_cricapi_key(request: CricAPIKeyValidationRequest):
+    """Validate a CricAPI key before saving.
+
+    Tests the key against the series search endpoint.
+    """
+    import httpx
+
+    key = request.api_key.strip()
+    if not key:
+        return CricAPIKeyValidationResponse(
+            valid=False, message="API key cannot be empty"
+        )
+
+    url = "https://api.cricapi.com/v1/series"
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(url, params={"apikey": key, "search": "IPL"})
+
+        if resp.status_code != 200:
+            return CricAPIKeyValidationResponse(
+                valid=False, message=f"API returned status {resp.status_code}"
+            )
+
+        data = resp.json()
+        if data.get("status") == "failure":
+            return CricAPIKeyValidationResponse(
+                valid=False, message=data.get("reason", "Invalid API key")
+            )
+
+        info = data.get("info", {})
+        hits_today = info.get("hitsToday", 0)
+        hits_limit = info.get("hitsLimit", 100)
+        series_count = len(data.get("data", []))
+
+        return CricAPIKeyValidationResponse(
+            valid=True,
+            message=(
+                f"Valid key — {hits_today}/{hits_limit} hits used today, "
+                f"{series_count} IPL series found"
+            ),
+            hits_today=hits_today,
+            hits_limit=hits_limit,
+        )
+
+    except httpx.TimeoutException:
+        return CricAPIKeyValidationResponse(
+            valid=False, message="Connection to CricAPI timed out"
+        )
+    except Exception as e:
+        return CricAPIKeyValidationResponse(
+            valid=False, message=f"Connection error: {e}"
         )

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -3,7 +3,7 @@
 All request/response models for settings endpoints.
 """
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_serializer, field_validator
 
@@ -63,6 +63,7 @@ class DispatcharrSettingsModel(BaseModel):
     @classmethod
     def _mask_password(cls, v: str | None) -> str | None:
         return MASKED_SECRET if v else None
+
     epg_id: int | None = None
     # None = all profiles, [] = no profiles, [1,2,...] = specific profiles
     # Supports int IDs and string wildcards like "{sport}", "{league}"
@@ -238,10 +239,17 @@ class DisplaySettingsModel(BaseModel):
     xmltv_generator_name: str = "Teamarr"
     xmltv_generator_url: str = "https://github.com/Pharaoh-Labs/teamarr"
     tsdb_api_key: str | None = None  # Optional TheSportsDB premium API key
+    cricapi_api_key: str | None = None  # Optional CricAPI key for cricket data
+    cricket_provider: Literal["cricapi", "tsdb"] = "cricapi"
 
     @field_serializer("tsdb_api_key")
     @classmethod
     def _mask_tsdb_key(cls, v: str | None) -> str | None:
+        return MASKED_SECRET if v else None
+
+    @field_serializer("cricapi_api_key")
+    @classmethod
+    def _mask_cricapi_key(cls, v: str | None) -> str | None:
         return MASKED_SECRET if v else None
 
 
@@ -257,6 +265,21 @@ class TSDBKeyValidationResponse(BaseModel):
     valid: bool
     is_premium: bool = False
     message: str
+
+
+class CricAPIKeyValidationRequest(BaseModel):
+    """Request to validate a CricAPI API key."""
+
+    api_key: str = Field(..., description="CricAPI API key to validate")
+
+
+class CricAPIKeyValidationResponse(BaseModel):
+    """Response from CricAPI API key validation."""
+
+    valid: bool
+    message: str
+    hits_today: int = 0
+    hits_limit: int = 100
 
 
 # =============================================================================

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -263,6 +263,13 @@ CREATE TABLE IF NOT EXISTS settings (
     -- Premium key ($9/mo) gives 100 req/min and higher limits
     tsdb_api_key TEXT,
 
+    -- CricAPI (CricketData.org) API key for cricket fixtures
+    -- Free tier: 100 requests/day
+    cricapi_api_key TEXT,
+
+    -- Cricket data provider: 'cricapi' (default, free) or 'tsdb' (premium)
+    cricket_provider TEXT DEFAULT 'cricapi',
+
     -- Channel ID Format
     channel_id_format TEXT DEFAULT '{team_name_pascal}.{league_id}',
 
@@ -1032,10 +1039,12 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     ('nll', 'espn', 'lacrosse/nll', NULL, 'National Lacrosse League', 'lacrosse', 'https://a.espncdn.com/guid/5f77fe12-e54f-41a1-904e-77135452f348/logos/default.png', NULL, 1, 'NLL', 'nll', 'team_vs_team', NULL, NULL, NULL, NULL),
     ('pll', 'espn', 'lacrosse/pll', NULL, 'Premier Lacrosse League', 'lacrosse', 'https://a.espncdn.com/combiner/i?img=/i/teamlogos/leagues/500/pll.png', NULL, 1, 'PLL', 'pll', 'team_vs_team', NULL, NULL, NULL, NULL),
 
-    -- Cricket (TSDB) - Premium tier, requires TSDB premium key for full event coverage
-    ('ipl', 'tsdb', '4460', 'Indian Premier League', 'Indian Premier League', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/gaiti11741709844.png', NULL, 1, 'IPL', 'ipl', 'team_vs_team', NULL, NULL, NULL, 'premium'),
-    ('bbl', 'tsdb', '4461', 'Australian Big Bash League', 'Big Bash League', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/yko7ny1546635346.png', NULL, 1, 'BBL', 'bbl', 'team_vs_team', NULL, NULL, NULL, 'premium'),
-    ('sa20', 'tsdb', '5532', 'SA20', 'South Africa Twenty20', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/aakvuk1734183412.png', NULL, 1, 'SA20', 'sa20', 'team_vs_team', NULL, NULL, NULL, 'premium'),
+    -- Cricket (CricAPI) - Free tier via CricketData.org
+    -- provider_league_id = series GUID (auto-updated on season rollover)
+    -- TSDB premium users: toggle cricket_provider to 'tsdb' in settings
+    ('ipl', 'cricapi', '87c62aac-bc3c-4738-ab93-19da0690488f', NULL, 'Indian Premier League', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/gaiti11741709844.png', NULL, 1, 'IPL', 'ipl', 'team_vs_team', NULL, NULL, NULL, NULL),
+    ('bbl', 'cricapi', '4e2f50ed-ed84-46fc-bdcb-ace304b0da34', NULL, 'Big Bash League', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/yko7ny1546635346.png', NULL, 1, 'BBL', 'bbl', 'team_vs_team', NULL, NULL, NULL, NULL),
+    ('sa20', 'cricapi', 'f530b0f7-25c0-422e-bf8b-1f2c1e6c68f6', NULL, 'SA20', 'cricket', 'https://r2.thesportsdb.com/images/media/league/badge/aakvuk1734183412.png', NULL, 1, 'SA20', 'sa20', 'team_vs_team', NULL, NULL, NULL, NULL),
 
     -- Rugby (ESPN)
     ('rwc',   'espn', 'rugby/164205',    NULL, 'Rugby World Cup',                 'rugby', 'https://upload.wikimedia.org/wikipedia/commons/a/a3/Rugby_World_Cup_Logo%2C_used_post_RWC_2023.svg', NULL, 1, 'RWC',   'rwc',   'team_vs_team', NULL, NULL, NULL, NULL),

--- a/teamarr/database/settings/read.py
+++ b/teamarr/database/settings/read.py
@@ -46,6 +46,12 @@ def _build_display_settings(row) -> DisplaySettings:
         xmltv_generator_name=row["xmltv_generator_name"] or d.xmltv_generator_name,
         xmltv_generator_url=row["xmltv_generator_url"] or d.xmltv_generator_url,
         tsdb_api_key=row["tsdb_api_key"],
+        cricapi_api_key=row["cricapi_api_key"],
+        cricket_provider=(
+            row["cricket_provider"]
+            if "cricket_provider" in row.keys() and row["cricket_provider"]
+            else "cricapi"
+        ),
     )
 
 
@@ -419,7 +425,8 @@ def get_display_settings(conn: Connection) -> DisplaySettings:
     cursor = conn.cursor()
     cursor.execute(
         """SELECT time_format, show_timezone, channel_id_format,
-                  xmltv_generator_name, xmltv_generator_url, tsdb_api_key
+                  xmltv_generator_name, xmltv_generator_url, tsdb_api_key,
+                  cricapi_api_key, cricket_provider
            FROM settings WHERE id = 1"""
     )
     row = cursor.fetchone()

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -126,6 +126,8 @@ class DisplaySettings:
     xmltv_generator_name: str = "Teamarr"
     xmltv_generator_url: str = "https://github.com/Pharaoh-Labs/teamarr"
     tsdb_api_key: str | None = None
+    cricapi_api_key: str | None = None
+    cricket_provider: str = "cricapi"
 
 
 @dataclass

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -364,6 +364,8 @@ def update_display_settings(conn: Connection, **kwargs) -> bool:
         "xmltv_generator_name": "xmltv_generator_name",
         "xmltv_generator_url": "xmltv_generator_url",
         "tsdb_api_key": "tsdb_api_key",
+        "cricapi_api_key": "cricapi_api_key",
+        "cricket_provider": "cricket_provider",
     }
 
     updates = []
@@ -513,7 +515,8 @@ def update_channel_numbering_settings(
     if global_consolidation_mode is not None:
         if global_consolidation_mode not in ("consolidate", "separate"):
             logger.warning(
-                "[CHANNEL_NUM] Invalid global_consolidation_mode '%s'", global_consolidation_mode,
+                "[CHANNEL_NUM] Invalid global_consolidation_mode '%s'",
+                global_consolidation_mode,
             )
             return False
         updates.append("global_consolidation_mode = ?")
@@ -943,5 +946,3 @@ def update_backup_settings(
         logger.info("[BACKUP] Updated settings: %s", [u.split(" = ")[0] for u in updates])
         return True
     return False
-
-

--- a/teamarr/providers/__init__.py
+++ b/teamarr/providers/__init__.py
@@ -15,6 +15,7 @@ ProviderRegistry.initialize() must be called during app startup
 to inject the LeagueMappingSource into providers.
 """
 
+from teamarr.providers.cricapi import CricAPIClient, CricAPIProvider
 from teamarr.providers.espn import ESPNClient, ESPNProvider
 from teamarr.providers.hockeytech import HockeyTechClient, HockeyTechProvider
 from teamarr.providers.mlbstats import MLBStatsClient, MLBStatsProvider
@@ -79,6 +80,55 @@ def _create_tsdb_provider() -> TSDBProvider:
         league_mapping_source=ProviderRegistry.get_league_mapping_source(),
         api_key=_get_tsdb_api_key(),
         team_name_resolver=_create_tsdb_team_name_resolver(),
+    )
+
+
+def _get_cricapi_api_key() -> str | None:
+    """Fetch CricAPI API key from database settings.
+
+    This is the boundary where database access happens before
+    passing to the provider layer (which should not access database).
+    """
+    try:
+        from teamarr.database import get_db
+
+        with get_db() as conn:
+            cursor = conn.execute("SELECT cricapi_api_key FROM settings WHERE id = 1")
+            row = cursor.fetchone()
+            if row and row["cricapi_api_key"]:
+                return row["cricapi_api_key"]
+    except Exception:
+        # Database not available or column doesn't exist yet - expected during startup
+        pass
+    return None
+
+
+def _create_cricapi_series_id_updater() -> callable:
+    """Create a series ID updater callback for CricAPI provider.
+
+    This callback accesses the database, keeping DB access at the factory
+    boundary rather than inside the provider layer.
+    """
+    from teamarr.database import get_db
+
+    def updater(league_code: str, new_series_id: str) -> None:
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE leagues SET provider_league_id = ? "
+                "WHERE league_code = ? AND provider = 'cricapi'",
+                (new_series_id, league_code),
+            )
+            conn.commit()
+
+    return updater
+
+
+def _create_cricapi_provider() -> CricAPIProvider:
+    """Factory for CricAPI provider with injected dependencies."""
+    return CricAPIProvider(
+        league_mapping_source=ProviderRegistry.get_league_mapping_source(),
+        api_key=_get_cricapi_api_key(),
+        series_id_updater=_create_cricapi_series_id_updater(),
     )
 
 
@@ -157,6 +207,14 @@ ProviderRegistry.register(
 )
 
 ProviderRegistry.register(
+    name="cricapi",
+    provider_class=CricAPIProvider,
+    factory=_create_cricapi_provider,
+    priority=45,  # Cricket leagues (IPL, BBL, SA20)
+    enabled=True,
+)
+
+ProviderRegistry.register(
     name="tsdb",
     provider_class=TSDBProvider,
     factory=_create_tsdb_provider,
@@ -173,6 +231,9 @@ __all__ = [
     # Registry
     "ProviderConfig",
     "ProviderRegistry",
+    # CricAPI
+    "CricAPIClient",
+    "CricAPIProvider",
     # ESPN
     "ESPNClient",
     "ESPNProvider",

--- a/teamarr/providers/cricapi/__init__.py
+++ b/teamarr/providers/cricapi/__init__.py
@@ -1,0 +1,6 @@
+"""CricAPI data provider package."""
+
+from teamarr.providers.cricapi.client import CricAPIClient
+from teamarr.providers.cricapi.provider import CricAPIProvider
+
+__all__ = ["CricAPIClient", "CricAPIProvider"]

--- a/teamarr/providers/cricapi/client.py
+++ b/teamarr/providers/cricapi/client.py
@@ -166,11 +166,11 @@ class CricAPIClient:
 
                 # Check for API-level errors
                 status = result.get("status", "")
-                if status == "error":
+                if status != "success":
                     logger.warning(
                         "[CRAPI] API error for %s: %s",
                         endpoint,
-                        result.get("msg", "unknown"),
+                        result.get("reason", result.get("msg", "unknown")),
                     )
                     return None
 
@@ -182,7 +182,7 @@ class CricAPIClient:
                     e.response.status_code,
                     url,
                 )
-                if attempt < self._retry_count - 1:
+                if attempt < self._retry_count - 1 and e.response.status_code >= 500:
                     time.sleep(self._retry_delay * (attempt + 1))
                     continue
                 return None

--- a/teamarr/providers/cricapi/client.py
+++ b/teamarr/providers/cricapi/client.py
@@ -1,0 +1,356 @@
+"""CricAPI HTTP client.
+
+Handles raw HTTP requests to CricketData.org (CricAPI) endpoints
+with caching and retry logic. No data transformation -- just fetch
+and return JSON.
+
+Rate limits:
+- Free tier: 100 requests/day (tracked via hitsToday/hitsLimit)
+
+Caching is aggressive to stay within daily rate limits:
+- series_info: 8 hours (all matches for a series)
+- series search: 24 hours (series lookup by name)
+- match_info: 30 minutes (individual match details)
+- currentMatches: 5 minutes (live/active matches)
+
+Dependencies are injected via constructor:
+- LeagueMappingSource: For league configuration lookup
+- api_key: From database settings (passed by factory in providers/__init__.py)
+
+This client has NO direct database access -- all config is injected.
+"""
+
+import logging
+import threading
+import time
+
+import httpx
+
+from teamarr.core import LeagueMappingSource
+from teamarr.utilities.cache import TTLCache, make_cache_key
+
+logger = logging.getLogger(__name__)
+
+CRICAPI_BASE_URL = "https://api.cricapi.com/v1"
+
+# Cache TTLs (seconds)
+CRICAPI_CACHE_TTL_SERIES_INFO = 8 * 60 * 60  # 8 hours
+CRICAPI_CACHE_TTL_SERIES_SEARCH = 24 * 60 * 60  # 24 hours
+CRICAPI_CACHE_TTL_MATCH_INFO = 30 * 60  # 30 minutes
+CRICAPI_CACHE_TTL_CURRENT_MATCHES = 5 * 60  # 5 minutes
+
+
+class CricAPIClient:
+    """Low-level CricAPI HTTP client with caching and retry logic.
+
+    API key resolution:
+    1. Explicit api_key parameter (from database via factory)
+    2. No fallback -- must be configured via Settings UI
+
+    Free tier: 100 requests/day. Caching is aggressive to conserve quota.
+    Rate limit tracking via hitsToday/hitsLimit from API responses.
+
+    League mappings provided via LeagueMappingSource (no direct database access).
+    """
+
+    def __init__(
+        self,
+        league_mapping_source: LeagueMappingSource | None = None,
+        api_key: str | None = None,
+        timeout: float = 10.0,
+        retry_count: int = 3,
+        retry_delay: float = 1.0,
+    ):
+        self._league_mapping_source = league_mapping_source
+        self._api_key = api_key
+        self._timeout = timeout
+        self._retry_count = retry_count
+        self._retry_delay = retry_delay
+        self._client: httpx.Client | None = None
+        self._client_lock = threading.Lock()
+        self._cache = TTLCache()
+
+        # Rate limit tracking from API responses
+        self._hits_today: int = 0
+        self._hits_limit: int = 100
+        self._hits_lock = threading.Lock()
+
+    @property
+    def api_key(self) -> str | None:
+        """Return configured API key."""
+        return self._api_key
+
+    @property
+    def hits_today(self) -> int:
+        """Return current daily API hit count."""
+        with self._hits_lock:
+            return self._hits_today
+
+    @property
+    def hits_limit(self) -> int:
+        """Return daily API hit limit."""
+        with self._hits_lock:
+            return self._hits_limit
+
+    @property
+    def hits_remaining(self) -> int:
+        """Return remaining daily API hits."""
+        with self._hits_lock:
+            return max(0, self._hits_limit - self._hits_today)
+
+    def _get_client(self) -> httpx.Client:
+        """Get or create the HTTP client (thread-safe, lazy init)."""
+        if self._client is None:
+            with self._client_lock:
+                # Double-check after acquiring lock
+                if self._client is None:
+                    self._client = httpx.Client(
+                        timeout=self._timeout,
+                        limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
+                    )
+        return self._client
+
+    def _update_rate_limit_info(self, response_data: dict | None) -> None:
+        """Extract and store rate limit info from API response.
+
+        CricAPI returns rate limit info in the 'info' field:
+        {"hitsToday": 7, "hitsLimit": 100, "totalRows": 74, "queryTime": 10}
+        """
+        if not response_data:
+            return
+
+        info = response_data.get("info")
+        if not info:
+            return
+
+        with self._hits_lock:
+            if "hitsToday" in info:
+                self._hits_today = int(info["hitsToday"])
+            if "hitsLimit" in info:
+                self._hits_limit = int(info["hitsLimit"])
+
+    def _request(self, endpoint: str, params: dict | None = None) -> dict | None:
+        """Make HTTP request with retry logic.
+
+        Retries up to retry_count times on transient errors (5xx, network).
+        Updates rate limit tracking from every response.
+
+        Args:
+            endpoint: API endpoint path (e.g., 'series_info')
+            params: Query parameters (apikey added automatically)
+
+        Returns:
+            Parsed JSON response or None on failure
+        """
+        if not self._api_key:
+            logger.warning("[CRAPI] No API key configured, skipping request to %s", endpoint)
+            return None
+
+        url = f"{CRICAPI_BASE_URL}/{endpoint}"
+
+        # Build params with apikey
+        request_params = dict(params) if params else {}
+        request_params["apikey"] = self._api_key
+
+        for attempt in range(self._retry_count):
+            try:
+                client = self._get_client()
+                response = client.get(url, params=request_params)
+
+                response.raise_for_status()
+
+                result = response.json()
+
+                # Track rate limit info from response
+                self._update_rate_limit_info(result)
+
+                # Check for API-level errors
+                status = result.get("status", "")
+                if status == "error":
+                    logger.warning(
+                        "[CRAPI] API error for %s: %s",
+                        endpoint,
+                        result.get("msg", "unknown"),
+                    )
+                    return None
+
+                return result
+
+            except httpx.HTTPStatusError as e:
+                logger.warning(
+                    "[CRAPI] HTTP %d for %s",
+                    e.response.status_code,
+                    url,
+                )
+                if attempt < self._retry_count - 1:
+                    time.sleep(self._retry_delay * (attempt + 1))
+                    continue
+                return None
+
+            except (httpx.RequestError, RuntimeError, OSError) as e:
+                logger.warning("[CRAPI] Request failed for %s: %s", url, e)
+                if attempt < self._retry_count - 1:
+                    time.sleep(self._retry_delay * (attempt + 1))
+                    continue
+                return None
+
+        return None
+
+    def supports_league(self, league: str) -> bool:
+        """Check if we have mapping for this league."""
+        if not self._league_mapping_source:
+            return False
+        return self._league_mapping_source.supports_league(league, "cricapi")
+
+    def get_provider_league_id(self, league: str) -> str | None:
+        """Get CricAPI series GUID for a league code.
+
+        This is the provider_league_id from league mappings (the series GUID).
+        """
+        if not self._league_mapping_source:
+            return None
+        mapping = self._league_mapping_source.get_mapping(league, "cricapi")
+        return mapping.provider_league_id if mapping else None
+
+    def get_sport(self, league: str) -> str:
+        """Get canonical sport code for a league (lowercase)."""
+        if not self._league_mapping_source:
+            return "cricket"
+        mapping = self._league_mapping_source.get_mapping(league, "cricapi")
+        if mapping and mapping.sport:
+            return mapping.sport
+        return "cricket"
+
+    def get_series_info(self, series_id: str) -> dict | None:
+        """Fetch all matches for a series.
+
+        Uses series_info endpoint with the series GUID.
+
+        Args:
+            series_id: CricAPI series GUID
+
+        Returns:
+            Raw API response with info and matchList, or None
+        """
+        cache_key = make_cache_key("cricapi", "series_info", series_id)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[CRAPI] Cache hit: %s", cache_key)
+            return cached
+
+        result = self._request("series_info", {"id": series_id})
+        if result:
+            self._cache.set(cache_key, result, CRICAPI_CACHE_TTL_SERIES_INFO)
+            logger.debug(
+                "[CRAPI] Cached series_info for %s (%dh TTL)",
+                series_id,
+                CRICAPI_CACHE_TTL_SERIES_INFO // 3600,
+            )
+        return result
+
+    def search_series(self, name: str) -> dict | None:
+        """Search for series by name.
+
+        Args:
+            name: Search term (e.g., "Indian Premier League")
+
+        Returns:
+            Raw API response with list of matching series, or None
+        """
+        cache_key = make_cache_key("cricapi", "series_search", name.lower())
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[CRAPI] Cache hit: %s", cache_key)
+            return cached
+
+        result = self._request("series", {"search": name})
+        if result:
+            self._cache.set(cache_key, result, CRICAPI_CACHE_TTL_SERIES_SEARCH)
+            logger.debug(
+                "[CRAPI] Cached series search for %s (%dh TTL)",
+                name,
+                CRICAPI_CACHE_TTL_SERIES_SEARCH // 3600,
+            )
+        return result
+
+    def get_match_info(self, match_id: str) -> dict | None:
+        """Fetch single match details with scores.
+
+        Args:
+            match_id: CricAPI match GUID
+
+        Returns:
+            Raw API response with match data, or None
+        """
+        cache_key = make_cache_key("cricapi", "match_info", match_id)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[CRAPI] Cache hit: %s", cache_key)
+            return cached
+
+        result = self._request("match_info", {"id": match_id})
+        if result:
+            self._cache.set(cache_key, result, CRICAPI_CACHE_TTL_MATCH_INFO)
+            logger.debug(
+                "[CRAPI] Cached match_info for %s (%dm TTL)",
+                match_id,
+                CRICAPI_CACHE_TTL_MATCH_INFO // 60,
+            )
+        return result
+
+    def get_current_matches(self, offset: int = 0) -> dict | None:
+        """Fetch currently active matches.
+
+        Args:
+            offset: Pagination offset
+
+        Returns:
+            Raw API response with current match list, or None
+        """
+        cache_key = make_cache_key("cricapi", "current_matches", str(offset))
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug("[CRAPI] Cache hit: %s", cache_key)
+            return cached
+
+        result = self._request("currentMatches", {"offset": str(offset)})
+        if result:
+            self._cache.set(cache_key, result, CRICAPI_CACHE_TTL_CURRENT_MATCHES)
+            logger.debug(
+                "[CRAPI] Cached currentMatches (%dm TTL)",
+                CRICAPI_CACHE_TTL_CURRENT_MATCHES // 60,
+            )
+        return result
+
+    def cache_stats(self) -> dict:
+        """Get cache statistics."""
+        return self._cache.stats()
+
+    def clear_cache(self) -> None:
+        """Clear all cached data."""
+        self._cache.clear()
+
+    def rate_limit_stats(self) -> dict:
+        """Get rate limit statistics for UI feedback.
+
+        Returns dict with:
+        - hits_today: Current daily API hit count
+        - hits_limit: Daily API hit limit
+        - hits_remaining: Remaining daily hits
+        """
+        with self._hits_lock:
+            return {
+                "hits_today": self._hits_today,
+                "hits_limit": self._hits_limit,
+                "hits_remaining": max(0, self._hits_limit - self._hits_today),
+            }
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        with self._client_lock:
+            if self._client:
+                try:
+                    self._client.close()
+                except Exception as e:
+                    logger.debug("[CRAPI] Error closing HTTP client: %s", e)
+                self._client = None

--- a/teamarr/providers/cricapi/provider.py
+++ b/teamarr/providers/cricapi/provider.py
@@ -99,7 +99,7 @@ class CricAPIProvider(SportsProvider):
             return []
 
         match_list = series_data.get("matchList", [])
-        today = date.today()
+        today = datetime.now(UTC).date()
         cutoff = today + timedelta(days=days_ahead)
 
         events = []

--- a/teamarr/providers/cricapi/provider.py
+++ b/teamarr/providers/cricapi/provider.py
@@ -1,0 +1,601 @@
+"""CricAPI sports data provider.
+
+Fetches cricket fixture data from CricketData.org (CricAPI) and normalizes
+it into teamarr's internal types. Used for cricket leagues (IPL, BBL, SA20, etc.).
+"""
+
+import logging
+import re
+from collections.abc import Callable
+from datetime import UTC, date, datetime, timedelta
+
+from teamarr.core import (
+    Event,
+    EventStatus,
+    LeagueMappingSource,
+    SportsProvider,
+    Team,
+    Venue,
+)
+from teamarr.providers.cricapi.client import CricAPIClient
+
+logger = logging.getLogger(__name__)
+
+# Type alias for series ID updater callback
+# Takes (league_code, new_series_id) -> None
+SeriesIdUpdater = Callable[[str, str], None]
+
+# Mapping of league codes to CricAPI search terms for auto-detection
+LEAGUE_SEARCH_TERMS: dict[str, str] = {
+    "ipl": "Indian Premier League",
+    "bbl": "Big Bash League",
+    "sa20": "SA20",
+}
+
+
+class CricAPIProvider(SportsProvider):
+    """CricAPI implementation of SportsProvider.
+
+    Handles cricket leagues (IPL, BBL, SA20, etc.) using CricketData.org API.
+    """
+
+    def __init__(
+        self,
+        league_mapping_source: LeagueMappingSource | None = None,
+        client: CricAPIClient | None = None,
+        api_key: str | None = None,
+        series_id_updater: SeriesIdUpdater | None = None,
+    ):
+        self._league_mapping_source = league_mapping_source
+        self._client = client or CricAPIClient(
+            league_mapping_source=league_mapping_source,
+            api_key=api_key,
+        )
+        self._series_id_updater = series_id_updater
+
+    @property
+    def name(self) -> str:
+        return "cricapi"
+
+    def supports_league(self, league: str) -> bool:
+        return self._client.supports_league(league)
+
+    def get_events(self, league: str, target_date: date) -> list[Event]:
+        """Get all events for a league on a specific date.
+
+        Fetches series_info (all matches for the series) and filters by date.
+        """
+        series_data = self._get_series_matches(league)
+        if not series_data:
+            return []
+
+        date_str = target_date.strftime("%Y-%m-%d")
+        match_list = series_data.get("matchList", [])
+
+        events = []
+        for match in match_list:
+            match_date = match.get("date", "")
+            if match_date != date_str:
+                continue
+            event = self._parse_match(match, league)
+            if event:
+                events.append(event)
+
+        return events
+
+    def get_team_schedule(
+        self,
+        team_id: str,
+        league: str,
+        days_ahead: int = 14,
+    ) -> list[Event]:
+        """Get upcoming schedule for a specific team.
+
+        Fetches series_info and filters by team name.
+        Team IDs in CricAPI are derived from team names.
+        """
+        series_data = self._get_series_matches(league)
+        if not series_data:
+            return []
+
+        match_list = series_data.get("matchList", [])
+        today = date.today()
+        cutoff = today + timedelta(days=days_ahead)
+
+        events = []
+        seen_ids: set[str] = set()
+
+        for match in match_list:
+            # Check team name match
+            teams = match.get("teams", [])
+            if not self._team_in_match(team_id, teams, match):
+                continue
+
+            # Filter by date range
+            match_date_str = match.get("date", "")
+            if not match_date_str:
+                continue
+            try:
+                match_date = date.fromisoformat(match_date_str)
+            except ValueError:
+                continue
+
+            if match_date < today or match_date > cutoff:
+                continue
+
+            event = self._parse_match(match, league)
+            if event and event.id not in seen_ids:
+                seen_ids.add(event.id)
+                events.append(event)
+
+        events.sort(key=lambda e: e.start_time)
+        return events
+
+    def get_team(self, team_id: str, league: str) -> Team | None:
+        """Get team details.
+
+        Extracts team info from series_info teamInfo array.
+        Team ID is derived from team name.
+        """
+        series_data = self._get_series_matches(league)
+        if not series_data:
+            return None
+
+        match_list = series_data.get("matchList", [])
+
+        for match in match_list:
+            team_info_list = match.get("teamInfo", [])
+            for team_info in team_info_list:
+                team_name = team_info.get("name", "")
+                if self._team_ids_match(team_id, team_name):
+                    return self._parse_team_info(team_info, league)
+
+        return None
+
+    def get_event(self, event_id: str, league: str) -> Event | None:
+        """Get a specific event by ID.
+
+        Fetches match_info for the event ID.
+        """
+        data = self._client.get_match_info(event_id)
+        if not data:
+            return None
+
+        match_data = data.get("data")
+        if not match_data:
+            return None
+
+        return self._parse_match(match_data, league)
+
+    def get_league_teams(self, league: str) -> list[Team]:
+        """Get all teams in a league.
+
+        Extracts unique teams from series_info matchList.
+        """
+        series_data = self._get_series_matches(league)
+        if not series_data:
+            return []
+
+        match_list = series_data.get("matchList", [])
+        seen_teams: dict[str, dict] = {}  # name -> teamInfo dict
+
+        for match in match_list:
+            for team_info in match.get("teamInfo", []):
+                name = team_info.get("name", "")
+                if name and name not in seen_teams:
+                    seen_teams[name] = team_info
+
+        return [self._parse_team_info(info, league) for info in seen_teams.values()]
+
+    def get_supported_leagues(self) -> list[str]:
+        """Get all leagues this provider supports."""
+        if not self._league_mapping_source:
+            return []
+        mappings = self._league_mapping_source.get_leagues_for_provider("cricapi")
+        return [m.league_code for m in mappings]
+
+    # =========================================================================
+    # Series ID resolution
+    # =========================================================================
+
+    def _get_series_matches(self, league: str) -> dict | None:
+        """Fetch all matches for a league's series.
+
+        Attempts to resolve the series ID:
+        1. Use provider_league_id if set and returns valid data
+        2. Auto-detect via series search if the stored ID is invalid or stale
+
+        A valid series with an empty matchList (off-season / rest day) is
+        returned as-is rather than triggering a re-detect, to conserve API quota.
+        """
+        series_id = self._client.get_provider_league_id(league)
+
+        if series_id:
+            data = self._client.get_series_info(series_id)
+            if data and data.get("status") == "success":
+                return data.get("data")
+
+            # Series ID returned an error or failure status — try auto-detect
+            logger.info(
+                "[CRAPI] Series ID %s returned invalid data for %s, auto-detecting",
+                series_id,
+                league,
+            )
+
+        return self._resolve_series_id(league)
+
+    def _resolve_series_id(self, league: str) -> dict | None:
+        """Auto-detect current series ID by searching.
+
+        Searches for the series by name, picks the one with the latest
+        startDate that has matches > 0. Persists new ID via callback.
+        """
+        search_term = LEAGUE_SEARCH_TERMS.get(league)
+        if not search_term:
+            # Try using the display name from league mapping
+            if self._league_mapping_source:
+                mapping = self._league_mapping_source.get_mapping(league, "cricapi")
+                if mapping and mapping.display_name:
+                    search_term = mapping.display_name
+            if not search_term:
+                logger.warning("[CRAPI] No search term mapping for league %s", league)
+                return None
+
+        search_result = self._client.search_series(search_term)
+        if not search_result:
+            logger.warning("[CRAPI] Series search returned no results for %s", search_term)
+            return None
+
+        series_list = search_result.get("data", [])
+        if not series_list:
+            logger.warning("[CRAPI] No series found for search term %s", search_term)
+            return None
+
+        # Pick series with latest startDate that has matches > 0
+        best_series = None
+        best_start = ""
+
+        for series in series_list:
+            matches_count = series.get("matches", 0)
+            if not matches_count or int(matches_count) <= 0:
+                continue
+
+            start_date = series.get("startDate", "")
+            if start_date and start_date > best_start:
+                best_start = start_date
+                best_series = series
+
+        if not best_series:
+            logger.warning("[CRAPI] No series with matches found for %s", search_term)
+            return None
+
+        series_id = best_series.get("id", "")
+        series_name = best_series.get("name", "unknown")
+        logger.info(
+            "[CRAPI] Auto-detected series %s (%s) for league %s",
+            series_id,
+            series_name,
+            league,
+        )
+
+        # Persist new series ID via callback
+        if self._series_id_updater and series_id:
+            try:
+                self._series_id_updater(league, series_id)
+                logger.info(
+                    "[CRAPI] Updated series ID for %s to %s",
+                    league,
+                    series_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[CRAPI] Failed to update series ID for %s: %s",
+                    league,
+                    e,
+                )
+
+        # Fetch the full series info with the detected ID
+        data = self._client.get_series_info(series_id)
+        if data and data.get("status") == "success":
+            return data.get("data")
+
+        return None
+
+    # =========================================================================
+    # Parsing helpers
+    # =========================================================================
+
+    def _parse_match(self, match_data: dict, league: str) -> Event | None:
+        """Parse a CricAPI match dict into an Event dataclass."""
+        try:
+            match_id = match_data.get("id")
+            if not match_id:
+                return None
+
+            # Parse start time
+            start_time = self._parse_datetime(
+                match_data.get("dateTimeGMT"),
+                match_data.get("date"),
+            )
+            if not start_time:
+                return None
+
+            sport = self._client.get_sport(league)
+
+            # Build teams
+            teams = match_data.get("teams", [])
+            team_info_list = match_data.get("teamInfo", [])
+
+            home_team = self._build_team(
+                teams[0] if len(teams) > 0 else "",
+                team_info_list,
+                0,
+                league,
+                sport,
+                match_id,
+            )
+            away_team = self._build_team(
+                teams[1] if len(teams) > 1 else "",
+                team_info_list,
+                1,
+                league,
+                sport,
+                match_id,
+            )
+
+            # Parse status
+            status = self._parse_status(match_data)
+
+            # Parse venue
+            venue = self._parse_venue(match_data.get("venue", ""))
+
+            # Build names
+            event_name = match_data.get("name", "")
+            if not event_name and home_team.name and away_team.name:
+                event_name = f"{home_team.name} vs {away_team.name}"
+
+            short_name = ""
+            if home_team.abbreviation and away_team.abbreviation:
+                short_name = f"{away_team.abbreviation} vs {home_team.abbreviation}"
+            elif home_team.short_name and away_team.short_name:
+                short_name = f"{away_team.short_name} vs {home_team.short_name}"
+            else:
+                short_name = event_name
+
+            return Event(
+                id=str(match_id),
+                provider=self.name,
+                name=event_name,
+                short_name=short_name,
+                start_time=start_time,
+                home_team=home_team,
+                away_team=away_team,
+                status=status,
+                league=league,
+                sport=sport,
+                venue=venue,
+            )
+
+        except Exception as e:
+            logger.warning(
+                "[CRAPI] Failed to parse match %s: %s",
+                match_data.get("id", "unknown"),
+                e,
+            )
+            return None
+
+    def _build_team(
+        self,
+        team_name: str,
+        team_info_list: list[dict],
+        index: int,
+        league: str,
+        sport: str,
+        match_id: str,
+    ) -> Team:
+        """Build a Team dataclass from match data.
+
+        Uses teamInfo if available for richer data (shortname, img).
+        Falls back to teams array for basic name.
+        """
+        # Try to get teamInfo for this index
+        team_info = None
+        if index < len(team_info_list):
+            info = team_info_list[index]
+            info_name = info.get("name", "")
+            if info_name == team_name:
+                team_info = info
+
+        # If no matching teamInfo by index, try by name
+        if not team_info and team_name:
+            for info in team_info_list:
+                if info.get("name") == team_name:
+                    team_info = info
+                    break
+
+        if team_info:
+            return self._parse_team_info(team_info, league, sport)
+
+        # Fallback: build from team name only
+        team_id = self._make_team_id(team_name)
+        abbrev = self._make_abbrev(team_name)
+
+        return Team(
+            id=team_id,
+            provider=self.name,
+            name=team_name,
+            short_name=team_name,
+            abbreviation=abbrev,
+            league=league,
+            sport=sport,
+        )
+
+    def _parse_team_info(
+        self,
+        team_info: dict,
+        league: str,
+        sport: str | None = None,
+    ) -> Team:
+        """Parse a teamInfo dict into a Team dataclass."""
+        name = team_info.get("name", "")
+        short_name = team_info.get("shortname", "") or name
+        abbrev = team_info.get("shortname", "") or self._make_abbrev(name)
+        logo_url = team_info.get("img")
+        team_id = self._make_team_id(name)
+
+        return Team(
+            id=team_id,
+            provider=self.name,
+            name=name,
+            short_name=short_name,
+            abbreviation=abbrev,
+            league=league,
+            sport=sport or self._client.get_sport(league),
+            logo_url=logo_url,
+        )
+
+    def _parse_status(self, match_data: dict) -> EventStatus:
+        """Parse CricAPI match status into EventStatus.
+
+        Status mapping:
+        - Contains "not started" or "Match starts at" -> "scheduled"
+        - Contains "won by" or "Match ended" -> "final"
+        - Contains "Postponed" -> "postponed"
+        - Contains "Cancelled" -> "cancelled"
+        - Otherwise if matchStarted=True and matchEnded=False -> "live"
+        """
+        status_str = match_data.get("status", "")
+        status_lower = status_str.lower() if status_str else ""
+
+        if "not started" in status_lower or "match starts at" in status_lower:
+            return EventStatus(state="scheduled", detail=status_str or None)
+
+        if "won by" in status_lower or "match ended" in status_lower:
+            return EventStatus(state="final", detail=status_str or None)
+
+        if "postponed" in status_lower:
+            return EventStatus(state="postponed", detail=status_str or None)
+
+        if "cancelled" in status_lower:
+            return EventStatus(state="cancelled", detail=status_str or None)
+
+        # Check live status from boolean flags
+        match_started = match_data.get("matchStarted", False)
+        match_ended = match_data.get("matchEnded", False)
+
+        if match_started and not match_ended:
+            return EventStatus(state="live", detail=status_str or None)
+
+        # Default to scheduled
+        return EventStatus(state="scheduled", detail=status_str or None)
+
+    def _parse_venue(self, venue_str: str) -> Venue | None:
+        """Parse venue string from CricAPI.
+
+        Venue format: "Stadium Name, City" or just "Stadium Name"
+        """
+        if not venue_str:
+            return None
+
+        # Try to split on last comma for city
+        parts = venue_str.rsplit(",", 1)
+        if len(parts) == 2:
+            return Venue(
+                name=parts[0].strip(),
+                city=parts[1].strip(),
+            )
+
+        return Venue(name=venue_str.strip())
+
+    def _parse_datetime(
+        self,
+        datetime_gmt: str | None,
+        date_str: str | None,
+    ) -> datetime | None:
+        """Parse CricAPI datetime into UTC datetime.
+
+        Prefers dateTimeGMT (ISO with explicit GMT).
+        Falls back to date-only string (assumes midnight UTC).
+        """
+        if datetime_gmt:
+            try:
+                # CricAPI format: "2026-03-26T14:00:00" (already GMT/UTC)
+                dt = datetime.fromisoformat(datetime_gmt)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                return dt
+            except ValueError:
+                pass
+
+        if date_str:
+            try:
+                dt = datetime.fromisoformat(date_str)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                return dt
+            except ValueError:
+                pass
+
+        return None
+
+    def _make_team_id(self, team_name: str) -> str:
+        """Derive a stable team ID from team name.
+
+        CricAPI doesn't provide stable numeric IDs for teams,
+        so we use a slug derived from the name.
+        """
+        if not team_name:
+            return ""
+
+        # Lowercase, replace non-alphanumeric with underscore, collapse multiples
+        slug = re.sub(r"[^a-z0-9]+", "_", team_name.lower()).strip("_")
+        return f"cricapi_{slug}"
+
+    def _make_abbrev(self, team_name: str) -> str:
+        """Generate abbreviation from team name.
+
+        Takes first letters of significant words, up to 4 characters.
+        """
+        if not team_name:
+            return ""
+
+        words = team_name.split()
+        # Filter out common filler words
+        skip = {"the", "of", "and", "fc", "sc", "club"}
+        abbrev = "".join(w[0].upper() for w in words if w.lower() not in skip)
+
+        # Cap at 4 characters
+        return abbrev[:4] if abbrev else team_name[:3].upper()
+
+    def _team_in_match(
+        self,
+        team_id: str,
+        teams_list: list[str],
+        match_data: dict,
+    ) -> bool:
+        """Check if a team (by ID or name) is in a match.
+
+        Team IDs are derived from names, so we check both the ID match
+        and the raw team name in the teams array.
+        """
+        # Check by derived ID against team names in the match
+        for team_name in teams_list:
+            if self._team_ids_match(team_id, team_name):
+                return True
+
+        return False
+
+    def _team_ids_match(self, team_id: str, team_name: str) -> bool:
+        """Check if a team ID matches a team name.
+
+        Since IDs are derived from names, we check both directions.
+        """
+        derived_id = self._make_team_id(team_name)
+        if team_id == derived_id:
+            return True
+
+        # Also check if the team_name appears in the ID
+        if team_name.lower() in team_id.lower():
+            return True
+
+        return False

--- a/tests/test_cricapi_provider.py
+++ b/tests/test_cricapi_provider.py
@@ -1,0 +1,1021 @@
+"""Tests for CricAPI provider and client.
+
+Verifies data normalization from CricAPI JSON responses to teamarr types,
+status mapping, team ID derivation, series ID auto-detection, and caching.
+"""
+
+from datetime import UTC, date, datetime
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teamarr.core import LeagueMapping
+from teamarr.providers.cricapi.client import CricAPIClient
+from teamarr.providers.cricapi.provider import CricAPIProvider
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _make_mapping(
+    league_code: str = "ipl",
+    provider_league_id: str = "test-series-guid-123",
+    sport: str = "cricket",
+    display_name: str = "Indian Premier League",
+) -> LeagueMapping:
+    return LeagueMapping(
+        league_code=league_code,
+        provider="cricapi",
+        provider_league_id=provider_league_id,
+        provider_league_name=None,
+        sport=sport,
+        display_name=display_name,
+    )
+
+
+def _make_mock_source(mapping: LeagueMapping | None = None):
+    """Create a mock LeagueMappingSource."""
+    source = MagicMock()
+    if mapping is None:
+        mapping = _make_mapping()
+
+    source.get_mapping.return_value = mapping
+    source.supports_league.return_value = mapping is not None
+    source.get_leagues_for_provider.return_value = [mapping] if mapping else []
+    return source
+
+
+SAMPLE_SERIES_INFO_RESPONSE = {
+    "status": "success",
+    "data": {
+        "info": {
+            "id": "series-guid-abc",
+            "name": "Indian Premier League 2026",
+            "t20": 70,
+            "matches": 74,
+        },
+        "matchList": [
+            {
+                "id": "match-guid-1",
+                "name": "Chennai Super Kings vs Kolkata Knight Riders, 25th Match",
+                "matchType": "t20",
+                "status": "Match not started",
+                "venue": "Wankhede Stadium, Mumbai",
+                "date": "2026-03-26",
+                "dateTimeGMT": "2026-03-26T14:00:00",
+                "teams": ["Chennai Super Kings", "Kolkata Knight Riders"],
+                "teamInfo": [
+                    {
+                        "name": "Chennai Super Kings",
+                        "shortname": "CSK",
+                        "img": "https://example.com/csk.png",
+                    },
+                    {
+                        "name": "Kolkata Knight Riders",
+                        "shortname": "KKR",
+                        "img": "https://example.com/kkr.png",
+                    },
+                ],
+                "matchStarted": False,
+                "matchEnded": False,
+            },
+            {
+                "id": "match-guid-2",
+                "name": "Mumbai Indians vs Royal Challengers Bengaluru, 26th Match",
+                "matchType": "t20",
+                "status": "Kolkata Knight Riders won by 5 wickets",
+                "venue": "M Chinnaswamy Stadium, Bengaluru",
+                "date": "2026-03-27",
+                "dateTimeGMT": "2026-03-27T10:00:00",
+                "teams": ["Mumbai Indians", "Royal Challengers Bengaluru"],
+                "teamInfo": [
+                    {
+                        "name": "Mumbai Indians",
+                        "shortname": "MI",
+                        "img": "https://example.com/mi.png",
+                    },
+                    {
+                        "name": "Royal Challengers Bengaluru",
+                        "shortname": "RCB",
+                        "img": "https://example.com/rcb.png",
+                    },
+                ],
+                "matchStarted": True,
+                "matchEnded": True,
+            },
+        ],
+    },
+    "info": {"hitsToday": 3, "hitsLimit": 100, "totalRows": 74, "queryTime": 10},
+}
+
+SAMPLE_SERIES_SEARCH_RESPONSE = {
+    "status": "success",
+    "data": [
+        {
+            "id": "series-guid-2025",
+            "name": "Indian Premier League 2025",
+            "startDate": "2025-03-20",
+            "endDate": "2025-05-25",
+            "matches": 70,
+        },
+        {
+            "id": "series-guid-2026",
+            "name": "Indian Premier League 2026",
+            "startDate": "2026-03-20",
+            "endDate": "2026-05-25",
+            "matches": 74,
+        },
+    ],
+    "info": {"hitsToday": 5, "hitsLimit": 100},
+}
+
+
+# =============================================================================
+# Client Tests
+# =============================================================================
+
+
+class TestCricAPIClient:
+    """Tests for CricAPIClient."""
+
+    def test_no_api_key_returns_none(self):
+        """Client without API key returns None from requests."""
+        client = CricAPIClient(api_key=None)
+        result = client._request("series_info", {"id": "test"})
+        assert result is None
+
+    def test_rate_limit_tracking(self):
+        """Client tracks hitsToday and hitsLimit from responses."""
+        client = CricAPIClient(api_key="test-key")
+
+        # Simulate updating rate limit info from a response
+        client._update_rate_limit_info(SAMPLE_SERIES_INFO_RESPONSE)
+
+        assert client.hits_today == 3
+        assert client.hits_limit == 100
+        assert client.hits_remaining == 97
+
+    def test_rate_limit_none_response(self):
+        """Client handles None response gracefully."""
+        client = CricAPIClient(api_key="test-key")
+        client._update_rate_limit_info(None)
+        assert client.hits_today == 0
+        assert client.hits_limit == 100
+
+    def test_rate_limit_no_info_field(self):
+        """Client handles response without info field."""
+        client = CricAPIClient(api_key="test-key")
+        client._update_rate_limit_info({"status": "success", "data": {}})
+        assert client.hits_today == 0
+
+    def test_supports_league(self):
+        """Client delegates supports_league to mapping source."""
+        source = _make_mock_source()
+        client = CricAPIClient(league_mapping_source=source, api_key="key")
+
+        assert client.supports_league("ipl") is True
+        source.supports_league.assert_called_with("ipl", "cricapi")
+
+    def test_supports_league_no_source(self):
+        """Client returns False when no mapping source configured."""
+        client = CricAPIClient(api_key="key")
+        assert client.supports_league("ipl") is False
+
+    def test_get_provider_league_id(self):
+        """Client returns provider_league_id from mapping."""
+        source = _make_mock_source()
+        client = CricAPIClient(league_mapping_source=source, api_key="key")
+
+        assert client.get_provider_league_id("ipl") == "test-series-guid-123"
+
+    def test_get_provider_league_id_no_mapping(self):
+        """Client returns None when mapping not found."""
+        source = _make_mock_source()
+        source.get_mapping.return_value = None
+        client = CricAPIClient(league_mapping_source=source, api_key="key")
+
+        assert client.get_provider_league_id("unknown") is None
+
+    def test_get_sport(self):
+        """Client returns sport from mapping."""
+        source = _make_mock_source()
+        client = CricAPIClient(league_mapping_source=source, api_key="key")
+
+        assert client.get_sport("ipl") == "cricket"
+
+    def test_get_sport_default(self):
+        """Client returns 'cricket' when no mapping source."""
+        client = CricAPIClient(api_key="key")
+        assert client.get_sport("ipl") == "cricket"
+
+    def test_thread_safe_client_creation(self):
+        """Client creates httpx.Client lazily and thread-safely."""
+        client = CricAPIClient(api_key="key")
+        assert client._client is None
+
+        httpx_client = client._get_client()
+        assert httpx_client is not None
+
+        # Second call returns same instance
+        assert client._get_client() is httpx_client
+
+    def test_cache_stats(self):
+        """Client exposes cache statistics."""
+        client = CricAPIClient(api_key="key")
+        stats = client.cache_stats()
+        assert "total_entries" in stats
+        assert "hits" in stats
+
+    def test_close_client(self):
+        """Client closes underlying httpx.Client."""
+        client = CricAPIClient(api_key="key")
+        client._get_client()  # Force creation
+        assert client._client is not None
+
+        client.close()
+        assert client._client is None
+
+    def test_rate_limit_stats(self):
+        """Client exposes rate limit statistics."""
+        client = CricAPIClient(api_key="key")
+        stats = client.rate_limit_stats()
+        assert stats["hits_today"] == 0
+        assert stats["hits_limit"] == 100
+        assert stats["hits_remaining"] == 100
+
+
+# =============================================================================
+# Provider Tests
+# =============================================================================
+
+
+class TestCricAPIProviderProperties:
+    """Tests for provider basic properties."""
+
+    def test_name(self):
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source, api_key="key")
+        assert provider.name == "cricapi"
+
+    def test_supports_league(self):
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source, api_key="key")
+        assert provider.supports_league("ipl") is True
+
+    def test_get_supported_leagues(self):
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source, api_key="key")
+        leagues = provider.get_supported_leagues()
+        assert "ipl" in leagues
+
+
+# =============================================================================
+# Status Mapping Tests
+# =============================================================================
+
+
+class TestStatusMapping:
+    """Tests for CricAPI status string to teamarr EventStatus mapping."""
+
+    def _make_provider(self):
+        source = _make_mock_source()
+        return CricAPIProvider(league_mapping_source=source, api_key="key")
+
+    def test_not_started(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Match not started"})
+        assert status.state == "scheduled"
+        assert status.detail == "Match not started"
+
+    def test_match_starts_at(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Match starts at 14:00 GMT"})
+        assert status.state == "scheduled"
+
+    def test_won_by(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Chennai Super Kings won by 5 wickets"})
+        assert status.state == "final"
+        assert status.detail == "Chennai Super Kings won by 5 wickets"
+
+    def test_match_ended(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Match ended"})
+        assert status.state == "final"
+
+    def test_postponed(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Postponed due to rain"})
+        assert status.state == "postponed"
+
+    def test_cancelled(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": "Cancelled"})
+        assert status.state == "cancelled"
+
+    def test_live_from_flags(self):
+        p = self._make_provider()
+        status = p._parse_status({
+            "status": "",
+            "matchStarted": True,
+            "matchEnded": False,
+        })
+        assert status.state == "live"
+
+    def test_default_scheduled(self):
+        p = self._make_provider()
+        status = p._parse_status({"status": ""})
+        assert status.state == "scheduled"
+
+    def test_empty_status_no_flags(self):
+        p = self._make_provider()
+        status = p._parse_status({})
+        assert status.state == "scheduled"
+
+
+# =============================================================================
+# Datetime Parsing Tests
+# =============================================================================
+
+
+class TestDatetimeParsing:
+    """Tests for CricAPI datetime string to UTC datetime parsing."""
+
+    def _make_provider(self):
+        source = _make_mock_source()
+        return CricAPIProvider(league_mapping_source=source, api_key="key")
+
+    def test_datetime_gmt(self):
+        p = self._make_provider()
+        dt = p._parse_datetime("2026-03-26T14:00:00", None)
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.month == 3
+        assert dt.day == 26
+        assert dt.hour == 14
+        assert dt.minute == 0
+        assert dt.tzinfo is not None
+
+    def test_date_only(self):
+        p = self._make_provider()
+        dt = p._parse_datetime(None, "2026-03-26")
+        assert dt is not None
+        assert dt.year == 2026
+        assert dt.month == 3
+        assert dt.day == 26
+        assert dt.hour == 0
+
+    def test_prefers_datetime_gmt(self):
+        p = self._make_provider()
+        dt = p._parse_datetime("2026-03-26T14:00:00", "2026-03-27")
+        assert dt is not None
+        assert dt.day == 26  # Uses dateTimeGMT, not date
+
+    def test_none_both(self):
+        p = self._make_provider()
+        dt = p._parse_datetime(None, None)
+        assert dt is None
+
+
+# =============================================================================
+# Team ID Derivation Tests
+# =============================================================================
+
+
+class TestTeamIdDerivation:
+    """Tests for team ID generation from team names."""
+
+    def _make_provider(self):
+        source = _make_mock_source()
+        return CricAPIProvider(league_mapping_source=source, api_key="key")
+
+    def test_simple_name(self):
+        p = self._make_provider()
+        team_id = p._make_team_id("Chennai Super Kings")
+        assert team_id == "cricapi_chennai_super_kings"
+
+    def test_empty_name(self):
+        p = self._make_provider()
+        team_id = p._make_team_id("")
+        assert team_id == ""
+
+    def test_special_characters(self):
+        p = self._make_provider()
+        team_id = p._make_team_id("St. Lucia Zoups FC")
+        assert team_id == "cricapi_st_lucia_zoups_fc"
+
+    def test_team_ids_match(self):
+        p = self._make_provider()
+        team_id = p._make_team_id("Chennai Super Kings")
+        assert p._team_ids_match(team_id, "Chennai Super Kings") is True
+
+    def test_team_ids_no_match(self):
+        p = self._make_provider()
+        team_id = p._make_team_id("Chennai Super Kings")
+        assert p._team_ids_match(team_id, "Mumbai Indians") is False
+
+
+# =============================================================================
+# Abbreviation Generation Tests
+# =============================================================================
+
+
+class TestAbbreviation:
+    """Tests for abbreviation generation from team names."""
+
+    def _make_provider(self):
+        source = _make_mock_source()
+        return CricAPIProvider(league_mapping_source=source, api_key="key")
+
+    def test_multi_word(self):
+        p = self._make_provider()
+        abbrev = p._make_abbrev("Chennai Super Kings")
+        assert abbrev == "CSK"
+
+    def test_empty(self):
+        p = self._make_provider()
+        abbrev = p._make_abbrev("")
+        assert abbrev == ""
+
+    def test_filters_stopwords(self):
+        p = self._make_provider()
+        abbrev = p._make_abbrev("The Club of FC")
+        # "The", "of", "FC", "club" are all skipped -> empty -> fallback to first 3 chars
+        assert abbrev == "THE"
+
+    def test_cap_at_four(self):
+        p = self._make_provider()
+        abbrev = p._make_abbrev("One Two Three Four Five")
+        assert len(abbrev) <= 4
+
+
+# =============================================================================
+# Match Parsing Tests
+# =============================================================================
+
+
+class TestMatchParsing:
+    """Tests for full match data parsing into Event dataclass."""
+
+    def _make_provider_with_mock_client(self):
+        source = _make_mock_source()
+        client = CricAPIClient(league_mapping_source=source, api_key="test-key")
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+        return provider
+
+    def test_parse_match_basic(self):
+        p = self._make_provider_with_mock_client()
+        match_data = SAMPLE_SERIES_INFO_RESPONSE["data"]["matchList"][0]
+
+        event = p._parse_match(match_data, "ipl")
+
+        assert event is not None
+        assert event.id == "match-guid-1"
+        assert event.provider == "cricapi"
+        assert event.name == "Chennai Super Kings vs Kolkata Knight Riders, 25th Match"
+        assert event.league == "ipl"
+        assert event.sport == "cricket"
+        assert event.status.state == "scheduled"
+
+        # Team names
+        assert event.home_team.name == "Chennai Super Kings"
+        assert event.away_team.name == "Kolkata Knight Riders"
+
+        # Short names from teamInfo
+        assert event.home_team.short_name == "CSK"
+        assert event.away_team.short_name == "KKR"
+
+        # Abbreviations from teamInfo
+        assert event.home_team.abbreviation == "CSK"
+        assert event.away_team.abbreviation == "KKR"
+
+        # Start time
+        assert event.start_time.year == 2026
+        assert event.start_time.month == 3
+        assert event.start_time.day == 26
+        assert event.start_time.hour == 14
+
+        # Venue
+        assert event.venue is not None
+        assert event.venue.name == "Wankhede Stadium"
+        assert event.venue.city == "Mumbai"
+
+    def test_parse_match_final_status(self):
+        p = self._make_provider_with_mock_client()
+        match_data = SAMPLE_SERIES_INFO_RESPONSE["data"]["matchList"][1]
+
+        event = p._parse_match(match_data, "ipl")
+        assert event is not None
+        assert event.status.state == "final"
+        assert "won by" in event.status.detail.lower()
+
+    def test_parse_match_no_id(self):
+        p = self._make_provider_with_mock_client()
+        event = p._parse_match({}, "ipl")
+        assert event is None
+
+    def test_parse_match_no_datetime(self):
+        p = self._make_provider_with_mock_client()
+        event = p._parse_match({"id": "test-id"}, "ipl")
+        assert event is None
+
+
+# =============================================================================
+# Venue Parsing Tests
+# =============================================================================
+
+
+class TestVenueParsing:
+    """Tests for venue string parsing."""
+
+    def _make_provider(self):
+        source = _make_mock_source()
+        return CricAPIProvider(league_mapping_source=source, api_key="key")
+
+    def test_venue_with_city(self):
+        p = self._make_provider()
+        venue = p._parse_venue("Wankhede Stadium, Mumbai")
+        assert venue is not None
+        assert venue.name == "Wankhede Stadium"
+        assert venue.city == "Mumbai"
+
+    def test_venue_without_city(self):
+        p = self._make_provider()
+        venue = p._parse_venue("Melbourne Cricket Ground")
+        assert venue is not None
+        assert venue.name == "Melbourne Cricket Ground"
+        assert venue.city is None
+
+    def test_venue_empty(self):
+        p = self._make_provider()
+        venue = p._parse_venue("")
+        assert venue is None
+
+    def test_venue_none(self):
+        p = self._make_provider()
+        venue = p._parse_venue(None)
+        assert venue is None
+
+
+# =============================================================================
+# Integration Tests (with mocked client)
+# =============================================================================
+
+
+class TestGetEvents:
+    """Tests for get_events using mocked series_info responses."""
+
+    def _make_provider_with_mocked_client(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_provider_league_id.return_value = "series-guid-abc"
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+        return provider, client
+
+    def test_get_events_filters_by_date(self):
+        provider, _ = self._make_provider_with_mocked_client()
+
+        events = provider.get_events("ipl", date(2026, 3, 26))
+        assert len(events) == 1
+        assert events[0].id == "match-guid-1"
+
+    def test_get_events_no_matches_for_date(self):
+        provider, _ = self._make_provider_with_mocked_client()
+
+        events = provider.get_events("ipl", date(2026, 4, 1))
+        assert events == []
+
+    def test_get_events_multiple_on_same_day(self):
+        provider, client = self._make_provider_with_mocked_client()
+
+        # Add another match on the same date
+        response = {
+            "status": "success",
+            "data": {
+                "info": {"id": "s1", "name": "Test", "matches": 2},
+                "matchList": [
+                    {
+                        "id": "m1",
+                        "name": "Team A vs Team B",
+                        "matchType": "t20",
+                        "status": "Match not started",
+                        "venue": "Ground 1",
+                        "date": "2026-04-01",
+                        "dateTimeGMT": "2026-04-01T10:00:00",
+                        "teams": ["Team A", "Team B"],
+                        "teamInfo": [
+                            {"name": "Team A", "shortname": "TA"},
+                            {"name": "Team B", "shortname": "TB"},
+                        ],
+                        "matchStarted": False,
+                        "matchEnded": False,
+                    },
+                    {
+                        "id": "m2",
+                        "name": "Team C vs Team D",
+                        "matchType": "t20",
+                        "status": "Match not started",
+                        "venue": "Ground 2",
+                        "date": "2026-04-01",
+                        "dateTimeGMT": "2026-04-01T14:00:00",
+                        "teams": ["Team C", "Team D"],
+                        "teamInfo": [
+                            {"name": "Team C", "shortname": "TC"},
+                            {"name": "Team D", "shortname": "TD"},
+                        ],
+                        "matchStarted": False,
+                        "matchEnded": False,
+                    },
+                ],
+            },
+        }
+        client.get_series_info.return_value = response
+
+        events = provider.get_events("ipl", date(2026, 4, 1))
+        assert len(events) == 2
+
+
+class TestGetTeamSchedule:
+    """Tests for get_team_schedule."""
+
+    def _make_provider_with_mocked_client(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_provider_league_id.return_value = "series-guid-abc"
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+        return provider
+
+    def test_get_team_schedule_filters_by_team(self):
+        provider = self._make_provider_with_mocked_client()
+
+        team_id = "cricapi_chennai_super_kings"
+        with patch(
+            "teamarr.providers.cricapi.provider.date"
+        ) as mock_date:
+            mock_date.today.return_value = date(2026, 3, 25)
+            mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+            mock_date.fromisoformat = date.fromisoformat
+            events = provider.get_team_schedule(team_id, "ipl", days_ahead=30)
+        assert len(events) == 1
+        assert events[0].id == "match-guid-1"
+
+    def test_get_team_schedule_no_matches(self):
+        provider = self._make_provider_with_mocked_client()
+
+        team_id = "cricapi_nonexistent_team"
+        events = provider.get_team_schedule(team_id, "ipl", days_ahead=30)
+        assert events == []
+
+
+class TestGetLeagueTeams:
+    """Tests for get_league_teams."""
+
+    def _make_provider_with_mocked_client(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_provider_league_id.return_value = "series-guid-abc"
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+        return provider
+
+    def test_get_league_teams_extracts_unique(self):
+        provider = self._make_provider_with_mocked_client()
+
+        teams = provider.get_league_teams("ipl")
+        assert len(teams) == 4  # CSK, KKR, MI, RCB
+
+        team_names = {t.name for t in teams}
+        assert "Chennai Super Kings" in team_names
+        assert "Kolkata Knight Riders" in team_names
+        assert "Mumbai Indians" in team_names
+        assert "Royal Challengers Bengaluru" in team_names
+
+    def test_get_league_teams_has_logos(self):
+        provider = self._make_provider_with_mocked_client()
+
+        teams = provider.get_league_teams("ipl")
+        csk = next(t for t in teams if "Chennai" in t.name)
+        assert csk.logo_url == "https://example.com/csk.png"
+
+
+class TestSeriesAutoDetection:
+    """Tests for auto-detection of series ID."""
+
+    def _make_provider_with_mocked_client(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+        client.search_series.return_value = SAMPLE_SERIES_SEARCH_RESPONSE
+
+        # Initially no provider_league_id set
+        client.get_provider_league_id.return_value = None
+
+        updater = MagicMock()
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+            series_id_updater=updater,
+        )
+        return provider, client, updater
+
+    def test_auto_detect_picks_latest_series(self):
+        provider, client, updater = self._make_provider_with_mocked_client()
+
+        events = provider.get_events("ipl", date(2026, 3, 26))
+        assert len(events) == 1
+
+        # Should have called search_series with "Indian Premier League"
+        client.search_series.assert_called_once()
+        search_arg = client.search_series.call_args[0][0]
+        assert "Indian Premier League" in search_arg
+
+        # Should have called updater to persist the new series ID
+        updater.assert_called_once_with("ipl", "series-guid-2026")
+
+    def test_auto_detect_skips_zero_match_series(self):
+        provider, client, updater = self._make_provider_with_mocked_client()
+
+        # Return search results where one series has 0 matches
+        client.search_series.return_value = {
+            "status": "success",
+            "data": [
+                {
+                    "id": "old-series",
+                    "name": "IPL 2024",
+                    "startDate": "2024-03-20",
+                    "matches": 0,  # No matches
+                },
+                {
+                    "id": "good-series",
+                    "name": "IPL 2026",
+                    "startDate": "2026-03-20",
+                    "matches": 70,
+                },
+            ],
+        }
+
+        provider.get_events("ipl", date(2026, 3, 26))
+
+        # Should skip the 0-match series and pick the good one
+        updater.assert_called_once_with("ipl", "good-series")
+
+    def test_auto_detect_no_search_term(self):
+        """Provider with unknown league code and no display name returns empty."""
+        source = _make_mock_source(
+            _make_mapping(league_code="unknown_cricket", display_name="")
+        )
+        client = MagicMock(spec=CricAPIClient)
+        client.get_provider_league_id.return_value = None
+        client.supports_league.return_value = True
+        client.get_sport.return_value = "cricket"
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+
+        events = provider.get_events("unknown_cricket", date(2026, 3, 26))
+        assert events == []
+
+    def test_stale_series_id_triggers_auto_detect(self):
+        """When provider_league_id returns an error/failure status, auto-detect."""
+        provider, client, updater = self._make_provider_with_mocked_client()
+
+        # Set a stale series ID that returns a failure status
+        client.get_provider_league_id.return_value = "stale-series-id"
+        failure_response = {
+            "status": "failure",
+            "reason": "Series not found",
+        }
+        client.get_series_info.side_effect = [
+            failure_response,  # First call with stale ID
+            SAMPLE_SERIES_INFO_RESPONSE,  # Second call after auto-detect
+        ]
+
+        events = provider.get_events("ipl", date(2026, 3, 26))
+        assert len(events) == 1
+
+        # Should have called search and updater
+        client.search_series.assert_called_once()
+        updater.assert_called_once()
+
+    def test_empty_matchlist_does_not_trigger_auto_detect(self):
+        """A valid series with an empty matchList (off-season) is returned as-is."""
+        provider, client, updater = self._make_provider_with_mocked_client()
+
+        client.get_provider_league_id.return_value = "current-series-id"
+        off_season_response = {
+            "status": "success",
+            "data": {
+                "info": {"id": "current-series-id", "name": "IPL 2026", "matches": 0},
+                "matchList": [],
+            },
+        }
+        client.get_series_info.return_value = off_season_response
+
+        events = provider.get_events("ipl", date(2026, 3, 26))
+        assert events == []
+
+        # Should NOT have called search or updater — no API waste
+        client.search_series.assert_not_called()
+        updater.assert_not_called()
+
+
+class TestGetEvent:
+    """Tests for get_event (single match lookup)."""
+
+    def test_get_event_returns_match(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.get_sport.return_value = "cricket"
+
+        match_response = {
+            "status": "success",
+            "data": SAMPLE_SERIES_INFO_RESPONSE["data"]["matchList"][0],
+        }
+        client.get_match_info.return_value = match_response
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+
+        event = provider.get_event("match-guid-1", "ipl")
+        assert event is not None
+        assert event.id == "match-guid-1"
+
+    def test_get_event_not_found(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.get_match_info.return_value = None
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+
+        event = provider.get_event("nonexistent", "ipl")
+        assert event is None
+
+
+class TestGetTeam:
+    """Tests for get_team."""
+
+    def test_get_team_by_name(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_provider_league_id.return_value = "series-guid-abc"
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+
+        team = provider.get_team("cricapi_chennai_super_kings", "ipl")
+        assert team is not None
+        assert team.name == "Chennai Super Kings"
+        assert team.abbreviation == "CSK"
+        assert team.logo_url == "https://example.com/csk.png"
+
+    def test_get_team_not_found(self):
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.supports_league.return_value = True
+        client.get_provider_league_id.return_value = "series-guid-abc"
+        client.get_sport.return_value = "cricket"
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+        )
+
+        team = provider.get_team("cricapi_nonexistent_team", "ipl")
+        assert team is None
+
+
+# =============================================================================
+# Edge Case Tests
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_parse_match_missing_team_info(self):
+        """Match with teams array but no teamInfo should still parse."""
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source, api_key="key")
+
+        match_data = {
+            "id": "m1",
+            "name": "Team A vs Team B",
+            "date": "2026-04-01",
+            "dateTimeGMT": "2026-04-01T10:00:00",
+            "teams": ["Team A", "Team B"],
+            "teamInfo": [],  # Empty teamInfo
+            "status": "Match not started",
+            "matchStarted": False,
+            "matchEnded": False,
+        }
+
+        event = provider._parse_match(match_data, "ipl")
+        assert event is not None
+        assert event.home_team.name == "Team A"
+        assert event.away_team.name == "Team B"
+        # Should derive IDs from names
+        assert "team_a" in event.home_team.id
+        assert "team_b" in event.away_team.id
+
+    def test_parse_match_no_teams_at_all(self):
+        """Match with no teams at all should still parse with empty team data."""
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source, api_key="key")
+
+        match_data = {
+            "id": "m1",
+            "name": "TBD vs TBD",
+            "date": "2026-04-01",
+            "dateTimeGMT": "2026-04-01T10:00:00",
+            "teams": [],
+            "teamInfo": [],
+            "status": "Match not started",
+            "matchStarted": False,
+            "matchEnded": False,
+        }
+
+        event = provider._parse_match(match_data, "ipl")
+        assert event is not None
+        # Short name should fall back to event name
+        assert event.short_name == "TBD vs TBD"
+
+    def test_provider_with_no_client(self):
+        """Provider with no client or api_key creates client internally."""
+        source = _make_mock_source()
+        provider = CricAPIProvider(league_mapping_source=source)
+        assert provider._client is not None
+        assert provider._client.api_key is None
+
+    def test_series_id_updater_error_doesnt_crash(self):
+        """If series_id_updater raises, provider still returns data."""
+        source = _make_mock_source()
+        client = MagicMock(spec=CricAPIClient)
+        client.get_provider_league_id.return_value = None
+        client.supports_league.return_value = True
+        client.get_sport.return_value = "cricket"
+        client.search_series.return_value = SAMPLE_SERIES_SEARCH_RESPONSE
+        client.get_series_info.return_value = SAMPLE_SERIES_INFO_RESPONSE
+
+        failing_updater = MagicMock(side_effect=RuntimeError("DB error"))
+
+        provider = CricAPIProvider(
+            league_mapping_source=source,
+            client=client,
+            api_key="test-key",
+            series_id_updater=failing_updater,
+        )
+
+        events = provider.get_events("ipl", date(2026, 3, 26))
+        # Should still return events even if updater fails
+        assert len(events) == 1


### PR DESCRIPTION
This MR introduces a new sports data provider,  CricAPI  (via CricketData.org), designed to fetch fixture data for major cricket leagues, IPL, BBL, and SA20. It includes a frontend toggle allowing users to choose between the free CricAPI tier (which provides full fixture schedules) and their existing premium TSDB keys.

A free CricAPI key is good for 100 requests a day and I implemented caching to help prevent going over the limit.