### PR TITLE
Add read-only team channel status endpoint

### DIFF
--- a/teamarr/api/models.py
+++ b/teamarr/api/models.py
@@ -65,6 +65,58 @@ class TeamResponse(BaseModel):
     updated_at: datetime
 
 
+class TeamChannelStatusTeam(BaseModel):
+    """Team fields included in the channel status response."""
+
+    id: int
+    provider: str
+    provider_team_id: str
+    primary_league: str
+    leagues: list[str]
+    sport: str
+    team_name: str
+    team_abbrev: str | None = None
+    channel_id: str
+    active: bool
+
+
+class TeamChannelStatusDispatcharrChannel(BaseModel):
+    """Dispatcharr channel mapping for a Teamarr team channel."""
+
+    found: bool
+    id: int | None = None
+    uuid: str | None = None
+    name: str | None = None
+    channel_number: str | None = None
+    tvg_id: str | None = None
+    stream_count: int = 0
+    streams: list[int] = Field(default_factory=list)
+    error: str | None = None
+
+
+class TeamChannelStatusProgramme(BaseModel):
+    """Next live programme window for a Teamarr team channel."""
+
+    found: bool
+    start: datetime | None = None
+    stop: datetime | None = None
+    title: str | None = None
+    sub_title: str | None = None
+    is_live: bool = False
+    source: str = "team_epg_xmltv"
+
+
+class TeamChannelStatusResponse(BaseModel):
+    """Combined status for a static Teamarr team channel."""
+
+    team: TeamChannelStatusTeam
+    dispatcharr_channel: TeamChannelStatusDispatcharrChannel
+    next_live_window: TeamChannelStatusProgramme
+    status: str
+    missing: list[str] = Field(default_factory=list)
+    xmltv_updated_at: datetime | None = None
+
+
 # =============================================================================
 # Templates
 # =============================================================================

--- a/teamarr/api/routes/teams.py
+++ b/teamarr/api/routes/teams.py
@@ -6,7 +6,12 @@ import logging
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
 
-from teamarr.api.models import TeamCreate, TeamResponse, TeamUpdate
+from teamarr.api.models import (
+    TeamChannelStatusResponse,
+    TeamCreate,
+    TeamResponse,
+    TeamUpdate,
+)
 from teamarr.database import get_db
 
 logger = logging.getLogger(__name__)
@@ -138,6 +143,49 @@ def get_team(team_id: int):
         if not team:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
         return team
+
+
+@router.get("/teams/{team_id}/channel-status", response_model=TeamChannelStatusResponse)
+def get_team_channel_status(team_id: int):
+    """Get Dispatcharr mapping and next live window for a static team channel."""
+    from teamarr.database.teams import get_team as db_get_team
+    from teamarr.dispatcharr import ChannelManager, get_dispatcharr_client
+    from teamarr.services.team_channel_status import build_team_channel_status
+
+    with get_db() as conn:
+        team = db_get_team(conn, team_id)
+        if not team:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
+
+        xmltv_row = conn.execute(
+            "SELECT xmltv_content, updated_at FROM team_epg_xmltv WHERE team_id = ?",
+            (team_id,),
+        ).fetchone()
+
+    dispatcharr_channel = None
+    dispatcharr_error = None
+    try:
+        client = get_dispatcharr_client(get_db)
+        if client:
+            manager = ChannelManager(client)
+            dispatcharr_channel = manager.find_by_tvg_id(team["channel_id"])
+        else:
+            dispatcharr_error = "Dispatcharr connection not available"
+    except Exception as exc:
+        dispatcharr_error = str(exc)
+        logger.warning(
+            "[TEAMS] Failed to resolve Dispatcharr channel for team %s: %s",
+            team_id,
+            exc,
+        )
+
+    return build_team_channel_status(
+        team=team,
+        dispatcharr_channel=dispatcharr_channel,
+        xmltv_content=xmltv_row["xmltv_content"] if xmltv_row else None,
+        xmltv_updated_at=xmltv_row["updated_at"] if xmltv_row else None,
+        dispatcharr_error=dispatcharr_error,
+    )
 
 
 @router.put("/teams/{team_id}", response_model=TeamResponse)

