### PR TITLE
 Support standard regex named groups in Custom Patterns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   teamarr:
-    image: ghcr.io/pharaoh-labs/teamarr:latest
+    build: .
     container_name: teamarr
     restart: unless-stopped
     ports:

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -833,12 +833,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_teams: e.target.value || null })
                           }
-                          placeholder="(?P<team1>[A-Z]{2,3})\s*[@vs]+\s*(?P<team2>[A-Z]{2,3})"
+                          placeholder="(?<team1>[A-Z]{2,3})\s*[@vs]+\s*(?<team2>[A-Z]{2,3})"
                           disabled={!formData.custom_regex_teams_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_teams_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named groups: (?P&lt;team1&gt;...) and (?P&lt;team2&gt;...)
+                          Use named groups: (?&lt;team1&gt;...) and (?&lt;team2&gt;...)
                         </p>
                       </div>
 
@@ -858,12 +858,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_date: e.target.value || null })
                           }
-                          placeholder="(?P<date>\d{1,2}/\d{1,2})"
+                          placeholder="(?<date>\d{1,2}/\d{1,2})"
                           disabled={!formData.custom_regex_date_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_date_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;date&gt;...)
+                          Use named group: (?&lt;date&gt;...)
                         </p>
 
                         {/* Month/Day sub-options */}
@@ -884,7 +884,7 @@ export function EventGroupForm() {
                               onChange={(e) =>
                                 setFormData({ ...formData, custom_regex_month: e.target.value || null })
                               }
-                              placeholder="(?P<month>\w+)"
+                              placeholder="(?<month>\w+)"
                               disabled={!formData.custom_regex_month_enabled}
                               className={cn("font-mono text-sm", !formData.custom_regex_month_enabled && "opacity-50")}
                             />
@@ -904,7 +904,7 @@ export function EventGroupForm() {
                               onChange={(e) =>
                                 setFormData({ ...formData, custom_regex_day: e.target.value || null })
                               }
-                              placeholder="(?P<day>\d{1,2})"
+                              placeholder="(?<day>\d{1,2})"
                               disabled={!formData.custom_regex_day_enabled}
                               className={cn("font-mono text-sm", !formData.custom_regex_day_enabled && "opacity-50")}
                             />
@@ -928,12 +928,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_time: e.target.value || null })
                           }
-                          placeholder="(?P<time>\d{1,2}:\d{2}\s*(?:AM|PM)?)"
+                          placeholder="(?<time>\d{1,2}:\d{2}\s*(?:AM|PM)?)"
                           disabled={!formData.custom_regex_time_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_time_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;time&gt;...)
+                          Use named group: (?&lt;time&gt;...)
                         </p>
                       </div>
 
@@ -953,12 +953,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_league: e.target.value || null })
                           }
-                          placeholder="(?P<league>NHL|NBA|NFL|MLB)"
+                          placeholder="(?<league>NHL|NBA|NFL|MLB)"
                           disabled={!formData.custom_regex_league_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_league_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;league&gt;...)
+                          Use named group: (?&lt;league&gt;...)
                         </p>
                       </div>
                     </div>
@@ -987,12 +987,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_fighters: e.target.value || null })
                           }
-                          placeholder="(?P<fighter1>\w+)\s+vs\.?\s+(?P<fighter2>\w+)"
+                          placeholder="(?<fighter1>\w+)\s+vs\.?\s+(?<fighter2>\w+)"
                           disabled={!formData.custom_regex_fighters_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_fighters_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named groups: (?P&lt;fighter1&gt;...) and (?P&lt;fighter2&gt;...)
+                          Use named groups: (?&lt;fighter1&gt;...) and (?&lt;fighter2&gt;...)
                         </p>
                       </div>
 
@@ -1012,12 +1012,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_event_name: e.target.value || null })
                           }
-                          placeholder="(?P<event_name>UFC\s*\d+|Bellator\s*\d+)"
+                          placeholder="(?<event_name>UFC\s*\d+|Bellator\s*\d+)"
                           disabled={!formData.custom_regex_event_name_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_event_name_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;event_name&gt;...)
+                          Use named group: (?&lt;event_name&gt;...)
                         </p>
                       </div>
 
@@ -1037,12 +1037,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_date: e.target.value || null })
                           }
-                          placeholder="(?P<date>\d{1,2}/\d{1,2})"
+                          placeholder="(?<date>\d{1,2}/\d{1,2})"
                           disabled={!formData.custom_regex_date_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_date_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;date&gt;...)
