### PR TITLE
add fuzzy matching for event cards

### DIFF
--- a/teamarr/consumers/matching/event_matcher.py
+++ b/teamarr/consumers/matching/event_matcher.py
@@ -206,6 +206,7 @@ class EventCardMatcher:
 
         # Strategy 1: Match by event number (UFC 315)
         # Uses word-boundary matching to avoid "UFC 32" matching "UFC 325"
+        event_num = None
         if event_hint:
             event_num = self._extract_event_number(event_hint)
             if event_num:
@@ -291,6 +292,47 @@ class EventCardMatcher:
                     return MatchOutcome.matched(
                         MatchMethod.FUZZY,
                         event,
+                        detected_league=league,
+                        confidence=confidence,
+                        stream_name=ctx.stream_name,
+                        stream_id=ctx.stream_id,
+                    )
+
+        # Strategy 3: Fuzzy event name matching
+        # For named events without standard numbers (e.g., "UFC at the White House", "UFC Freedom 250")
+        if not event_num:
+            stream_norm = normalize_text(ctx.stream_name)
+            # Remove common generic/noise words to ensure the stream has a distinct name
+            stream_norm_clean = re.sub(
+                r'\b(ufc|mma|boxing|prelims|main card|early prelims|live|event|ppv|pm|am|et|pt|ct|mt)\b', 
+                '', 
+                stream_norm
+            ).strip()
+
+            if stream_norm_clean and len(stream_norm_clean) > 3:
+                best_score = 0
+                best_event = None
+
+                for event in events:
+                    event_norm = normalize_text(event.name)
+                    # Use partial_token_set_ratio because the stream name might contain extra words (e.g. "live event 01")
+                    # and the API name might contain extra words (e.g. "UFC Freedom 250: Topuria vs Gaethje")
+                    score = fuzz.partial_token_set_ratio(stream_norm, event_norm)
+                    if score > best_score:
+                        best_score = score
+                        best_event = event
+
+                if best_score >= FIGHTER_MATCH_THRESHOLD and best_event:
+                    confidence = best_score / 100.0
+                    logger.debug(
+                        "[MATCHED] event_card stream=%s -> %s (method=fuzzy_event_name, score=%d)",
+                        ctx.stream_name[:40],
+                        best_event.name,
+                        best_score,
+                    )
+                    return MatchOutcome.matched(
+                        MatchMethod.FUZZY,
+                        best_event,
                         detected_league=league,
                         confidence=confidence,
                         stream_name=ctx.stream_name,


### PR DESCRIPTION
This PR improves the event matching logic for combat sports (UFC, Boxing, MMA) to better handle "named" events that lack a standard numbered format. Adds fuzzy matching as strategy 3