--- a/teamarr/services/team_channel_status.py
+++ b/teamarr/services/team_channel_status.py
@@ -1,0 +1,163 @@
+"""Read-only status helpers for static Teamarr team channels."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from xml.etree import ElementTree as ET
+
+
+def parse_xmltv_timestamp(value: str | None) -> datetime | None:
+    """Parse XMLTV timestamps like ``20260610014500 +0000`` as UTC datetimes."""
+    if not value:
+        return None
+
+    raw = value.strip()
+    if len(raw) < 14:
+        return None
+
+    base = raw[:14]
+    offset = raw[15:].strip() if len(raw) > 15 else "+0000"
+
+    try:
+        parsed = datetime.strptime(f"{base}{offset}", "%Y%m%d%H%M%S%z")
+    except ValueError:
+        try:
+            parsed = datetime.strptime(base, "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+        except ValueError:
+            return None
+
+    return parsed.astimezone(UTC)
+
+
+def _text(element: ET.Element, name: str) -> str | None:
+    child = element.find(name)
+    if child is None or child.text is None:
+        return None
+    text = child.text.strip()
+    return text or None
+
+
+def _is_live_programme(element: ET.Element) -> bool:
+    if element.find("live") is not None:
+        return True
+
+    categories = {
+        (category.text or "").strip().lower()
+        for category in element.findall("category")
+        if category.text
+    }
+    return bool(categories & {"sports event", "live-sport", "live sport"})
+
+
+def find_next_live_window(
+    xmltv_content: str | None,
+    channel_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Return the current or next live programme for a team channel."""
+    if not xmltv_content or not channel_id:
+        return None
+
+    now = (now or datetime.now(UTC)).astimezone(UTC)
+
+    try:
+        root = ET.fromstring(xmltv_content)
+    except ET.ParseError:
+        return None
+
+    candidates: list[dict[str, Any]] = []
+    for programme in root.findall("programme"):
+        if programme.attrib.get("channel") != channel_id:
+            continue
+
+        start = parse_xmltv_timestamp(programme.attrib.get("start"))
+        stop = parse_xmltv_timestamp(programme.attrib.get("stop"))
+        if stop is not None and stop < now:
+            continue
+        if not _is_live_programme(programme):
+            continue
+
+        candidates.append(
+            {
+                "found": True,
+                "start": start,
+                "stop": stop,
+                "title": _text(programme, "title"),
+                "sub_title": _text(programme, "sub-title"),
+                "is_live": True,
+                "source": "team_epg_xmltv",
+            }
+        )
+
+    candidates.sort(
+        key=lambda item: item["start"] or datetime.max.replace(tzinfo=UTC)
+    )
+    return candidates[0] if candidates else None
+
+
+def build_team_channel_status(
+    team: dict[str, Any],
+    dispatcharr_channel: Any | None,
+    xmltv_content: str | None,
+    xmltv_updated_at: str | datetime | None = None,
+    dispatcharr_error: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build the API response payload for a static team channel."""
+    next_live_window = find_next_live_window(
+        xmltv_content,
+        channel_id=team.get("channel_id", ""),
+        now=now,
+    )
+
+    dispatcharr_payload = {"found": False, "error": dispatcharr_error}
+    if dispatcharr_channel is not None:
+        streams = list(getattr(dispatcharr_channel, "streams", ()) or ())
+        dispatcharr_payload = {
+            "found": True,
+            "id": getattr(dispatcharr_channel, "id", None),
+            "uuid": getattr(dispatcharr_channel, "uuid", None),
+            "name": getattr(dispatcharr_channel, "name", None),
+            "channel_number": getattr(dispatcharr_channel, "channel_number", None),
+            "tvg_id": getattr(dispatcharr_channel, "tvg_id", None),
+            "stream_count": len(streams),
+            "streams": streams,
+            "error": None,
+        }
+
+    programme_payload = next_live_window or {
+        "found": False,
+        "is_live": False,
+        "source": "team_epg_xmltv",
+    }
+
+    missing: list[str] = []
+    if dispatcharr_channel is None:
+        missing.append("dispatcharr_channel")
+    if not xmltv_content:
+        missing.append("team_epg_xmltv")
+    elif next_live_window is None:
+        missing.append("next_live_window")
+
+    status = "ready" if not missing else "incomplete"
+
+    return {
+        "team": {
+            "id": team["id"],
+            "provider": team["provider"],
+            "provider_team_id": team["provider_team_id"],
+            "primary_league": team["primary_league"],
+            "leagues": team.get("leagues") or [],
+            "sport": team["sport"],
+            "team_name": team["team_name"],
+            "team_abbrev": team.get("team_abbrev"),
+            "channel_id": team["channel_id"],
+            "active": bool(team.get("active")),
+        },
+        "dispatcharr_channel": dispatcharr_payload,
+        "next_live_window": programme_payload,
+        "status": status,
+        "missing": missing,
+        "xmltv_updated_at": xmltv_updated_at,
+    }

--- a/tests/test_team_channel_status.py
+++ b/tests/test_team_channel_status.py
@@ -1,0 +1,251 @@
+"""Tests for the static team channel status endpoint helpers."""
+
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from teamarr.api.routes import teams as teams_route
+from teamarr.services.team_channel_status import (
+    build_team_channel_status,
+    find_next_live_window,
+    parse_xmltv_timestamp,
+)
+
+TEAM = {
+    "id": 5762,
+    "provider": "espn",
+    "provider_team_id": "20",
+    "primary_league": "mlb",
+    "leagues": ["mlb"],
+    "sport": "baseball",
+    "team_name": "Washington Nationals",
+    "team_abbrev": "WSH",
+    "channel_id": "teamarr-team-sfv6-test-washington-nationals-20",
+    "active": 1,
+}
+
+
+XMLTV = """<?xml version="1.0"?>
+<tv>
+  <channel id="teamarr-team-sfv6-test-washington-nationals-20">
+    <display-name>Washington Nationals</display-name>
+  </channel>
+  <programme start="20260609010000 +0000" stop="20260609050000 +0000"
+      channel="teamarr-team-sfv6-test-washington-nationals-20">
+    <title>Past game</title>
+    <live/>
+  </programme>
+  <programme start="20260610014500 +0000" stop="20260610051500 +0000"
+      channel="teamarr-team-sfv6-test-washington-nationals-20">
+    <title>MLB Baseball</title>
+    <sub-title>Washington Nationals at San Francisco Giants</sub-title>
+    <category>Sports Event</category>
+    <live/>
+  </programme>
+  <programme start="20260610194500 +0000" stop="20260610231500 +0000"
+      channel="teamarr-team-sfv6-test-washington-nationals-20">
+    <title>MLB Baseball Later</title>
+    <category>Sports Event</category>
+    <live/>
+  </programme>
+</tv>
+"""
+
+
+@dataclass(frozen=True)
+class FakeDispatcharrChannel:
+    id: int = 8698
+    uuid: str = "e5aa42b8-829d-4902-8a31-ce7c668110ca"
+    name: str = "[TEST] Washington Nationals"
+    channel_number: str = "9900.0"
+    tvg_id: str = "teamarr-team-sfv6-test-washington-nationals-20"
+    streams: tuple[int, ...] = (602572, 602573, 602574)
+
+
+def test_parse_xmltv_timestamp_utc():
+    parsed = parse_xmltv_timestamp("20260610014500 +0000")
+    assert parsed is not None
+    assert parsed.isoformat() == "2026-06-10T01:45:00+00:00"
+
+
+def test_parse_xmltv_timestamp_invalid_returns_none():
+    assert parse_xmltv_timestamp("broken") is None
+    assert parse_xmltv_timestamp(None) is None
+
+
+def test_find_next_live_window_skips_past_programmes():
+    window = find_next_live_window(
+        XMLTV,
+        channel_id="teamarr-team-sfv6-test-washington-nationals-20",
+        now=datetime(2026, 6, 9, 20, 0, tzinfo=UTC),
+    )
+
+    assert window is not None
+    assert window["title"] == "MLB Baseball"
+    assert window["sub_title"] == "Washington Nationals at San Francisco Giants"
+    assert window["start"].isoformat() == "2026-06-10T01:45:00+00:00"
+    assert window["stop"].isoformat() == "2026-06-10T05:15:00+00:00"
+
+
+def test_find_next_live_window_requires_live_signal():
+    xmltv = """<tv>
+      <programme start="20260610014500 +0000" stop="20260610051500 +0000"
+          channel="team">
+        <title>Studio filler</title>
+      </programme>
+    </tv>"""
+
+    assert find_next_live_window(xmltv, "team", now=datetime(2026, 6, 9, tzinfo=UTC)) is None
+
+
+def test_build_team_channel_status_ready():
+    status = build_team_channel_status(
+        team=TEAM,
+        dispatcharr_channel=FakeDispatcharrChannel(),
+        xmltv_content=XMLTV,
+        xmltv_updated_at="2026-06-09 19:27:40",
+        now=datetime(2026, 6, 9, 20, 0, tzinfo=UTC),
+    )
+
+    assert status["status"] == "ready"
+    assert status["missing"] == []
+    assert status["team"]["active"] is True
+    assert status["dispatcharr_channel"]["found"] is True
+    assert status["dispatcharr_channel"]["id"] == 8698
+    assert status["dispatcharr_channel"]["stream_count"] == 3
+    assert status["next_live_window"]["found"] is True
+
+
+def test_build_team_channel_status_missing_dispatcharr_and_xmltv():
+    status = build_team_channel_status(
+        team=TEAM,
+        dispatcharr_channel=None,
+        xmltv_content=None,
+        dispatcharr_error="Dispatcharr connection not available",
+    )
+
+    assert status["status"] == "incomplete"
+    assert status["missing"] == ["dispatcharr_channel", "team_epg_xmltv"]
+    assert status["dispatcharr_channel"]["found"] is False
+    assert status["dispatcharr_channel"]["error"] == "Dispatcharr connection not available"
+    assert status["next_live_window"]["found"] is False
+
+
+def _team_status_db(xmltv: str | None = XMLTV):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE teams (
+            id INTEGER PRIMARY KEY,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            provider TEXT NOT NULL,
+            provider_team_id TEXT NOT NULL,
+            primary_league TEXT NOT NULL,
+            leagues TEXT DEFAULT '[]',
+            sport TEXT NOT NULL,
+            team_name TEXT NOT NULL,
+            team_abbrev TEXT,
+            team_logo_url TEXT,
+            team_color TEXT,
+            channel_id TEXT NOT NULL,
+            channel_logo_url TEXT,
+            template_id INTEGER,
+            active INTEGER DEFAULT 1
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE team_epg_xmltv (
+            team_id INTEGER PRIMARY KEY,
+            xmltv_content TEXT NOT NULL,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute(
+        """
+        INSERT INTO teams (
+            id, provider, provider_team_id, primary_league, leagues, sport,
+            team_name, team_abbrev, channel_id, active
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            TEAM["id"],
+            TEAM["provider"],
+            TEAM["provider_team_id"],
+            TEAM["primary_league"],
+            '["mlb"]',
+            TEAM["sport"],
+            TEAM["team_name"],
+            TEAM["team_abbrev"],
+            TEAM["channel_id"],
+            TEAM["active"],
+        ),
+    )
+    if xmltv is not None:
+        conn.execute(
+            "INSERT INTO team_epg_xmltv (team_id, xmltv_content) VALUES (?, ?)",
+            (TEAM["id"], xmltv),
+        )
+    conn.commit()
+    return conn
+
+
+def _patch_team_status_db(monkeypatch, conn):
+    @contextmanager
+    def fake_get_db():
+        yield conn
+
+    monkeypatch.setattr(teams_route, "get_db", fake_get_db)
+
+
+def test_team_channel_status_endpoint_ready(monkeypatch):
+    conn = _team_status_db()
+    _patch_team_status_db(monkeypatch, conn)
+
+    import teamarr.dispatcharr as dispatcharr
+
+    class FakeManager:
+        def __init__(self, client):
+            self.client = client
+
+        def find_by_tvg_id(self, tvg_id):
+            assert tvg_id == TEAM["channel_id"]
+            return FakeDispatcharrChannel()
+
+    monkeypatch.setattr(dispatcharr, "get_dispatcharr_client", lambda db_factory: object())
+    monkeypatch.setattr(dispatcharr, "ChannelManager", FakeManager)
+
+    response = teams_route.get_team_channel_status(TEAM["id"])
+
+    assert response["status"] == "ready"
+    assert response["team"]["team_name"] == "Washington Nationals"
+    assert response["dispatcharr_channel"]["id"] == 8698
+    assert response["next_live_window"]["title"] == "MLB Baseball"
+
+
+def test_team_channel_status_endpoint_missing_dispatcharr(monkeypatch):
+    conn = _team_status_db()
+    _patch_team_status_db(monkeypatch, conn)
+
+    import teamarr.dispatcharr as dispatcharr
+
+    monkeypatch.setattr(dispatcharr, "get_dispatcharr_client", lambda db_factory: None)
+
+    response = teams_route.get_team_channel_status(TEAM["id"])
+
+    assert response["status"] == "incomplete"
+    assert response["missing"] == ["dispatcharr_channel"]
+    assert response["dispatcharr_channel"]["error"] == "Dispatcharr connection not available"
+
+
+def test_team_channel_status_endpoint_team_not_found(monkeypatch):
+    conn = _team_status_db()
+    _patch_team_status_db(monkeypatch, conn)
+
+    with pytest.raises(teams_route.HTTPException) as exc:
+        teams_route.get_team_channel_status(999)
+
+    assert exc.value.status_code == 404