+                          Use named group: (?&lt;date&gt;...)
                         </p>
 
                         {/* Month/Day sub-options */}
@@ -1063,7 +1063,7 @@ export function EventGroupForm() {
                               onChange={(e) =>
                                 setFormData({ ...formData, custom_regex_month: e.target.value || null })
                               }
-                              placeholder="(?P<month>\w+)"
+                              placeholder="(?<month>\w+)"
                               disabled={!formData.custom_regex_month_enabled}
                               className={cn("font-mono text-sm", !formData.custom_regex_month_enabled && "opacity-50")}
                             />
@@ -1083,7 +1083,7 @@ export function EventGroupForm() {
                               onChange={(e) =>
                                 setFormData({ ...formData, custom_regex_day: e.target.value || null })
                               }
-                              placeholder="(?P<day>\d{1,2})"
+                              placeholder="(?<day>\d{1,2})"
                               disabled={!formData.custom_regex_day_enabled}
                               className={cn("font-mono text-sm", !formData.custom_regex_day_enabled && "opacity-50")}
                             />
@@ -1107,12 +1107,12 @@ export function EventGroupForm() {
                           onChange={(e) =>
                             setFormData({ ...formData, custom_regex_time: e.target.value || null })
                           }
-                          placeholder="(?P<time>\d{1,2}:\d{2}\s*(?:AM|PM)?)"
+                          placeholder="(?<time>\d{1,2}:\d{2}\s*(?:AM|PM)?)"
                           disabled={!formData.custom_regex_time_enabled}
                           className={cn("font-mono text-sm", !formData.custom_regex_time_enabled && "opacity-50")}
                         />
                         <p className="text-xs text-muted-foreground">
-                          Use named group: (?P&lt;time&gt;...)
+                          Use named group: (?&lt;time&gt;...)
                         </p>
                       </div>
                     </div>

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Checkbox } from "@/components/ui/checkbox"
 import { cn } from "@/lib/utils"
+import { jsToPython } from "@/lib/regex-utils"
 import {
   useGroup,
   useCreateGroup,
@@ -230,6 +231,14 @@ export function EventGroupForm() {
     try {
       const submitData = {
         ...formData,
+        custom_regex_teams: formData.custom_regex_teams ? jsToPython(formData.custom_regex_teams) : null,
+        custom_regex_date: formData.custom_regex_date ? jsToPython(formData.custom_regex_date) : null,
+        custom_regex_month: formData.custom_regex_month ? jsToPython(formData.custom_regex_month) : null,
+        custom_regex_day: formData.custom_regex_day ? jsToPython(formData.custom_regex_day) : null,
+        custom_regex_time: formData.custom_regex_time ? jsToPython(formData.custom_regex_time) : null,
+        custom_regex_league: formData.custom_regex_league ? jsToPython(formData.custom_regex_league) : null,
+        custom_regex_fighters: formData.custom_regex_fighters ? jsToPython(formData.custom_regex_fighters) : null,
+        custom_regex_event_name: formData.custom_regex_event_name ? jsToPython(formData.custom_regex_event_name) : null,
         // Subscription override fields
         subscription_leagues: useGlobalSubscription
           ? null

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -11,7 +11,7 @@ import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Checkbox } from "@/components/ui/checkbox"
 import { cn } from "@/lib/utils"
-import { jsToPython } from "@/lib/regex-utils"
+import { jsToPython, pythonToJs } from "@/lib/regex-utils"
 import {
   useGroup,
   useCreateGroup,
@@ -162,26 +162,26 @@ export function EventGroupForm() {
         m3u_account_id: group.m3u_account_id,
         m3u_account_name: group.m3u_account_name,
         // Stream filtering
-        stream_include_regex: group.stream_include_regex,
+        stream_include_regex: group.stream_include_regex ? pythonToJs(group.stream_include_regex) : null,
         stream_include_regex_enabled: group.stream_include_regex_enabled,
-        stream_exclude_regex: group.stream_exclude_regex,
+        stream_exclude_regex: group.stream_exclude_regex ? pythonToJs(group.stream_exclude_regex) : null,
         stream_exclude_regex_enabled: group.stream_exclude_regex_enabled,
-        custom_regex_teams: group.custom_regex_teams,
+        custom_regex_teams: group.custom_regex_teams ? pythonToJs(group.custom_regex_teams) : null,
         custom_regex_teams_enabled: group.custom_regex_teams_enabled,
-        custom_regex_date: group.custom_regex_date,
+        custom_regex_date: group.custom_regex_date ? pythonToJs(group.custom_regex_date) : null,
         custom_regex_date_enabled: group.custom_regex_date_enabled,
-        custom_regex_month: group.custom_regex_month,
+        custom_regex_month: group.custom_regex_month ? pythonToJs(group.custom_regex_month) : null,
         custom_regex_month_enabled: group.custom_regex_month_enabled,
-        custom_regex_day: group.custom_regex_day,
+        custom_regex_day: group.custom_regex_day ? pythonToJs(group.custom_regex_day) : null,
         custom_regex_day_enabled: group.custom_regex_day_enabled,
-        custom_regex_time: group.custom_regex_time,
+        custom_regex_time: group.custom_regex_time ? pythonToJs(group.custom_regex_time) : null,
         custom_regex_time_enabled: group.custom_regex_time_enabled,
-        custom_regex_league: group.custom_regex_league,
+        custom_regex_league: group.custom_regex_league ? pythonToJs(group.custom_regex_league) : null,
         custom_regex_league_enabled: group.custom_regex_league_enabled,
         // EVENT_CARD specific
-        custom_regex_fighters: group.custom_regex_fighters,
+        custom_regex_fighters: group.custom_regex_fighters ? pythonToJs(group.custom_regex_fighters) : null,
         custom_regex_fighters_enabled: group.custom_regex_fighters_enabled,
-        custom_regex_event_name: group.custom_regex_event_name,
+        custom_regex_event_name: group.custom_regex_event_name ? pythonToJs(group.custom_regex_event_name) : null,
         custom_regex_event_name_enabled: group.custom_regex_event_name_enabled,
         skip_builtin_filter: group.skip_builtin_filter,
         team_streams_enabled: group.team_streams_enabled,
@@ -231,6 +231,8 @@ export function EventGroupForm() {
     try {
       const submitData = {
         ...formData,
+        stream_include_regex: formData.stream_include_regex ? jsToPython(formData.stream_include_regex) : null,
+        stream_exclude_regex: formData.stream_exclude_regex ? jsToPython(formData.stream_exclude_regex) : null,
         custom_regex_teams: formData.custom_regex_teams ? jsToPython(formData.custom_regex_teams) : null,
         custom_regex_date: formData.custom_regex_date ? jsToPython(formData.custom_regex_date) : null,
         custom_regex_month: formData.custom_regex_month ? jsToPython(formData.custom_regex_month) : null,

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -64,20 +64,6 @@ class ClassifiedStream:
     feed_hint: str | None = None
 
 
-def _fix_regex_pattern(pattern: str | None) -> str | None:
-    """Convert JavaScript-style named groups and backreferences to Python style.
-    
-    Transforms `(?<name>...)` to `(?P<name>...)` and `\\k<name>` to `(?P=name)`.
-    """
-    if not pattern:
-        return pattern
-    # Replace (?<name> with (?P<name>
-    pattern = re.sub(r'\(\?<([a-zA-Z_]\w*)>', r'(?P<\1>', pattern)
-    # Replace \k<name> with (?P=name)
-    pattern = re.sub(r'\\k<([a-zA-Z_]\w*)>', r'(?P=\1)', pattern)
-    return pattern
-
-
 @dataclass
 class CustomRegexConfig:
     """Configuration for custom regex extraction patterns."""
@@ -119,8 +105,7 @@ class CustomRegexConfig:
 
         if self._compiled_teams is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.teams_pattern)
-                self._compiled_teams = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_teams = re.compile(self.teams_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom teams regex pattern: %s", e)
                 return None
@@ -134,8 +119,7 @@ class CustomRegexConfig:
 
         if self._compiled_date is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.date_pattern)
-                self._compiled_date = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_date = re.compile(self.date_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom date regex pattern: %s", e)
                 return None
@@ -149,8 +133,7 @@ class CustomRegexConfig:
 
         if self._compiled_month is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.month_pattern)
-                self._compiled_month = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_month = re.compile(self.month_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom month regex pattern: %s", e)
                 return None
@@ -164,8 +147,7 @@ class CustomRegexConfig:
 
         if self._compiled_day is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.day_pattern)
-                self._compiled_day = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_day = re.compile(self.day_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom day regex pattern: %s", e)
                 return None
@@ -179,8 +161,7 @@ class CustomRegexConfig:
 
         if self._compiled_time is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.time_pattern)
-                self._compiled_time = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_time = re.compile(self.time_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom time regex pattern: %s", e)
                 return None
@@ -194,8 +175,7 @@ class CustomRegexConfig:
 
         if self._compiled_league is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.league_pattern)
-                self._compiled_league = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_league = re.compile(self.league_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom league regex pattern: %s", e)
                 return None
@@ -209,8 +189,7 @@ class CustomRegexConfig:
 
         if self._compiled_fighters is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.fighters_pattern)
-                self._compiled_fighters = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_fighters = re.compile(self.fighters_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom fighters regex pattern: %s", e)
                 return None
@@ -224,8 +203,7 @@ class CustomRegexConfig:
 
         if self._compiled_event_name is None:
             try:
-                fixed_pattern = _fix_regex_pattern(self.event_name_pattern)
-                self._compiled_event_name = re.compile(fixed_pattern, re.IGNORECASE)
+                self._compiled_event_name = re.compile(self.event_name_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom event_name regex pattern: %s", e)
                 return None

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -64,6 +64,20 @@ class ClassifiedStream:
     feed_hint: str | None = None
 
 
+def _fix_regex_pattern(pattern: str | None) -> str | None:
+    """Convert JavaScript-style named groups and backreferences to Python style.
+    
+    Transforms `(?<name>...)` to `(?P<name>...)` and `\\k<name>` to `(?P=name)`.
+    """
+    if not pattern:
+        return pattern
+    # Replace (?<name> with (?P<name>
+    pattern = re.sub(r'\(\?<([a-zA-Z_]\w*)>', r'(?P<\1>', pattern)
+    # Replace \k<name> with (?P=name)
+    pattern = re.sub(r'\\k<([a-zA-Z_]\w*)>', r'(?P=\1)', pattern)
+    return pattern
+
+
 @dataclass
 class CustomRegexConfig:
     """Configuration for custom regex extraction patterns."""
@@ -105,7 +119,8 @@ class CustomRegexConfig:
 
         if self._compiled_teams is None:
             try:
-                self._compiled_teams = re.compile(self.teams_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.teams_pattern)
+                self._compiled_teams = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom teams regex pattern: %s", e)
                 return None
@@ -119,7 +134,8 @@ class CustomRegexConfig:
 
         if self._compiled_date is None:
             try:
-                self._compiled_date = re.compile(self.date_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.date_pattern)
+                self._compiled_date = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom date regex pattern: %s", e)
                 return None
@@ -133,7 +149,8 @@ class CustomRegexConfig:
 
         if self._compiled_month is None:
             try:
-                self._compiled_month = re.compile(self.month_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.month_pattern)
+                self._compiled_month = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom month regex pattern: %s", e)
                 return None
@@ -147,7 +164,8 @@ class CustomRegexConfig:
 
         if self._compiled_day is None:
             try:
-                self._compiled_day = re.compile(self.day_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.day_pattern)
+                self._compiled_day = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom day regex pattern: %s", e)
                 return None
@@ -161,7 +179,8 @@ class CustomRegexConfig:
 
         if self._compiled_time is None:
             try:
-                self._compiled_time = re.compile(self.time_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.time_pattern)
+                self._compiled_time = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom time regex pattern: %s", e)
                 return None
@@ -175,7 +194,8 @@ class CustomRegexConfig:
 
         if self._compiled_league is None:
             try:
-                self._compiled_league = re.compile(self.league_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.league_pattern)
+                self._compiled_league = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom league regex pattern: %s", e)
                 return None
@@ -189,7 +209,8 @@ class CustomRegexConfig:
 
         if self._compiled_fighters is None:
             try:
-                self._compiled_fighters = re.compile(self.fighters_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.fighters_pattern)
+                self._compiled_fighters = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom fighters regex pattern: %s", e)
                 return None
@@ -203,7 +224,8 @@ class CustomRegexConfig:
 
         if self._compiled_event_name is None:
             try:
-                self._compiled_event_name = re.compile(self.event_name_pattern, re.IGNORECASE)
+                fixed_pattern = _fix_regex_pattern(self.event_name_pattern)
+                self._compiled_event_name = re.compile(fixed_pattern, re.IGNORECASE)
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom event_name regex pattern: %s", e)
                 return None


### PR DESCRIPTION
This PR improves the Custom Regex experience by ensuring you can use standard regex syntax everywhere. The UI will now automatically convert your patterns into the backend-compatible format when saving, and convert them back when loading the form.
This ensures that what you test in the Pattern Tester is exactly what you see and edit in the form, without having to worry about syntax differences under the hood.