### PR TITLE
Introduce a  fallback mechanism using stream's localized country names to determine the correct language channel 

### DIFF
--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -636,6 +636,11 @@ class ChannelLifecycleService:
                             stream_name, conn
                         )
 
+                        # Fallback to language of country name if no explicit hint was found
+                        if matched_keyword is None and outcome.country_language:
+                            matched_keyword = outcome.country_language
+                            keyword_behavior = "separate"
+
                         # V1 Parity: If behavior is 'ignore', skip stream entirely
                         # This must happen BEFORE any channel lookup/creation
                         if keyword_behavior == "ignore":

--- a/teamarr/consumers/matching/country_resolver.py
+++ b/teamarr/consumers/matching/country_resolver.py
@@ -44,50 +44,50 @@ _LOCALES = [
 # Hardcoded supplement for FIFA members that are NOT sovereign ISO 3166 states,
 # plus ESPN spelling quirks. Keys are unidecode-normalised lowercase.
 # Values are the exact team_name string ESPN uses.
-_FIFA_OVERRIDES: dict[str, str] = {
+_FIFA_OVERRIDES: dict[str, tuple[str, str | None]] = {
     # Home nations (part of GB in ISO 3166, compete separately in FIFA)
-    "scotland": "Scotland",
-    "escocia": "Scotland",
-    "schottland": "Scotland",
-    "ecosse": "Scotland",  # French "Écosse" → unidecoded
-    "scozia": "Scotland",
-    "skocia": "Scotland",
-    "england": "England",
-    "inglaterra": "England",
-    "angleterre": "England",
-    "inghilterra": "England",
-    "engeland": "England",
-    "wales": "Wales",
-    "gales": "Wales",
-    "pays de galles": "Wales",
-    "galles": "Wales",
-    "cymru": "Wales",
-    "kymry": "Wales",
-    "northern ireland": "Northern Ireland",
-    "irlanda del norte": "Northern Ireland",
-    "irlande du nord": "Northern Ireland",
-    "nordirland": "Northern Ireland",
-    "irlanda del nord": "Northern Ireland",
+    "scotland": ("Scotland", "English"),
+    "escocia": ("Scotland", "Spanish"),
+    "schottland": ("Scotland", "German"),
+    "ecosse": ("Scotland", "French"),  # French "Écosse" → unidecoded
+    "scozia": ("Scotland", "Italian"),
+    "skocia": ("Scotland", "Albanian"),
+    "england": ("England", "English"),
+    "inglaterra": ("England", "Spanish"),
+    "angleterre": ("England", "French"),
+    "inghilterra": ("England", "Italian"),
+    "engeland": ("England", "Dutch"),
+    "wales": ("Wales", "English"),
+    "gales": ("Wales", "Spanish"),
+    "pays de galles": ("Wales", "French"),
+    "galles": ("Wales", "Italian"),
+    "cymru": ("Wales", "Welsh"),
+    "kymry": ("Wales", "Welsh"),
+    "northern ireland": ("Northern Ireland", "English"),
+    "irlanda del norte": ("Northern Ireland", "Spanish"),
+    "irlande du nord": ("Northern Ireland", "French"),
+    "nordirland": ("Northern Ireland", "German"),
+    "irlanda del nord": ("Northern Ireland", "Italian"),
     # ESPN uses "Türkiye" (new official English spelling since 2022)
-    "turkey": "Türkiye",
-    "turquie": "Türkiye",
-    "turkei": "Türkiye",  # German "Türkei" → unidecoded
-    "turchia": "Türkiye",
-    "turkije": "Türkiye",
-    "turquia": "Türkiye",  # Spanish "Turquía" → unidecoded
-    "turquía": "Türkiye",  # keep accented form too (resolved via unidecode at lookup)
+    "turkey": ("Türkiye", "English"),
+    "turquie": ("Türkiye", "French"),
+    "turkei": ("Türkiye", "German"),  # German "Türkei" → unidecoded
+    "turchia": ("Türkiye", "Italian"),
+    "turkije": ("Türkiye", "Dutch"),
+    "turquia": ("Türkiye", "Spanish"),  # Spanish "Turquía" → unidecoded
+    "turquía": ("Türkiye", "Spanish"),  # keep accented form too (resolved via unidecode at lookup)
     # Kosovo (FIFA member since 2016, not universally recognised)
-    "kosovo": "Kosovo",
-    "cossovo": "Kosovo",
+    "kosovo": ("Kosovo", None),
+    "cossovo": ("Kosovo", "Portuguese"),
     # Palestine (FIFA member)
-    "palestine": "Palestine",
-    "palestina": "Palestine",
-    "palastina": "Palestine",  # German "Palästina" → unidecoded
-    "palestaine": "Palestine",
+    "palestine": ("Palestine", "English"),
+    "palestina": ("Palestine", "Spanish"),
+    "palastina": ("Palestine", "German"),  # German "Palästina" → unidecoded
+    "palestaine": ("Palestine", "Arabic"),
     # Taiwan (FIFA uses "Chinese Taipei")
-    "taiwan": "Chinese Taipei",
-    "chinese taipei": "Chinese Taipei",
-    "taipei chinos": "Chinese Taipei",
+    "taiwan": ("Chinese Taipei", "English"),
+    "chinese taipei": ("Chinese Taipei", "English"),
+    "taipei chinos": ("Chinese Taipei", "Spanish"),
 }
 
 
@@ -120,6 +120,7 @@ class CountryNameResolver:
 
     def __init__(self) -> None:
         self._map: dict[str, str] = {}
+        self._lang_map: dict[str, str] = {}
         self._build()
         logger.debug(
             "[COUNTRY] Country name resolver built: %d entries across %d locales",
@@ -141,6 +142,17 @@ class CountryNameResolver:
         """
         return self._map.get(_normalize(name))
 
+    def resolve_language(self, name: str) -> str | None:
+        """Resolve a name to the language of its country.
+
+        Args:
+            name: Team name as extracted from stream (any language/case/accents)
+
+        Returns:
+            English name of the language (e.g. "Spanish"), or None if not recognised.
+        """
+        return self._lang_map.get(_normalize(name))
+
     def _build(self) -> None:
         """Build the locale-aware name → canonical mapping."""
         try:
@@ -154,7 +166,11 @@ class CountryNameResolver:
                 "Install pycountry and babel to enable."
             )
             # Still load the FIFA overrides which need no extra deps
-            self._map.update({_normalize(k): _normalize(v) for k, v in _FIFA_OVERRIDES.items()})
+            for k, (v, lang) in _FIFA_OVERRIDES.items():
+                norm_k = _normalize(k)
+                self._map[norm_k] = _normalize(v)
+                if lang:
+                    self._lang_map[norm_k] = lang
             return
 
         # Build locale objects up front (skip bad locale codes silently)
@@ -184,7 +200,14 @@ class CountryNameResolver:
             for locale in locales:
                 localized = locale.territories.get(country.alpha_2)
                 if localized:
-                    self._map[_normalize(localized)] = canonical
+                    norm_loc = _normalize(localized)
+                    self._map[norm_loc] = canonical
+                    # Store the English name of the language (e.g., "Spanish")
+                    self._lang_map[norm_loc] = locale.english_name
 
         # FIFA overrides win over the pycountry defaults (e.g. "turkey" → "turkiye")
-        self._map.update({_normalize(k): _normalize(v) for k, v in _FIFA_OVERRIDES.items()})
+        for k, (v, lang) in _FIFA_OVERRIDES.items():
+            norm_k = _normalize(k)
+            self._map[norm_k] = _normalize(v)
+            if lang and norm_k not in self._lang_map:
+                self._lang_map[norm_k] = lang

--- a/teamarr/consumers/matching/result.py
+++ b/teamarr/consumers/matching/result.py
@@ -210,6 +210,9 @@ class MatchOutcome:
     found_league: str | None = None
     found_league_name: str | None = None
 
+    # Extracted country language fallback (if matched via localized country name)
+    country_language: str | None = None
+
     @classmethod
     def filtered(
         cls,
@@ -265,6 +268,7 @@ class MatchOutcome:
         origin_match_method: str | None = None,
         epg_program_start: datetime | None = None,
         epg_program_end: datetime | None = None,
+        country_language: str | None = None,
     ) -> "MatchOutcome":
         """Create a MATCHED result.
 
@@ -294,6 +298,7 @@ class MatchOutcome:
             origin_match_method=origin_match_method,
             epg_program_start=epg_program_start,
             epg_program_end=epg_program_end,
+            country_language=country_language,
         )
 
     @classmethod
@@ -330,6 +335,7 @@ class MatchOutcome:
             origin_match_method=matched_outcome.origin_match_method,
             found_league=found_league,
             found_league_name=found_league_name,
+            country_language=matched_outcome.country_language,
         )
 
     @property

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -394,6 +394,16 @@ class TeamMatcher:
             if retry_result and retry_result.is_matched:
                 result = retry_result
 
+        # Try to resolve country language if not already set and we have a match
+        if result.is_matched and result.country_language is None:
+            lang = None
+            if ctx.team1:
+                lang = self._country_resolver.resolve_language(ctx.team1)
+            if not lang and ctx.team2:
+                lang = self._country_resolver.resolve_language(ctx.team2)
+            if lang:
+                result.country_language = lang
+
         # Cache successful matches
         if result.is_matched and result.event:
             self._cache_result(ctx, result)
@@ -541,6 +551,13 @@ class TeamMatcher:
             ))
 
         if matched_outcomes:
+            # Try to resolve country language
+            lang = None
+            if classified.team1:
+                lang = self._country_resolver.resolve_language(classified.team1)
+            if lang:
+                for outcome in matched_outcomes:
+                    outcome.country_language = lang
             return matched_outcomes
 
         return [MatchOutcome.failed(


### PR DESCRIPTION
# Details
- Extends `CountryNameResolver` to natively capture the language corresponding to localized country names using the `pycountry` and `babel` locales.
- Extends the hardcoded `_FIFA_OVERRIDES` map to provide language fallbacks for Home Nations (e.g., Scotland, Wales) that are not considered sovereign ISO 3166 states.

# Examples
- A stream named `Peacock 06: Catar v. Suiza` has no language tag. The system matches "Suiza" through the `es` locale, resolving the language to "Spanish". It will then automatically flag and add the stream to the Spanish channel.
-  An explicitly tagged stream like `Qatar vs Suiza FHD (ENG)` continues to behave exactly as it did before. The explicit `(ENG)` exception keyword takes precedence and stops the fallback mechanism from triggering.