### PR DESCRIPTION
# Add Read-Only Team Channel Status Endpoint

## Summary

This adds a read-only API endpoint for static Teamarr team channels:

```http
GET /api/v1/teams/{team_id}/channel-status
```

The endpoint returns the configured Teamarr team, its matching Dispatcharr channel, and the next generated live programme window from Teamarr XMLTV.

It gives external tools such as StreamFlow a single lightweight preflight lookup for team channels without triggering Teamarr generation, Dispatcharr M3U refreshes, full runs, mass queues, or channel lifecycle changes.

## What Changed

- Added Team channel status response models in `teamarr/api/models.py`.
- Added `GET /api/v1/teams/{team_id}/channel-status` in `teamarr/api/routes/teams.py`.
- Added `teamarr/services/team_channel_status.py` for XMLTV parsing and response construction.
- Added focused tests in `tests/test_team_channel_status.py`.

The response includes:

- Team metadata:
  - `id`
  - `provider`
  - `provider_team_id`
  - `primary_league`
  - `leagues`
  - `sport`
  - `team_name`
  - `team_abbrev`
  - `channel_id`
  - `active`
- Dispatcharr channel mapping:
  - `found`
  - `id`
  - `uuid`
  - `name`
  - `channel_number`
  - `tvg_id`
  - `stream_count`
  - `streams`
