### PR TITLE
chore: optimize docker build and add gzip middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nano \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies from pyproject.toml (single source of truth)
-COPY pyproject.toml ./
-RUN python -c "import tomllib; deps=tomllib.load(open('pyproject.toml','rb'))['project']['dependencies']; print('\n'.join(deps))" \
-    | pip install --no-cache-dir -r /dev/stdin
+# Copy uv binary from official image
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Install Python dependencies deterministically using uv.lock
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project --no-cache
+
+# Make the virtual environment the default Python
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Copy application code
 COPY teamarr/ ./teamarr/

--- a/teamarr/api/app.py
+++ b/teamarr/api/app.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -311,6 +312,9 @@ def create_app() -> FastAPI:
         openapi_url="/openapi.json",
         lifespan=lifespan,
     )
+
+    # Add gzip compression for large responses
+    app.add_middleware(GZipMiddleware, minimum_size=1000)
 
     # Include API routers
     app.include_router(health.router, tags=["Health"])


### PR DESCRIPTION
use UV in the docker compose for deterministic builds
add on the fly gzip compression to the EPG output