- Next live programme window from `team_epg_xmltv`:
  - `found`
  - `start`
  - `stop`
  - `title`
  - `sub_title`
  - `is_live`
  - `source`
- Overall status:
  - `ready` when team XMLTV, Dispatcharr channel, and next live window are present.
  - `incomplete` with a `missing` list when something is not available yet.

Unknown teams return HTTP `404` with:

```json
{"detail": "Team not found"}
```

## Why

Teamarr already exposes Dispatcharr channel IDs and event timing for event-managed channels through the managed-channel API, but static team channels only exposed the configured Teamarr team record.

For StreamFlow team/event preflight we need to know whether a static team channel is ready before queueing a targeted check:

- Does the Teamarr team exist?
- Does its `channel_id` resolve to a real Dispatcharr channel?
- Which Dispatcharr channel/UUID should a caller use?
- Does the generated team XMLTV contain a next live programme window?

Putting that into one read-only endpoint keeps StreamFlow and other callers out of Teamarr internals and avoids using broad generation or M3U refresh paths just to answer a status question.

## Example Live Response

```json
{
  "team": {
    "id": 5762,
    "provider": "espn",
    "provider_team_id": "20",
    "primary_league": "mlb",
    "leagues": ["mlb"],
    "sport": "baseball",
    "team_name": "Washington Nationals",
    "team_abbrev": "WSH",
    "channel_id": "teamarr-team-sfv6-test-washington-nationals-20",
    "active": true
  },
  "dispatcharr_channel": {
    "found": true,
    "id": 8698,
    "uuid": "e5aa42b8-829d-4902-8a31-ce7c668110ca",
    "name": "[SFV6 TEST] Washington Nationals Team Preflight",
    "channel_number": "9900.0",
    "tvg_id": "teamarr-team-sfv6-test-washington-nationals-20",
    "stream_count": 6,
    "streams": [602572, 602573, 602574, 667934, 667935, 667936],
    "error": null
  },
  "next_live_window": {
    "found": true,
    "start": "2026-06-10T01:45:00Z",
    "stop": "2026-06-10T05:15:00Z",
    "title": "MLB Baseball",
    "sub_title": "Washington Nationals at San Francisco Giants um 03:45 CEST Uhr am Wednesday, June 10, 2026",
    "is_live": true,
    "source": "team_epg_xmltv"
  },
  "status": "ready",
  "missing": [],
  "xmltv_updated_at": "2026-06-09T20:04:42"
}
```

## Testing

Implemented against current upstream `dev`:

- Base: `Pharaoh-Labs/teamarr:dev`
- Base commit: `bace48facc0e17197e9a848f84919601717b52d8`
- Feature branch: `feature/team-channel-status-api`
- Feature commit: `27f28ef0caa5abda824001dd3af5691d3a2fb19d`

Local tests:

```bash
python -m pytest tests/test_team_channel_status.py -q
```

Result:

```text
9 passed
```

Lint:

```bash
python -m ruff check teamarr/api/models.py teamarr/api/routes/teams.py teamarr/services/team_channel_status.py tests/test_team_channel_status.py
```

Result:

```text
All checks passed
```

Regression check:

```bash
python -m pytest tests/test_team_channel_status.py tests/test_team_import_collisions.py tests/test_dispatcharr_program_search.py tests/test_xmltv_filler_categories.py -q
```

Result:

```text
37 passed, 1 warning
```

The warning is the existing `datetime.utcnow()` deprecation in `teamarr/database/seed.py`.

Docker build:

- Workflow: `Docker Build and Publish`
- Run: `https://github.com/bttfw/teamarr/actions/runs/27232037330`
- Image: `ghcr.io/bttfw/teamarr:feature-team-channel-status-api`
- Image revision: `27f28ef0caa5abda824001dd3af5691d3a2fb19d`

Live system verification:

- Deployed through the normal Teamarr Docker template/update path on the live system.
- Running image: `ghcr.io/bttfw/teamarr:feature-team-channel-status-api`
- Container status: `running`, `healthy`
- Runtime metadata:
  - `GIT_BRANCH=feature/team-channel-status-api`
  - `GIT_SHA=27f28ef`

Live API checks:

```http
GET /api/v1/teams/5762/channel-status
```

Result:

- HTTP `200`
- `status: ready`
- Dispatcharr channel found: `true`
- Dispatcharr channel id: `8698`
- Dispatcharr UUID: `e5aa42b8-829d-4902-8a31-ce7c668110ca`
- Stream count: `6`
- Next live window: `2026-06-10T01:45:00Z` to `2026-06-10T05:15:00Z`

```http
GET /api/v1/teams/999999/channel-status
```

Result:

- HTTP `404`
- Body: `{"detail":"Team not found"}`
