### PR TITLE
Stream stats caching, stat-based ordering, and expandable channel streams

### DIFF
--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -162,3 +162,23 @@ export async function previewResetChannels(): Promise<ResetPreviewResponse> {
 export async function executeResetChannels(): Promise<ResetExecuteResponse> {
   return api.post("/channels/reset", {})
 }
+
+export interface ChannelStreamEntry {
+  dispatcharr_stream_id: number
+  stream_name: string | null
+  source_group: string | null
+  m3u_account_name: string | null
+  match_method: string | null
+  priority: number
+  stream_stats: Record<string, unknown> | null
+  stream_stats_updated_at: string | null
+}
+
+export interface ChannelStreamsResponse {
+  streams: ChannelStreamEntry[]
+  stats_refreshed: boolean
+}
+
+export async function getChannelStreams(channelId: number): Promise<ChannelStreamsResponse> {
+  return api.get(`/channels/managed/${channelId}/streams`)
+}

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -185,8 +185,16 @@ export interface ChannelStreamEntry {
   matched_event: string | null
   matched_league: string | null
   cache_match_method: string | null
+  cache_created_at: string | null
+  match_aliases: StreamNameMatch[]
+  match_patterns: StreamNameMatch[]
   user_corrected: boolean
   corrected_at: string | null
+}
+
+export interface StreamNameMatch {
+  text: string
+  team: string
 }
 
 export interface ChannelStreamsResponse {

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -163,6 +163,13 @@ export async function executeResetChannels(): Promise<ResetExecuteResponse> {
   return api.post("/channels/reset", {})
 }
 
+export interface StreamRuleMatch {
+  type: string
+  value: string
+  priority: number
+  is_winner: boolean
+}
+
 export interface ChannelStreamEntry {
   dispatcharr_stream_id: number
   stream_name: string | null
@@ -172,6 +179,7 @@ export interface ChannelStreamEntry {
   priority: number
   stream_stats: Record<string, unknown> | null
   stream_stats_updated_at: string | null
+  matched_rules: StreamRuleMatch[]
 }
 
 export interface ChannelStreamsResponse {

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -176,10 +176,17 @@ export interface ChannelStreamEntry {
   source_group: string | null
   m3u_account_name: string | null
   match_method: string | null
+  match_type: string | null
+  exception_keyword: string | null
   priority: number
   stream_stats: Record<string, unknown> | null
   stream_stats_updated_at: string | null
   matched_rules: StreamRuleMatch[]
+  matched_event: string | null
+  matched_league: string | null
+  cache_match_method: string | null
+  user_corrected: boolean
+  corrected_at: string | null
 }
 
 export interface ChannelStreamsResponse {

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -138,7 +138,7 @@ export interface ChannelNumberingSettingsUpdate {
 }
 
 export interface StreamOrderingRule {
-  type: "m3u" | "group" | "regex" | "stream_type" | "team_feed" | "not_team_feed" | "epg_match" | "dispatcharr_group" | "catch_all"
+  type: "m3u" | "group" | "regex" | "stream_type" | "team_feed" | "not_team_feed" | "epg_match" | "dispatcharr_group" | "stats_metric" | "catch_all"
   value: string
   priority: number  // 1-99, lower = higher priority
 }

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useRef, useEffect } from "react"
 import { toast } from "sonner"
 import { CollapsibleSection } from "@/components/ui/collapsible-section"
 import { Alert } from "@/components/ui/alert"
+import { RichTooltip } from "@/components/ui/rich-tooltip"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   Trash2,
@@ -14,6 +15,7 @@ import {
   X,
   ChevronRight,
   ChevronDown,
+  Info,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -194,7 +196,7 @@ function PriorityCell({ priority, rules }: { priority: number; rules: StreamRule
                 key={i}
                 className={`flex items-center gap-1.5 rounded px-1 py-0.5 ${
                   r.is_winner ? "bg-primary/10" : ""
-                }`}
+                } ${r.type === "catch_all" && !r.is_winner ? "opacity-50" : ""}`}
               >
                 <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
                   {r.priority}
@@ -853,8 +855,18 @@ export function ManagedChannelsTable() {
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Group</th>
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Account</th>
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Method</th>
-                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-2">Priority</th>
-                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5">Stats</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-2">Order</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5">
+                                  <span className="inline-flex items-center gap-1">
+                                    Stats
+                                    <RichTooltip
+                                      content="External stream stats (resolution, bitrate, fps, etc.) populated by Dispatcharr's stream probe. Only present once Dispatcharr has probed the stream."
+                                      side="top"
+                                    >
+                                      <Info className="h-3 w-3 text-muted-foreground/50 cursor-help shrink-0" />
+                                    </RichTooltip>
+                                  </span>
+                                </th>
                               </tr>
                             </thead>
                             <tbody>

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -146,13 +146,13 @@ const RULE_TYPE_LABELS: Record<string, string> = {
   catch_all: "Everything else",
 }
 
-// Clickable priority number → compact popover explaining which ordering rules
-// matched the stream, with the winning rule (the one that set the priority)
-// highlighted. Mirrors the click-popover pattern used by StatsMetricBuilder.
-function PriorityCell({ priority, rules }: { priority: number; rules: StreamRuleMatch[] }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
+// Close a popover on outside-click / Escape. Shared by the click-popovers below
+// (same behavior as StatsMetricBuilder's dropdown).
+function useOutsideDismiss(
+  ref: React.RefObject<HTMLElement | null>,
+  open: boolean,
+  setOpen: (v: boolean) => void,
+) {
   useEffect(() => {
     if (!open) return
     const onMouseDown = (e: MouseEvent) => {
@@ -165,7 +165,16 @@ function PriorityCell({ priority, rules }: { priority: number; rules: StreamRule
       document.removeEventListener("mousedown", onMouseDown)
       document.removeEventListener("keydown", onKeyDown)
     }
-  }, [open])
+  }, [ref, open, setOpen])
+}
+
+// Clickable priority number → compact popover explaining which ordering rules
+// matched the stream, with the winning rule (the one that set the priority)
+// highlighted.
+function PriorityCell({ priority, rules }: { priority: number; rules: StreamRuleMatch[] }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  useOutsideDismiss(ref, open, setOpen)
 
   if (rules.length === 0) {
     return <span className="text-muted-foreground">{priority}</span>
@@ -194,27 +203,113 @@ function PriorityCell({ priority, rules }: { priority: number; rules: StreamRule
             {ordered.map((r, i) => (
               <div
                 key={i}
-                className={`flex items-center gap-1.5 rounded px-1 py-0.5 ${
+                className={`flex items-start gap-1.5 rounded px-1 py-0.5 ${
                   r.is_winner ? "bg-primary/10" : ""
                 } ${r.type === "catch_all" && !r.is_winner ? "opacity-50" : ""}`}
               >
-                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                <span className="shrink-0 font-mono text-[11px] leading-5 tabular-nums text-muted-foreground">
                   {r.priority}
                 </span>
                 <span className="min-w-0 flex-1">
-                  <span className="text-[11px] font-medium">{RULE_TYPE_LABELS[r.type] ?? r.type}</span>
+                  {/* Name shares a line with the number (and badge); subtitle drops below. */}
+                  <span className="flex items-center gap-1.5">
+                    <span className="text-[11px] font-medium leading-5 truncate">
+                      {RULE_TYPE_LABELS[r.type] ?? r.type}
+                    </span>
+                    {r.is_winner && (
+                      <Badge variant="info" className="shrink-0 text-[9px] px-1 py-0">applied</Badge>
+                    )}
+                  </span>
                   {r.value && (
                     <span className="block truncate font-mono text-[10px] text-muted-foreground" title={r.value}>
                       {r.value}
                     </span>
                   )}
                 </span>
-                {r.is_winner && (
-                  <Badge variant="info" className="shrink-0 text-[9px] px-1 py-0">applied</Badge>
-                )}
               </div>
             ))}
           </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const METHOD_INFO: Record<string, { label: string; desc: string }> = {
+  epg: { label: "EPG", desc: "Matched via Dispatcharr's program guide (program title / sub-title)." },
+  fuzzy: { label: "Fuzzy", desc: "Matched by fuzzy comparison of the stream name to the event." },
+  exact: { label: "Exact", desc: "Exact name match." },
+  cache: { label: "Cache", desc: "Reused a previously cached match for this stream." },
+  alias: { label: "Alias", desc: "Matched via a user-defined team alias." },
+  pattern: { label: "Pattern", desc: "Matched via a team-name pattern." },
+  keyword: { label: "Keyword", desc: "Matched via an event keyword (e.g. UFC / boxing cards)." },
+  user_corrected: { label: "Pinned", desc: "Manually corrected by you — pinned, never auto-rematched." },
+  no_match: { label: "No match", desc: "No event matched this stream." },
+}
+
+// Clickable match-method badge → popover explaining how/why the stream matched
+// its event. Combines fields always on the stream (method, type, exception
+// keyword) with cache-derived detail (matched event, user correction) that's
+// only present for fingerprint-cached matches.
+function MethodCell({ stream }: { stream: ChannelStreamEntry }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  useOutsideDismiss(ref, open, setOpen)
+
+  const badge = getMatchMethodBadge(stream.match_method)
+  if (!badge) return <span className="text-muted-foreground">—</span>
+
+  const info = stream.match_method ? METHOD_INFO[stream.match_method] : undefined
+  // The finer cache method only adds value when it differs from the badge method.
+  const finer =
+    stream.cache_match_method && stream.cache_match_method !== stream.match_method
+      ? METHOD_INFO[stream.cache_match_method] ?? { label: stream.cache_match_method, desc: "" }
+      : undefined
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button onClick={() => setOpen((v) => !v)} title="Show match details" className="cursor-pointer">
+        {badge}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover p-2 shadow-lg space-y-1.5">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+            Match details
+          </div>
+          <div>
+            <span className="text-[11px] font-medium">{info?.label ?? stream.match_method}</span>
+            {info?.desc && <p className="text-[10px] text-muted-foreground leading-snug">{info.desc}</p>}
+          </div>
+          {finer && (
+            <div className="text-[10px] text-muted-foreground">
+              Cache method: <span className="font-medium text-foreground">{finer.label}</span>
+            </div>
+          )}
+          {stream.matched_event && (
+            <div className="text-[10px] text-muted-foreground">
+              Matched event:{" "}
+              <span className="font-medium text-foreground">{stream.matched_event}</span>
+              {stream.matched_league && <span className="uppercase"> ({stream.matched_league})</span>}
+            </div>
+          )}
+          {stream.match_type && (
+            <div className="text-[10px] text-muted-foreground">
+              Type: <span className="font-medium text-foreground">{stream.match_type === "team" ? "Team" : "Event"}</span>
+            </div>
+          )}
+          {stream.exception_keyword && (
+            <div className="text-[10px] text-muted-foreground">
+              Keyword: <span className="font-mono text-foreground">{stream.exception_keyword}</span>
+            </div>
+          )}
+          {stream.user_corrected && (
+            <div className="flex items-center gap-1.5">
+              <Badge variant="info" className="text-[9px] px-1 py-0">pinned</Badge>
+              <span className="text-[10px] text-muted-foreground">
+                Corrected by you{stream.corrected_at ? ` ${formatRelativeTime(stream.corrected_at)}` : ""}
+              </span>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -855,7 +950,7 @@ export function ManagedChannelsTable() {
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Group</th>
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Account</th>
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Method</th>
-                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-2">Order</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-2">Sort</th>
                                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5">
                                   <span className="inline-flex items-center gap-1">
                                     Stats
@@ -875,7 +970,7 @@ export function ManagedChannelsTable() {
                                   <td className="py-1 pr-4 font-medium">{stream.stream_name ?? `#${stream.dispatcharr_stream_id}`}</td>
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.source_group ?? "—"}</td>
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.m3u_account_name ?? "—"}</td>
-                                  <td className="py-1 pr-4">{getMatchMethodBadge(stream.match_method)}</td>
+                                  <td className="py-1 pr-4"><MethodCell stream={stream} /></td>
                                   <td className="py-1 pr-4"><PriorityCell priority={stream.priority} rules={stream.matched_rules} /></td>
                                   <td className="py-1"><StreamStatsBadges stats={stream.stream_stats} /></td>
                                 </tr>

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import React, { useState, useMemo } from "react"
 import { toast } from "sonner"
 import { CollapsibleSection } from "@/components/ui/collapsible-section"
 import { Alert } from "@/components/ui/alert"
@@ -12,9 +12,11 @@ import {
   Search,
   AlertTriangle,
   X,
+  ChevronRight,
+  ChevronDown,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
@@ -49,8 +51,9 @@ import {
   deleteManagedChannel,
   previewResetChannels,
   executeResetChannels,
+  getChannelStreams,
 } from "@/api/channels"
-import type { ManagedChannel, ResetChannelInfo } from "@/api/channels"
+import type { ManagedChannel, ResetChannelInfo, ChannelStreamEntry } from "@/api/channels"
 import { getLeagueDisplayName, getSportDisplayName } from "@/lib/utils"
 import { useSports } from "@/hooks/useSports"
 
@@ -81,6 +84,53 @@ function formatRelativeTime(dateStr: string | null): string {
   return formatDateTime(dateStr)
 }
 
+function StreamStatsBadges({ stats }: { stats: Record<string, unknown> | null }) {
+  if (!stats) return <span className="text-muted-foreground">—</span>
+
+  const chip = (content: React.ReactNode) => (
+    <span className="inline-flex rounded px-1.5 py-0.5 bg-muted text-[11px] font-mono leading-none text-muted-foreground">
+      {content}
+    </span>
+  )
+
+  const chips: React.ReactNode[] = []
+
+  const resolution = stats.resolution as string | undefined
+  if (resolution && resolution.includes("x")) {
+    chips.push(chip(resolution.replace("x", "×")))
+  }
+
+  const fps = stats.source_fps as number | undefined
+  if (fps != null) chips.push(chip(`${fps}fps`))
+
+  const bitrate = stats.ffmpeg_output_bitrate as number | undefined
+  if (bitrate != null) chips.push(chip(bitrate >= 1000 ? `${(bitrate / 1000).toFixed(1)} Mbps` : `${bitrate} kbps`))
+
+  const audioBitrate = stats.audio_bitrate as number | undefined
+  if (audioBitrate != null) chips.push(chip(`${audioBitrate} kbps audio`))
+
+  const sampleRate = stats.sample_rate as number | undefined
+  if (sampleRate != null) chips.push(chip(`${(sampleRate / 1000).toFixed(0)} kHz`))
+
+  if (chips.length === 0) return <span className="text-muted-foreground">—</span>
+
+  return <div className="flex flex-wrap gap-1 items-center">{chips.map((c, i) => <React.Fragment key={i}>{c}</React.Fragment>)}</div>
+}
+
+function getMatchMethodBadge(method: string | null) {
+  if (!method) return null
+  switch (method) {
+    case "epg":
+      return <Badge variant="info" className="text-xs">EPG</Badge>
+    case "fuzzy":
+      return <Badge variant="secondary" className="text-xs">Fuzzy</Badge>
+    case "exact":
+      return <Badge variant="outline" className="text-xs">Exact</Badge>
+    default:
+      return <Badge variant="outline" className="text-xs">{method}</Badge>
+  }
+}
+
 function getSyncStatusBadge(status: string) {
   switch (status) {
     case "in_sync":
@@ -106,6 +156,11 @@ export function ManagedChannelsTable() {
   const [sportFilter, setSportFilter] = useState<string>("")
   const [leagueFilter, setLeagueFilter] = useState<string>("")
   const [statusFilter, setStatusFilter] = useState<string>("")
+
+  // Expand states
+  const [expandedChannels, setExpandedChannels] = useState<Set<number>>(new Set())
+  const [channelStreams, setChannelStreams] = useState<Map<number, ChannelStreamEntry[]>>(new Map())
+  const [loadingStreams, setLoadingStreams] = useState<Set<number>>(new Set())
 
   // UI states
   const [deleteConfirm, setDeleteConfirm] = useState<ManagedChannel | null>(null)
@@ -262,6 +317,28 @@ export function ManagedChannelsTable() {
     },
   })
 
+  const handleToggleExpand = async (channelId: number) => {
+    const next = new Set(expandedChannels)
+    if (next.has(channelId)) {
+      next.delete(channelId)
+      setExpandedChannels(next)
+      return
+    }
+    next.add(channelId)
+    setExpandedChannels(next)
+    if (!channelStreams.has(channelId)) {
+      setLoadingStreams((prev) => new Set(prev).add(channelId))
+      try {
+        const data = await getChannelStreams(channelId)
+        setChannelStreams((prev) => new Map(prev).set(channelId, data.streams))
+      } catch {
+        setChannelStreams((prev) => new Map(prev).set(channelId, []))
+      } finally {
+        setLoadingStreams((prev) => { const s = new Set(prev); s.delete(channelId); return s })
+      }
+    }
+  }
+
   const handleDelete = async () => {
     if (!deleteConfirm) return
     try {
@@ -400,7 +477,11 @@ export function ManagedChannelsTable() {
       <CollapsibleSection
         title="Managed Channels"
         icon={<Tv className="h-5 w-5 text-muted-foreground" />}
-        count={`(${channelsData?.channels.length ?? 0})`}
+        count={
+          filteredChannels.length !== (channelsData?.channels.length ?? 0)
+            ? `(${filteredChannels.length} of ${channelsData?.channels.length ?? 0})`
+            : `(${channelsData?.channels.length ?? 0})`
+        }
         persistKey="channels.active"
       >
 
@@ -478,20 +559,6 @@ export function ManagedChannelsTable() {
       )}
 
       {/* Channels List */}
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2">
-            <Tv className="h-5 w-5" />
-            Channels ({filteredChannels.length}
-            {filteredChannels.length !== (channelsData?.channels.length ?? 0) && (
-              <span className="text-muted-foreground font-normal">
-                {" "}of {channelsData?.channels.length ?? 0}
-              </span>
-            )}
-            )
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
           {isLoading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -501,9 +568,10 @@ export function ManagedChannelsTable() {
               No managed channels found.
             </div>
           ) : (
-            <Table className="table-fixed">
+            <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead className="w-8"></TableHead>
                   <TableHead className="w-10">
                     <Checkbox
                       checked={isAllSelected}
@@ -520,6 +588,7 @@ export function ManagedChannelsTable() {
                 </TableRow>
                 {/* Filter row */}
                 <TableRow className="border-b-2 border-border">
+                  <TableHead className="py-0.5 pb-1.5"></TableHead>
                   <TableHead className="py-0.5 pb-1.5"></TableHead>
                   <TableHead className="py-0.5 pb-1.5">
                     <div className="relative">
@@ -581,12 +650,24 @@ export function ManagedChannelsTable() {
               <TableBody>
                 {filteredChannels.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                    <TableCell colSpan={9} className="text-center py-8 text-muted-foreground">
                       No channels match the current filters.
                     </TableCell>
                   </TableRow>
                 ) : filteredChannels.map((channel) => (
-                  <TableRow key={channel.id}>
+                  <React.Fragment key={channel.id}>
+                  <TableRow className={expandedChannels.has(channel.id) ? "border-b-0" : ""}>
+                    <TableCell className="px-1">
+                      <button
+                        onClick={() => handleToggleExpand(channel.id)}
+                        className="flex items-center justify-center w-6 h-6 text-muted-foreground hover:text-foreground"
+                        aria-label={expandedChannels.has(channel.id) ? "Collapse" : "Expand"}
+                      >
+                        {expandedChannels.has(channel.id)
+                          ? <ChevronDown className="h-4 w-4" />
+                          : <ChevronRight className="h-4 w-4" />}
+                      </button>
+                    </TableCell>
                     <TableCell>
                       <Checkbox
                         checked={selectedIds.has(channel.id)}
@@ -654,12 +735,60 @@ export function ManagedChannelsTable() {
                       </div>
                     </TableCell>
                   </TableRow>
+                  {expandedChannels.has(channel.id) && (
+                    <TableRow className="hover:bg-transparent border-b border-border/40">
+                      <TableCell colSpan={9} className="p-0 pb-2">
+                        <div className="ml-4 border-l-2 border-border/50 pl-2 pr-4 pt-2">
+                        {loadingStreams.has(channel.id) ? (
+                          <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                            Loading streams…
+                          </div>
+                        ) : (channelStreams.get(channel.id) ?? []).length === 0 ? (
+                          <p className="text-xs text-muted-foreground py-1">No active streams.</p>
+                        ) : (
+                          <table className="w-full text-xs">
+                            <colgroup>
+                              <col className="w-[28%]" />
+                              <col className="w-[18%]" />
+                              <col className="w-[16%]" />
+                              <col className="w-[10%]" />
+                              <col className="w-[6%]" />
+                              <col className="w-[22%]" />
+                            </colgroup>
+                            <thead>
+                              <tr>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Stream</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Group</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Account</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-4">Method</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5 pr-2">Priority</th>
+                                <th className="text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 pb-1.5">Stats</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {(channelStreams.get(channel.id) ?? []).map((stream) => (
+                                <tr key={stream.dispatcharr_stream_id} className="border-t border-border/30">
+                                  <td className="py-1 pr-4 font-medium">{stream.stream_name ?? `#${stream.dispatcharr_stream_id}`}</td>
+                                  <td className="py-1 pr-4 text-muted-foreground">{stream.source_group ?? "—"}</td>
+                                  <td className="py-1 pr-4 text-muted-foreground">{stream.m3u_account_name ?? "—"}</td>
+                                  <td className="py-1 pr-4">{getMatchMethodBadge(stream.match_method)}</td>
+                                  <td className="py-1 pr-4 text-muted-foreground">{stream.priority}</td>
+                                  <td className="py-1"><StreamStatsBadges stats={stream.stream_stats} /></td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  </React.Fragment>
                 ))}
               </TableBody>
             </Table>
           )}
-        </CardContent>
-      </Card>
 
       </CollapsibleSection>
 

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react"
+import React, { useState, useMemo, useRef, useEffect } from "react"
 import { toast } from "sonner"
 import { CollapsibleSection } from "@/components/ui/collapsible-section"
 import { Alert } from "@/components/ui/alert"
@@ -53,7 +53,7 @@ import {
   executeResetChannels,
   getChannelStreams,
 } from "@/api/channels"
-import type { ManagedChannel, ResetChannelInfo, ChannelStreamEntry } from "@/api/channels"
+import type { ManagedChannel, ResetChannelInfo, ChannelStreamEntry, StreamRuleMatch } from "@/api/channels"
 import { getLeagueDisplayName, getSportDisplayName } from "@/lib/utils"
 import { useSports } from "@/hooks/useSports"
 
@@ -129,6 +129,94 @@ function getMatchMethodBadge(method: string | null) {
     default:
       return <Badge variant="outline" className="text-xs">{method}</Badge>
   }
+}
+
+const RULE_TYPE_LABELS: Record<string, string> = {
+  m3u: "M3U Account",
+  group: "Event Group",
+  regex: "Regex",
+  stream_type: "Stream Type",
+  team_feed: "Home/Away Feed",
+  not_team_feed: "Not Home/Away Feed",
+  epg_match: "EPG Match",
+  dispatcharr_group: "Dispatcharr Group",
+  stats_metric: "Stats Metric",
+  catch_all: "Everything else",
+}
+
+// Clickable priority number → compact popover explaining which ordering rules
+// matched the stream, with the winning rule (the one that set the priority)
+// highlighted. Mirrors the click-popover pattern used by StatsMetricBuilder.
+function PriorityCell({ priority, rules }: { priority: number; rules: StreamRuleMatch[] }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false) }
+    document.addEventListener("mousedown", onMouseDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open])
+
+  if (rules.length === 0) {
+    return <span className="text-muted-foreground">{priority}</span>
+  }
+
+  // Winners first, then by ascending rule priority.
+  const ordered = [...rules].sort(
+    (a, b) => Number(b.is_winner) - Number(a.is_winner) || a.priority - b.priority
+  )
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-foreground"
+        title="Show matched rules"
+      >
+        {priority}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-md border bg-popover p-1.5 shadow-lg">
+          <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+            Matched rules
+          </div>
+          <div className="space-y-0.5">
+            {ordered.map((r, i) => (
+              <div
+                key={i}
+                className={`flex items-center gap-1.5 rounded px-1 py-0.5 ${
+                  r.is_winner ? "bg-primary/10" : ""
+                }`}
+              >
+                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                  {r.priority}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="text-[11px] font-medium">{RULE_TYPE_LABELS[r.type] ?? r.type}</span>
+                  {r.value && (
+                    <span className="block truncate font-mono text-[10px] text-muted-foreground" title={r.value}>
+                      {r.value}
+                    </span>
+                  )}
+                </span>
+                {r.is_winner && (
+                  <Badge variant="info" className="shrink-0 text-[9px] px-1 py-0">applied</Badge>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
 }
 
 function getSyncStatusBadge(status: string) {
@@ -487,7 +575,7 @@ export function ManagedChannelsTable() {
 
       {/* Section actions — live inside the collapsible body so they only show
           when the section is expanded. */}
-      <div className="flex justify-end gap-2">
+      <div className="flex justify-end gap-2 mb-3">
         <Button
           variant="outline"
           size="sm"
@@ -585,6 +673,7 @@ export function ManagedChannelsTable() {
                   <TableHead className="w-20">Status</TableHead>
                   <TableHead className="w-24">Delete At</TableHead>
                   <TableHead className="w-16 text-right">Actions</TableHead>
+                  <TableHead className="w-6"></TableHead>
                 </TableRow>
                 {/* Filter row */}
                 <TableRow className="border-b-2 border-border">
@@ -645,12 +734,13 @@ export function ManagedChannelsTable() {
                   </TableHead>
                   <TableHead className="py-0.5 pb-1.5"></TableHead>
                   <TableHead className="py-0.5 pb-1.5"></TableHead>
+                  <TableHead className="py-0.5 pb-1.5"></TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filteredChannels.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={9} className="text-center py-8 text-muted-foreground">
+                    <TableCell colSpan={10} className="text-center py-8 text-muted-foreground">
                       No channels match the current filters.
                     </TableCell>
                   </TableRow>
@@ -734,10 +824,11 @@ export function ManagedChannelsTable() {
                         </Button>
                       </div>
                     </TableCell>
+                    <TableCell></TableCell>
                   </TableRow>
                   {expandedChannels.has(channel.id) && (
                     <TableRow className="hover:bg-transparent border-b border-border/40">
-                      <TableCell colSpan={9} className="p-0 pb-2">
+                      <TableCell colSpan={10} className="p-0 pb-2">
                         <div className="ml-4 border-l-2 border-border/50 pl-2 pr-4 pt-2">
                         {loadingStreams.has(channel.id) ? (
                           <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
@@ -773,7 +864,7 @@ export function ManagedChannelsTable() {
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.source_group ?? "—"}</td>
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.m3u_account_name ?? "—"}</td>
                                   <td className="py-1 pr-4">{getMatchMethodBadge(stream.match_method)}</td>
-                                  <td className="py-1 pr-4 text-muted-foreground">{stream.priority}</td>
+                                  <td className="py-1 pr-4"><PriorityCell priority={stream.priority} rules={stream.matched_rules} /></td>
                                   <td className="py-1"><StreamStatsBadges stats={stream.stream_stats} /></td>
                                 </tr>
                               ))}

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -58,6 +58,7 @@ import {
 import type { ManagedChannel, ResetChannelInfo, ChannelStreamEntry, StreamRuleMatch } from "@/api/channels"
 import { getLeagueDisplayName, getSportDisplayName } from "@/lib/utils"
 import { useSports } from "@/hooks/useSports"
+import { useGenerationProgress } from "@/contexts/GenerationContext"
 
 function formatDateTime(dateStr: string | null): string {
   if (!dateStr) return "-"
@@ -171,12 +172,15 @@ function useOutsideDismiss(
 // Clickable priority number → compact popover explaining which ordering rules
 // matched the stream, with the winning rule (the one that set the priority)
 // highlighted.
-function PriorityCell({ priority, rules }: { priority: number; rules: StreamRuleMatch[] }) {
+function PriorityCell(
+  { priority, rules, generating }: { priority: number; rules: StreamRuleMatch[]; generating: boolean },
+) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   useOutsideDismiss(ref, open, setOpen)
 
-  if (rules.length === 0) {
+  // Nothing to explain and not generating → just the number.
+  if (rules.length === 0 && !generating) {
     return <span className="text-muted-foreground">{priority}</span>
   }
 
@@ -185,20 +189,40 @@ function PriorityCell({ priority, rules }: { priority: number; rules: StreamRule
     (a, b) => Number(b.is_winner) - Number(a.is_winner) || a.priority - b.priority
   )
 
+  // The popover evaluates the CURRENT rules; the stored number is from the last
+  // generation run. If they disagree, the rules changed since this stream was
+  // ordered and the stored order is stale until the next run. While a generation
+  // is running the number is mid-update, so we show a spinner instead of flagging
+  // it stale.
+  const winner = ordered.find((r) => r.is_winner)
+  const stale = !generating && winner != null && winner.priority !== priority
+
   return (
     <div className="relative inline-block" ref={ref}>
       <button
         onClick={() => setOpen((v) => !v)}
-        className="text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-foreground"
-        title="Show matched rules"
+        className={`underline decoration-dotted underline-offset-2 ${
+          stale
+            ? "text-amber-500 decoration-amber-500 hover:text-amber-400"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+        title={
+          generating
+            ? "Generation in progress — priority is updating"
+            : stale
+              ? "Rules changed since last sync — click for details"
+              : "Show matched rules"
+        }
       >
-        {priority}
+        {generating ? <Loader2 className="h-3 w-3 animate-spin" /> : <>{priority}{stale && "*"}</>}
       </button>
       {open && (
         <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-md border bg-popover p-1.5 shadow-lg">
+          {rules.length > 0 && (
           <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
             Matched rules
           </div>
+          )}
           <div className="space-y-0.5">
             {ordered.map((r, i) => (
               <div
@@ -229,6 +253,16 @@ function PriorityCell({ priority, rules }: { priority: number; rules: StreamRule
               </div>
             ))}
           </div>
+          {generating ? (
+            <div className={`text-[10px] leading-snug text-muted-foreground ${rules.length > 0 ? "mt-1 border-t pt-1" : ""}`}>
+              Generation in progress — the order is updating.
+            </div>
+          ) : stale ? (
+            <div className="mt-1 border-t pt-1 text-[10px] leading-snug text-amber-500">
+              Rules changed since this stream was ordered (stored #{priority}). The order above
+              applies on the next generation run.
+            </div>
+          ) : null}
         </div>
       )}
     </div>
@@ -283,6 +317,22 @@ function MethodCell({ stream }: { stream: ChannelStreamEntry }) {
           {finer && (
             <div className="text-[10px] text-muted-foreground">
               Cache method: <span className="font-medium text-foreground">{finer.label}</span>
+            </div>
+          )}
+          {stream.cache_created_at && (
+            <div className="text-[10px] text-muted-foreground">
+              Cached {formatRelativeTime(stream.cache_created_at)}
+            </div>
+          )}
+          {[...stream.match_aliases, ...stream.match_patterns].length > 0 && (
+            <div className="text-[10px] text-muted-foreground">
+              {[...stream.match_aliases, ...stream.match_patterns].map((a, i) => (
+                <div key={i} className="flex items-center gap-1">
+                  <span className="font-mono text-foreground">{a.text}</span>
+                  <span className="text-muted-foreground/60">→</span>
+                  <span className="font-medium text-foreground truncate">{a.team}</span>
+                </div>
+              ))}
             </div>
           )}
           {stream.matched_event && (
@@ -346,6 +396,8 @@ export function ManagedChannelsTable() {
   const [expandedChannels, setExpandedChannels] = useState<Set<number>>(new Set())
   const [channelStreams, setChannelStreams] = useState<Map<number, ChannelStreamEntry[]>>(new Map())
   const [loadingStreams, setLoadingStreams] = useState<Set<number>>(new Set())
+
+  const { isGenerating } = useGenerationProgress()
 
   // UI states
   const [deleteConfirm, setDeleteConfirm] = useState<ManagedChannel | null>(null)
@@ -502,6 +554,19 @@ export function ManagedChannelsTable() {
     },
   })
 
+  // Fetch (or refetch) the stream detail for one channel into local state.
+  const fetchStreams = async (channelId: number) => {
+    setLoadingStreams((prev) => new Set(prev).add(channelId))
+    try {
+      const data = await getChannelStreams(channelId)
+      setChannelStreams((prev) => new Map(prev).set(channelId, data.streams))
+    } catch {
+      setChannelStreams((prev) => new Map(prev).set(channelId, []))
+    } finally {
+      setLoadingStreams((prev) => { const s = new Set(prev); s.delete(channelId); return s })
+    }
+  }
+
   const handleToggleExpand = async (channelId: number) => {
     const next = new Set(expandedChannels)
     if (next.has(channelId)) {
@@ -512,17 +577,24 @@ export function ManagedChannelsTable() {
     next.add(channelId)
     setExpandedChannels(next)
     if (!channelStreams.has(channelId)) {
-      setLoadingStreams((prev) => new Set(prev).add(channelId))
-      try {
-        const data = await getChannelStreams(channelId)
-        setChannelStreams((prev) => new Map(prev).set(channelId, data.streams))
-      } catch {
-        setChannelStreams((prev) => new Map(prev).set(channelId, []))
-      } finally {
-        setLoadingStreams((prev) => { const s = new Set(prev); s.delete(channelId); return s })
-      }
+      await fetchStreams(channelId)
     }
   }
+
+  // When a generation run finishes, stream priorities/membership may have
+  // changed. Refresh the channels list and any expanded stream tables so the
+  // priority spinners resolve to the new ordering.
+  const expandedRef = useRef(expandedChannels)
+  expandedRef.current = expandedChannels
+  const wasGeneratingRef = useRef(isGenerating)
+  useEffect(() => {
+    if (wasGeneratingRef.current && !isGenerating) {
+      queryClient.invalidateQueries({ queryKey: ["managedChannels"] })
+      expandedRef.current.forEach((id) => { void fetchStreams(id) })
+    }
+    wasGeneratingRef.current = isGenerating
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isGenerating])
 
   const handleDelete = async () => {
     if (!deleteConfirm) return
@@ -971,7 +1043,7 @@ export function ManagedChannelsTable() {
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.source_group ?? "—"}</td>
                                   <td className="py-1 pr-4 text-muted-foreground">{stream.m3u_account_name ?? "—"}</td>
                                   <td className="py-1 pr-4"><MethodCell stream={stream} /></td>
-                                  <td className="py-1 pr-4"><PriorityCell priority={stream.priority} rules={stream.matched_rules} /></td>
+                                  <td className="py-1 pr-4"><PriorityCell priority={stream.priority} rules={stream.matched_rules} generating={isGenerating} /></td>
                                   <td className="py-1"><StreamStatsBadges stats={stream.stream_stats} /></td>
                                 </tr>
                               ))}

--- a/frontend/src/components/StreamOrderingManager.tsx
+++ b/frontend/src/components/StreamOrderingManager.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner"
 import {
   Plus,
   Trash2,
+  X,
   Loader2,
   AlertCircle,
   ChevronDown,
@@ -272,6 +273,7 @@ const RULE_TYPES = [
   { value: "stream_type", label: "Stream Type", description: "Match by how the stream was recognized: event, team, or EPG-matched (time-shared linear)" },
   { value: "team_feed", label: "Home/Away Feed", description: "Match streams that appear to be a team's own broadcast (home or away feed) for any enabled team" },
   { value: "dispatcharr_group", label: "Dispatcharr Group", description: "Match channel-source streams by the Dispatcharr channel group you selected as an EPG source" },
+  { value: "stats_metric", label: "Stats Metric", description: "Match streams where a numeric stat (resolution, bitrate, fps) meets a threshold" },
 ] as const
 
 const STREAM_TYPE_OPTIONS = [
@@ -296,7 +298,7 @@ const NO_VALUE_TYPES = new Set(["team_feed", "not_team_feed", "epg_match", "catc
 // Mirrors backend VALID_RULE_TYPES (database/settings/types.py) — used to validate imports.
 const VALID_RULE_TYPES = new Set([
   "m3u", "group", "regex", "stream_type",
-  "team_feed", "not_team_feed", "epg_match", "dispatcharr_group", "catch_all",
+  "team_feed", "not_team_feed", "epg_match", "dispatcharr_group", "stats_metric", "catch_all",
 ])
 
 interface RuleFormData {
@@ -304,7 +306,7 @@ interface RuleFormData {
   // Without this, keying by array index causes focus to follow DOM position
   // instead of the rule, breaking double-digit priority entry (#198).
   _id: number
-  type: "m3u" | "group" | "regex" | "stream_type" | "team_feed" | "not_team_feed" | "epg_match" | "dispatcharr_group" | "catch_all"
+  type: "m3u" | "group" | "regex" | "stream_type" | "team_feed" | "not_team_feed" | "epg_match" | "dispatcharr_group" | "stats_metric" | "catch_all"
   value: string
   priority: number
 }
@@ -528,6 +530,11 @@ function RuleRow({
                 onChange={(ids) => onUpdate(index, { ...rule, value: ids.join(",") })}
               />
             </div>
+          ) : rule.type === "stats_metric" ? (
+            <StatsMetricBuilder
+              value={rule.value}
+              onChange={(v) => onUpdate(index, { ...rule, value: v })}
+            />
           ) : (
             <Input
               value={rule.value}
@@ -555,6 +562,133 @@ function RuleRow({
           </Button>
         </div>
       </div>
+    </div>
+  )
+}
+
+const METRIC_LABELS: Record<string, string> = {
+  resolution_width: "Res W",
+  resolution_height: "Res H",
+  ffmpeg_output_bitrate: "Bitrate",
+  source_fps: "FPS",
+  audio_bitrate: "Audio",
+  sample_rate: "Sample",
+}
+const OP_SYMBOLS: Record<string, string> = {
+  ">=": "≥", "<=": "≤", ">": ">", "<": "<", "=": "=", is_unknown: "?",
+}
+
+function StatsMetricBuilder({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  type Cond = { metric: string; operator: string; threshold: string }
+  const conditions: Cond[] = (() => {
+    const parsed = value.split(";").filter(Boolean).map(cond => {
+      const parts = cond.split("|", 3)
+      return { metric: parts[0] ?? "", operator: parts[1] ?? ">=", threshold: parts[2] ?? "" }
+    })
+    return parsed.length > 0 ? parsed : [{ metric: "", operator: ">=", threshold: "" }]
+  })()
+
+  const serialize = (conds: Cond[]) => conds.map(c => `${c.metric}|${c.operator}|${c.threshold}`).join(";")
+  const updateCond = (ci: number, patch: Partial<Cond>) =>
+    onChange(serialize(conditions.map((c, i) => i === ci ? { ...c, ...patch } : c)))
+  const removeCond = (ci: number) => onChange(serialize(conditions.filter((_, i) => i !== ci)))
+  const addCond = () => onChange(serialize([...conditions, { metric: "", operator: ">=", threshold: "" }]))
+
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setIsOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === "Escape") setIsOpen(false) }
+    document.addEventListener("mousedown", onMouseDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [])
+
+  const summary = conditions
+    .filter(c => c.metric)
+    .map(c => c.operator === "is_unknown"
+      ? `${METRIC_LABELS[c.metric] ?? c.metric} unknown`
+      : `${METRIC_LABELS[c.metric] ?? c.metric} ${OP_SYMBOLS[c.operator] ?? c.operator} ${c.threshold || "…"}`)
+    .join(" AND ")
+
+  const isMulti = conditions.length > 1
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(o => !o)}
+        className={cn(
+          "flex h-9 w-full items-center justify-between rounded-md border border-input px-3 text-sm shadow-sm transition-colors",
+          "bg-secondary text-foreground cursor-pointer",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:border-primary",
+          isOpen && "ring-1 ring-ring border-primary",
+        )}
+      >
+        <span className={cn("truncate", !summary && "text-muted-foreground italic text-sm")}>
+          {summary || "Configure conditions…"}
+        </span>
+        <ChevronDown className={cn("h-4 w-4 ml-2 shrink-0 text-muted-foreground opacity-50 transition-transform", isOpen && "rotate-180")} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-50 left-0 mt-1 w-full min-w-[360px] rounded-md border border-border bg-card shadow-lg p-3 flex flex-col gap-2">
+          {conditions.map((cond, ci) => (
+            <div key={ci} className="flex items-center gap-1.5">
+              {isMulti && (
+                <span className="w-7 shrink-0 text-center text-[10px] font-semibold text-muted-foreground">
+                  {ci === 0 ? "" : "AND"}
+                </span>
+              )}
+              <div className="grid gap-1.5 grid-cols-[1fr_68px_84px] flex-1 min-w-0 items-center">
+                <Select value={cond.metric} onChange={(e) => updateCond(ci, { metric: e.target.value })}>
+                  <option value="">Metric…</option>
+                  <option value="resolution_width">Resolution Width (px)</option>
+                  <option value="resolution_height">Resolution Height (px)</option>
+                  <option value="ffmpeg_output_bitrate">Bitrate (kbps)</option>
+                  <option value="source_fps">FPS</option>
+                  <option value="audio_bitrate">Audio Bitrate (kbps)</option>
+                  <option value="sample_rate">Sample Rate (Hz)</option>
+                </Select>
+                <Select value={cond.operator} onChange={(e) => updateCond(ci, { operator: e.target.value })}>
+                  <option value=">=">≥</option>
+                  <option value="<=">≤</option>
+                  <option value=">">{">"}</option>
+                  <option value="<">{"<"}</option>
+                  <option value="=">=</option>
+                  <option value="is_unknown">Unknown</option>
+                </Select>
+                <Input
+                  type="number"
+                  value={cond.threshold}
+                  onChange={(e) => updateCond(ci, { threshold: e.target.value })}
+                  placeholder="Value"
+                  disabled={cond.operator === "is_unknown"}
+                />
+              </div>
+              {isMulti && (
+                <button type="button" onClick={() => removeCond(ci)} className="shrink-0 text-muted-foreground hover:text-destructive">
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={addCond}
+            className="flex items-center gap-1 self-start text-xs text-muted-foreground hover:text-foreground mt-0.5"
+          >
+            <Plus className="h-3 w-3" />
+            AND condition
+          </button>
+        </div>
+      )}
     </div>
   )
 }
@@ -674,7 +808,7 @@ export function StreamOrderingManager() {
       })
       toast.success("Stream ordering rules saved")
       setHasChanges(false)
-    } catch (err) {
+    } catch {
       toast.error("Failed to save stream ordering rules")
     }
   }

--- a/frontend/src/components/StreamOrderingManager.tsx
+++ b/frontend/src/components/StreamOrderingManager.tsx
@@ -273,7 +273,7 @@ const RULE_TYPES = [
   { value: "stream_type", label: "Stream Type", description: "Match by how the stream was recognized: event, team, or EPG-matched (time-shared linear)" },
   { value: "team_feed", label: "Home/Away Feed", description: "Match streams that appear to be a team's own broadcast (home or away feed) for any enabled team" },
   { value: "dispatcharr_group", label: "Dispatcharr Group", description: "Match channel-source streams by the Dispatcharr channel group you selected as an EPG source" },
-  { value: "stats_metric", label: "Stats Metric", description: "Match streams where a numeric stat (resolution, bitrate, fps) meets a threshold" },
+  { value: "stats_metric", label: "Stream Stats", description: "Match streams where a numeric stat (resolution, bitrate, fps) meets a threshold" },
 ] as const
 
 const STREAM_TYPE_OPTIONS = [
@@ -531,10 +531,20 @@ function RuleRow({
               />
             </div>
           ) : rule.type === "stats_metric" ? (
-            <StatsMetricBuilder
-              value={rule.value}
-              onChange={(v) => onUpdate(index, { ...rule, value: v })}
-            />
+            <div className="flex items-center gap-2">
+              <RichTooltip
+                content="Stat values (resolution, bitrate, fps, etc.) come from Dispatcharr's external stream probe — they're only available after Dispatcharr has probed a stream, so freshly added streams may not match until then."
+                side="top"
+              >
+                <Info className="h-3 w-3 text-muted-foreground/50 cursor-help shrink-0" />
+              </RichTooltip>
+              <div className="flex-1 min-w-0">
+                <StatsMetricBuilder
+                  value={rule.value}
+                  onChange={(v) => onUpdate(index, { ...rule, value: v })}
+                />
+              </div>
+            </div>
           ) : (
             <Input
               value={rule.value}

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -151,6 +151,13 @@ class StreamRuleMatch(BaseModel):
     is_winner: bool
 
 
+class StreamNameMatch(BaseModel):
+    """A name token that produced a match (alias text or team-name form → team)."""
+
+    text: str
+    team: str
+
+
 class ChannelStreamEntry(BaseModel):
     """A single stream attached to a managed channel, with cached stats."""
 
@@ -169,6 +176,9 @@ class ChannelStreamEntry(BaseModel):
     matched_event: str | None = None
     matched_league: str | None = None
     cache_match_method: str | None = None
+    cache_created_at: str | None = None
+    match_aliases: list[StreamNameMatch] = []
+    match_patterns: list[StreamNameMatch] = []
     user_corrected: bool = False
     corrected_at: str | None = None
 
@@ -388,6 +398,19 @@ def get_managed_channel_streams(channel_id: int):
                 cache_match_method=(d := match_details.get(
                     (s.source_group_id, s.dispatcharr_stream_id), {}
                 )).get("match_method"),
+                cache_created_at=(
+                    _safe_isoformat(d.get("created_at"))
+                    if d.get("match_method") == "cache"
+                    else None
+                ),
+                match_aliases=[
+                    StreamNameMatch(text=a["alias"], team=a["team"])
+                    for a in d.get("aliases", [])
+                ],
+                match_patterns=[
+                    StreamNameMatch(text=p["token"], team=p["team"])
+                    for p in d.get("patterns", [])
+                ],
                 user_corrected=d.get("user_corrected", False),
                 corrected_at=_safe_isoformat(d.get("corrected_at")),
             )

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -142,6 +142,15 @@ class DeleteResponse(BaseModel):
     message: str
 
 
+class StreamRuleMatch(BaseModel):
+    """One ordering rule that matched a stream (priority explainer)."""
+
+    type: str
+    value: str
+    priority: int
+    is_winner: bool
+
+
 class ChannelStreamEntry(BaseModel):
     """A single stream attached to a managed channel, with cached stats."""
 
@@ -153,6 +162,7 @@ class ChannelStreamEntry(BaseModel):
     priority: int = 0
     stream_stats: dict | None = None
     stream_stats_updated_at: str | None = None
+    matched_rules: list[StreamRuleMatch] = []
 
 
 class ChannelStreamsResponse(BaseModel):
@@ -273,6 +283,7 @@ def get_managed_channel_streams(channel_id: int):
     """
     from teamarr.database.channels import get_managed_channel
     from teamarr.database.channels.streams import get_channel_streams, refresh_stream_stats
+    from teamarr.services.stream_ordering import get_stream_ordering_service
 
     with get_db() as conn:
         channel = get_managed_channel(conn, channel_id)
@@ -314,6 +325,20 @@ def get_managed_channel_streams(channel_id: int):
                 streams = get_channel_streams(conn, channel_id)
                 stats_refreshed = True
 
+        # Explain each stream's priority: which ordering rules currently match it.
+        ordering_service = get_stream_ordering_service(conn)
+        matched_by_stream: dict[int, list[StreamRuleMatch]] = {
+            s.dispatcharr_stream_id: [
+                StreamRuleMatch(
+                    type=e.type, value=e.value, priority=e.priority, is_winner=e.is_winner
+                )
+                for e in ordering_service.evaluate_rules(
+                    s, group_names.get(s.source_group_id) if s.source_group_id else None
+                )
+            ]
+            for s in streams
+        }
+
     return ChannelStreamsResponse(
         streams=[
             ChannelStreamEntry(
@@ -325,6 +350,7 @@ def get_managed_channel_streams(channel_id: int):
                 priority=s.priority,
                 stream_stats=s.stream_stats,
                 stream_stats_updated_at=_safe_isoformat(s.stream_stats_updated_at),
+                matched_rules=matched_by_stream.get(s.dispatcharr_stream_id, []),
             )
             for s in streams
         ],

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -159,10 +159,18 @@ class ChannelStreamEntry(BaseModel):
     source_group: str | None = None
     m3u_account_name: str | None = None
     match_method: str | None = None
+    match_type: str | None = None
+    exception_keyword: str | None = None
     priority: int = 0
     stream_stats: dict | None = None
     stream_stats_updated_at: str | None = None
     matched_rules: list[StreamRuleMatch] = []
+    # Cache-derived match detail (absent for EPG / dedicated matches)
+    matched_event: str | None = None
+    matched_league: str | None = None
+    cache_match_method: str | None = None
+    user_corrected: bool = False
+    corrected_at: str | None = None
 
 
 class ChannelStreamsResponse(BaseModel):
@@ -282,7 +290,11 @@ def get_managed_channel_streams(channel_id: int):
     Source group names are resolved from event_epg_groups via a join.
     """
     from teamarr.database.channels import get_managed_channel
-    from teamarr.database.channels.streams import get_channel_streams, refresh_stream_stats
+    from teamarr.database.channels.streams import (
+        get_channel_streams,
+        get_stream_match_details,
+        refresh_stream_stats,
+    )
     from teamarr.services.stream_ordering import get_stream_ordering_service
 
     with get_db() as conn:
@@ -339,6 +351,24 @@ def get_managed_channel_streams(channel_id: int):
             for s in streams
         }
 
+        # Explain how each stream matched its event (cache-derived; absent for
+        # EPG / dedicated matches that bypass the fingerprint cache).
+        match_pairs = [
+            (s.source_group_id, s.dispatcharr_stream_id)
+            for s in streams
+            if s.source_group_id is not None
+        ]
+        match_details = get_stream_match_details(conn, match_pairs)
+
+    # The channel represents one event; that's the authoritative matched event for
+    # every stream on it. (The fingerprint cache can't be trusted here: EPG streams
+    # are time-shared across many event channels, so a stream's cache row points at
+    # whatever it last matched, not this channel's event.)
+    if channel.home_team or channel.away_team:
+        channel_event = f"{channel.away_team or ''} @ {channel.home_team or ''}".strip()
+    else:
+        channel_event = channel.event_name
+
     return ChannelStreamsResponse(
         streams=[
             ChannelStreamEntry(
@@ -347,10 +377,19 @@ def get_managed_channel_streams(channel_id: int):
                 source_group=group_names.get(s.source_group_id) if s.source_group_id else None,
                 m3u_account_name=s.m3u_account_name,
                 match_method=s.match_method,
+                match_type=s.match_type,
+                exception_keyword=s.exception_keyword,
                 priority=s.priority,
                 stream_stats=s.stream_stats,
                 stream_stats_updated_at=_safe_isoformat(s.stream_stats_updated_at),
                 matched_rules=matched_by_stream.get(s.dispatcharr_stream_id, []),
+                matched_event=channel_event,
+                matched_league=channel.league,
+                cache_match_method=(d := match_details.get(
+                    (s.source_group_id, s.dispatcharr_stream_id), {}
+                )).get("match_method"),
+                user_corrected=d.get("user_corrected", False),
+                corrected_at=_safe_isoformat(d.get("corrected_at")),
             )
             for s in streams
         ],

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -8,7 +8,7 @@ Provides REST API for:
 """
 
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -142,6 +142,26 @@ class DeleteResponse(BaseModel):
     message: str
 
 
+class ChannelStreamEntry(BaseModel):
+    """A single stream attached to a managed channel, with cached stats."""
+
+    dispatcharr_stream_id: int
+    stream_name: str | None = None
+    source_group: str | None = None
+    m3u_account_name: str | None = None
+    match_method: str | None = None
+    priority: int = 0
+    stream_stats: dict | None = None
+    stream_stats_updated_at: str | None = None
+
+
+class ChannelStreamsResponse(BaseModel):
+    """Streams attached to a managed channel."""
+
+    streams: list[ChannelStreamEntry]
+    stats_refreshed: bool = False
+
+
 # =============================================================================
 # ENDPOINTS
 # =============================================================================
@@ -241,6 +261,74 @@ def get_managed_channel(channel_id: int):
         sync_status=channel.sync_status,
         created_at=_safe_isoformat(channel.created_at),
         updated_at=_safe_isoformat(channel.updated_at),
+    )
+
+
+@router.get("/managed/{channel_id}/streams", response_model=ChannelStreamsResponse)
+def get_managed_channel_streams(channel_id: int):
+    """Get active streams for a managed channel with cached stats.
+
+    Triggers a stats refresh when any stream has null stats or stats older than 1 hour.
+    Source group names are resolved from event_epg_groups via a join.
+    """
+    from teamarr.database.channels import get_managed_channel
+    from teamarr.database.channels.streams import get_channel_streams, refresh_stream_stats
+
+    with get_db() as conn:
+        channel = get_managed_channel(conn, channel_id)
+        if not channel:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Channel {channel_id} not found",
+            )
+
+        streams = get_channel_streams(conn, channel_id)
+
+        # Resolve source group names in one query
+        group_ids = {s.source_group_id for s in streams if s.source_group_id is not None}
+        group_names: dict[int, str] = {}
+        if group_ids:
+            placeholders = ",".join("?" * len(group_ids))
+            rows = conn.execute(
+                f"SELECT id, name FROM event_epg_groups WHERE id IN ({placeholders})",
+                list(group_ids),
+            ).fetchall()
+            group_names = {row[0]: row[1] for row in rows}
+
+        # Refresh stats when any stream has null stats or stats older than 1 hour
+        needs_refresh = any(
+            s.stream_stats is None or (
+                s.stream_stats_updated_at is not None and (
+                    datetime.now(timezone.utc) - datetime.fromisoformat(  # noqa: UP017
+                        str(s.stream_stats_updated_at).replace("Z", "+00:00")
+                    )
+                ).total_seconds() > 3600
+            )
+            for s in streams
+        )
+
+        stats_refreshed = False
+        if needs_refresh and streams:
+            updated = refresh_stream_stats(conn, channel_id)
+            if updated:
+                streams = get_channel_streams(conn, channel_id)
+                stats_refreshed = True
+
+    return ChannelStreamsResponse(
+        streams=[
+            ChannelStreamEntry(
+                dispatcharr_stream_id=s.dispatcharr_stream_id,
+                stream_name=s.stream_name,
+                source_group=group_names.get(s.source_group_id) if s.source_group_id else None,
+                m3u_account_name=s.m3u_account_name,
+                match_method=s.match_method,
+                priority=s.priority,
+                stream_stats=s.stream_stats,
+                stream_stats_updated_at=_safe_isoformat(s.stream_stats_updated_at),
+            )
+            for s in streams
+        ],
+        stats_refreshed=stats_refreshed,
     )
 
 

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -1467,6 +1467,7 @@ def clear_group_match_cache(group_id: int):
     algorithm changes or cached matches are incorrect.
     """
     from teamarr.consumers.stream_match_cache import StreamMatchCache
+    from teamarr.database.channels.streams import clear_stream_stats_for_group
     from teamarr.database.groups import get_group
 
     with get_db() as conn:
@@ -1477,11 +1478,14 @@ def clear_group_match_cache(group_id: int):
                 detail=f"Group {group_id} not found",
             )
 
+        stats_cleared = clear_stream_stats_for_group(conn, group_id)
+
     cache = StreamMatchCache(get_db)
     entries_cleared = cache.clear_group(group_id)
 
     logger.info(
-        "[CACHE_CLEAR] group_id=%d name=%s entries=%d", group_id, group.name, entries_cleared
+        "[CACHE_CLEAR] group_id=%d name=%s entries=%d stats_cleared=%d",
+        group_id, group.name, entries_cleared, stats_cleared,
     )
 
     return ClearCacheResponse(
@@ -1499,6 +1503,7 @@ def clear_groups_match_cache(request: ClearCacheRequest):
     Forces re-matching on next EPG generation run for all specified groups.
     """
     from teamarr.consumers.stream_match_cache import StreamMatchCache
+    from teamarr.database.channels.streams import clear_stream_stats_for_group
     from teamarr.database.groups import get_group
 
     cache = StreamMatchCache(get_db)
@@ -1512,6 +1517,7 @@ def clear_groups_match_cache(request: ClearCacheRequest):
                 continue
 
             cleared = cache.clear_group(group_id)
+            clear_stream_stats_for_group(conn, group_id)
             results.append(ClearCacheGroupResult(group_id=group_id, cleared=cleared))
             total_cleared += cleared
 
@@ -1531,11 +1537,15 @@ def clear_all_match_cache():
     Forces re-matching on next EPG generation run for every group.
     """
     from teamarr.consumers.stream_match_cache import StreamMatchCache
+    from teamarr.database.channels.streams import clear_all_stream_stats
 
     cache = StreamMatchCache(get_db)
     cleared = cache.clear_all()
 
-    logger.info("[CACHE_CLEAR_ALL] Cleared %d entries", cleared)
+    with get_db() as conn:
+        stats_cleared = clear_all_stream_stats(conn)
+
+    logger.info("[CACHE_CLEAR_ALL] Cleared %d entries stats_cleared=%d", cleared, stats_cleared)
 
     return ClearCacheResponse(
         success=True,

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -1466,8 +1466,7 @@ def clear_group_match_cache(group_id: int):
     Forces re-matching on next EPG generation run. Useful when matching
     algorithm changes or cached matches are incorrect.
     """
-    from teamarr.consumers.stream_match_cache import StreamMatchCache
-    from teamarr.database.channels.streams import clear_stream_stats_for_group
+    from teamarr.consumers.stream_match_cache import clear_group_match_data
     from teamarr.database.groups import get_group
 
     with get_db() as conn:
@@ -1478,10 +1477,7 @@ def clear_group_match_cache(group_id: int):
                 detail=f"Group {group_id} not found",
             )
 
-        stats_cleared = clear_stream_stats_for_group(conn, group_id)
-
-    cache = StreamMatchCache(get_db)
-    entries_cleared = cache.clear_group(group_id)
+    entries_cleared, stats_cleared = clear_group_match_data(get_db, group_id)
 
     logger.info(
         "[CACHE_CLEAR] group_id=%d name=%s entries=%d stats_cleared=%d",
@@ -1502,26 +1498,28 @@ def clear_groups_match_cache(request: ClearCacheRequest):
 
     Forces re-matching on next EPG generation run for all specified groups.
     """
-    from teamarr.consumers.stream_match_cache import StreamMatchCache
-    from teamarr.database.channels.streams import clear_stream_stats_for_group
+    from teamarr.consumers.stream_match_cache import clear_group_match_data
     from teamarr.database.groups import get_group
 
-    cache = StreamMatchCache(get_db)
     results: list[ClearCacheGroupResult] = []
     total_cleared = 0
+    total_stats_cleared = 0
 
     with get_db() as conn:
-        for group_id in request.group_ids:
-            group = get_group(conn, group_id)
-            if not group:
-                continue
+        valid_group_ids = [
+            group_id for group_id in request.group_ids if get_group(conn, group_id)
+        ]
 
-            cleared = cache.clear_group(group_id)
-            clear_stream_stats_for_group(conn, group_id)
-            results.append(ClearCacheGroupResult(group_id=group_id, cleared=cleared))
-            total_cleared += cleared
+    for group_id in valid_group_ids:
+        cleared, stats_cleared = clear_group_match_data(get_db, group_id)
+        results.append(ClearCacheGroupResult(group_id=group_id, cleared=cleared))
+        total_cleared += cleared
+        total_stats_cleared += stats_cleared
 
-    logger.info("[CACHE_CLEAR_BULK] groups=%d total_cleared=%d", len(results), total_cleared)
+    logger.info(
+        "[CACHE_CLEAR_BULK] groups=%d total_cleared=%d total_stats_cleared=%d",
+        len(results), total_cleared, total_stats_cleared,
+    )
 
     return ClearCacheResponse(
         success=True,
@@ -1536,14 +1534,9 @@ def clear_all_match_cache():
 
     Forces re-matching on next EPG generation run for every group.
     """
-    from teamarr.consumers.stream_match_cache import StreamMatchCache
-    from teamarr.database.channels.streams import clear_all_stream_stats
+    from teamarr.consumers.stream_match_cache import clear_all_match_data
 
-    cache = StreamMatchCache(get_db)
-    cleared = cache.clear_all()
-
-    with get_db() as conn:
-        stats_cleared = clear_all_stream_stats(conn)
+    cleared, stats_cleared = clear_all_match_data(get_db)
 
     logger.info("[CACHE_CLEAR_ALL] Cleared %d entries stats_cleared=%d", cleared, stats_cleared)
 

--- a/teamarr/consumers/stream_match_cache.py
+++ b/teamarr/consumers/stream_match_cache.py
@@ -599,6 +599,38 @@ class StreamMatchCache:
             return cursor.fetchone()[0]
 
 
+def clear_group_match_data(get_db: Callable, group_id: int) -> tuple[int, int]:
+    """Clear both the stream match cache and cached stream stats for one group.
+
+    These are two halves of one intent ("redo this group from scratch on the next
+    run"), so they live together here: a caller can't clear one and forget the
+    other.
+
+    Returns:
+        (match_cache_entries_cleared, stream_stats_rows_cleared)
+    """
+    from teamarr.database.channels.streams import clear_stream_stats
+
+    entries_cleared = StreamMatchCache(get_db).clear_group(group_id)
+    with get_db() as conn:
+        stats_cleared = clear_stream_stats(conn, group_id)
+    return entries_cleared, stats_cleared
+
+
+def clear_all_match_data(get_db: Callable) -> tuple[int, int]:
+    """Clear the entire stream match cache and all cached stream stats.
+
+    Returns:
+        (match_cache_entries_cleared, stream_stats_rows_cleared)
+    """
+    from teamarr.database.channels.streams import clear_stream_stats
+
+    entries_cleared = StreamMatchCache(get_db).clear_all()
+    with get_db() as conn:
+        stats_cleared = clear_stream_stats(conn)
+    return entries_cleared, stats_cleared
+
+
 def get_generation_counter(get_connection: Callable) -> int:
     """Get current EPG generation counter from settings."""
     try:

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -444,6 +444,44 @@ def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
     return updated
 
 
+def clear_stream_stats_for_group(conn: Connection, group_id: int) -> int:
+    """Null cached stream stats for all active streams sourced from a group.
+
+    Called when a group's match cache is cleared so stats are freshly pulled
+    from Dispatcharr on the next streams fetch / run, like everything else.
+
+    Args:
+        conn: Database connection
+        group_id: Event group ID (matches managed_channel_streams.source_group_id)
+
+    Returns:
+        Number of stream rows whose stats were cleared
+    """
+    cursor = conn.execute(
+        """UPDATE managed_channel_streams
+           SET stream_stats = NULL, stream_stats_updated_at = NULL
+           WHERE source_group_id = ? AND removed_at IS NULL
+             AND (stream_stats IS NOT NULL OR stream_stats_updated_at IS NOT NULL)""",
+        (group_id,),
+    )
+    return cursor.rowcount
+
+
+def clear_all_stream_stats(conn: Connection) -> int:
+    """Null cached stream stats for every active stream (used by clear-all).
+
+    Returns:
+        Number of stream rows whose stats were cleared
+    """
+    cursor = conn.execute(
+        """UPDATE managed_channel_streams
+           SET stream_stats = NULL, stream_stats_updated_at = NULL
+           WHERE removed_at IS NULL
+             AND (stream_stats IS NOT NULL OR stream_stats_updated_at IS NOT NULL)""",
+    )
+    return cursor.rowcount
+
+
 def get_ordered_stream_ids(
     conn: Connection,
     managed_channel_id: int,

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -444,6 +444,59 @@ def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
     return updated
 
 
+def get_stream_match_details(
+    conn: Connection, pairs: list[tuple[int, int]]
+) -> dict[tuple[int, int], dict]:
+    """Fetch cached match details for (source_group_id, stream_id) pairs.
+
+    Reads stream_match_cache to explain how a stream matched its event: the
+    matched event name/league, the finer match method, and any user correction.
+    Returns the most recent entry per pair. Pairs with no cache row (e.g. EPG or
+    dedicated/exact matches, which don't use the fingerprint cache) are absent.
+
+    Each value dict has: event_name, league, match_method, user_corrected,
+    corrected_at.
+    """
+    if not pairs:
+        return {}
+
+    group_ids = {g for g, _ in pairs}
+    stream_ids = {s for _, s in pairs}
+    gp = ",".join("?" * len(group_ids))
+    sp = ",".join("?" * len(stream_ids))
+    rows = conn.execute(
+        f"""SELECT group_id, stream_id, event_id, league, cached_event_data,
+                   match_method, user_corrected, corrected_at
+            FROM stream_match_cache
+            WHERE group_id IN ({gp}) AND stream_id IN ({sp})
+            ORDER BY updated_at ASC""",
+        [*group_ids, *stream_ids],
+    ).fetchall()
+
+    wanted = set(pairs)
+    out: dict[tuple[int, int], dict] = {}
+    for r in rows:
+        key = (r["group_id"], r["stream_id"])
+        if key not in wanted or r["event_id"] == "__FAILED__":
+            continue
+        event_name = None
+        if r["cached_event_data"]:
+            try:
+                data = json.loads(r["cached_event_data"])
+                event_name = data.get("name") or data.get("short_name")
+            except (ValueError, AttributeError):
+                event_name = None
+        # Newer rows overwrite older ones (rows are ordered oldest-first).
+        out[key] = {
+            "event_name": event_name,
+            "league": r["league"],
+            "match_method": r["match_method"],
+            "user_corrected": bool(r["user_corrected"]),
+            "corrected_at": r["corrected_at"],
+        }
+    return out
+
+
 def clear_stream_stats(conn: Connection, group_id: int | None = None) -> int:
     """Null cached stream stats so they're freshly pulled from Dispatcharr next run.
 

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -5,6 +5,7 @@ CRUD operations for managed_channel_streams table.
 
 import json
 import logging
+import re
 from sqlite3 import Connection
 
 from .types import ManagedChannelStream
@@ -455,7 +456,8 @@ def get_stream_match_details(
     dedicated/exact matches, which don't use the fingerprint cache) are absent.
 
     Each value dict has: event_name, league, match_method, user_corrected,
-    corrected_at.
+    corrected_at, created_at, aliases (list of {alias, team} for alias matches),
+    patterns (list of {token, team} for pattern matches).
     """
     if not pairs:
         return {}
@@ -465,8 +467,9 @@ def get_stream_match_details(
     gp = ",".join("?" * len(group_ids))
     sp = ",".join("?" * len(stream_ids))
     rows = conn.execute(
-        f"""SELECT group_id, stream_id, event_id, league, cached_event_data,
-                   match_method, user_corrected, corrected_at
+        f"""SELECT group_id, stream_id, stream_name, event_id, league,
+                   cached_event_data, match_method, user_corrected, corrected_at,
+                   created_at
             FROM stream_match_cache
             WHERE group_id IN ({gp}) AND stream_id IN ({sp})
             ORDER BY updated_at ASC""",
@@ -474,18 +477,20 @@ def get_stream_match_details(
     ).fetchall()
 
     wanted = set(pairs)
+    aliases_by_league: dict[str, list] = {}  # memoize per league within this call
     out: dict[tuple[int, int], dict] = {}
     for r in rows:
         key = (r["group_id"], r["stream_id"])
         if key not in wanted or r["event_id"] == "__FAILED__":
             continue
+        data = {}
         event_name = None
         if r["cached_event_data"]:
             try:
                 data = json.loads(r["cached_event_data"])
                 event_name = data.get("name") or data.get("short_name")
             except (ValueError, AttributeError):
-                event_name = None
+                data = {}
         # Newer rows overwrite older ones (rows are ordered oldest-first).
         out[key] = {
             "event_name": event_name,
@@ -493,7 +498,74 @@ def get_stream_match_details(
             "match_method": r["match_method"],
             "user_corrected": bool(r["user_corrected"]),
             "corrected_at": r["corrected_at"],
+            "created_at": r["created_at"],
+            "aliases": _reconstruct_aliases(conn, r, data, aliases_by_league),
+            "patterns": _reconstruct_patterns(r, data),
         }
+    return out
+
+
+def _reconstruct_aliases(
+    conn: Connection, row, event_data: dict, cache: dict[str, list]
+) -> list[dict]:
+    """Find which user-defined alias(es) produced an alias match, for display.
+
+    Returns [{alias, team}] for aliases whose text appears in the cached stream
+    name and whose team is one of the matched event's teams. Non-alias matches
+    return []. Best-effort (substring match), purely informational.
+    """
+    if row["match_method"] != "alias" or not event_data:
+        return []
+    from teamarr.database.aliases import list_aliases
+
+    home = event_data.get("home_team") or {}
+    away = event_data.get("away_team") or {}
+    team_ids = {str(home.get("id")), str(away.get("id"))} - {"None"}
+    if not team_ids:
+        return []
+    league = (row["league"] or "").lower()
+    if league not in cache:
+        cache[league] = list_aliases(conn, league=league)
+    name_lower = (row["stream_name"] or "").lower()
+    return [
+        {"alias": a.alias, "team": a.team_name}
+        for a in cache[league]
+        if str(a.team_id) in team_ids and a.alias.lower() in name_lower
+    ]
+
+
+def _reconstruct_patterns(row, event_data: dict) -> list[dict]:
+    """Find which team-name form produced a pattern match, for display.
+
+    Returns [{token, team}] for the matched event's teams whose name / short
+    name / abbreviation appears in the cached stream name. Non-pattern matches
+    return []. Best-effort and purely informational: the longest (most specific)
+    form is preferred, and abbreviations match only on a word boundary to avoid
+    short-token false positives.
+    """
+    if row["match_method"] != "pattern" or not event_data:
+        return []
+    name_lower = (row["stream_name"] or "").lower()
+    if not name_lower:
+        return []
+
+    out: list[dict] = []
+    for side in ("home_team", "away_team"):
+        team = event_data.get(side) or {}
+        team_name = team.get("name")
+        if not team_name:
+            continue
+        token = None
+        for cand in (team.get("name"), team.get("short_name")):
+            if cand and cand.lower() in name_lower:
+                token = cand
+                break
+        if not token:
+            abbr = team.get("abbreviation")
+            if abbr and re.search(rf"\b{re.escape(abbr.lower())}\b", name_lower):
+                token = abbr
+        if token:
+            out.append({"token": token, "team": team_name})
     return out
 
 

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -444,40 +444,33 @@ def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
     return updated
 
 
-def clear_stream_stats_for_group(conn: Connection, group_id: int) -> int:
-    """Null cached stream stats for all active streams sourced from a group.
+def clear_stream_stats(conn: Connection, group_id: int | None = None) -> int:
+    """Null cached stream stats so they're freshly pulled from Dispatcharr next run.
 
-    Called when a group's match cache is cleared so stats are freshly pulled
-    from Dispatcharr on the next streams fetch / run, like everything else.
+    Called when a group's match cache is cleared. With ``group_id`` set, scopes to
+    streams sourced from that event group (managed_channel_streams.source_group_id);
+    with ``group_id=None``, clears every active stream (the clear-all path). The
+    "already null" guard keeps the returned count to rows that actually changed.
 
     Args:
         conn: Database connection
-        group_id: Event group ID (matches managed_channel_streams.source_group_id)
+        group_id: Event group ID to scope to, or None to clear all active streams
 
     Returns:
         Number of stream rows whose stats were cleared
     """
-    cursor = conn.execute(
-        """UPDATE managed_channel_streams
-           SET stream_stats = NULL, stream_stats_updated_at = NULL
-           WHERE source_group_id = ? AND removed_at IS NULL
-             AND (stream_stats IS NOT NULL OR stream_stats_updated_at IS NOT NULL)""",
-        (group_id,),
+    where = (
+        "removed_at IS NULL "
+        "AND (stream_stats IS NOT NULL OR stream_stats_updated_at IS NOT NULL)"
     )
-    return cursor.rowcount
-
-
-def clear_all_stream_stats(conn: Connection) -> int:
-    """Null cached stream stats for every active stream (used by clear-all).
-
-    Returns:
-        Number of stream rows whose stats were cleared
-    """
+    params: tuple = ()
+    if group_id is not None:
+        where = "source_group_id = ? AND " + where
+        params = (group_id,)
     cursor = conn.execute(
-        """UPDATE managed_channel_streams
-           SET stream_stats = NULL, stream_stats_updated_at = NULL
-           WHERE removed_at IS NULL
-             AND (stream_stats IS NOT NULL OR stream_stats_updated_at IS NOT NULL)""",
+        f"UPDATE managed_channel_streams "
+        f"SET stream_stats = NULL, stream_stats_updated_at = NULL WHERE {where}",
+        params,
     )
     return cursor.rowcount
 

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -3,6 +3,7 @@
 CRUD operations for managed_channel_streams table.
 """
 
+import json
 import logging
 from sqlite3 import Connection
 
@@ -384,6 +385,63 @@ def reorder_channel_streams(
         )
 
     return updated_count
+
+
+def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
+    """Fetch and cache stream_stats from Dispatcharr for a managed channel's active streams.
+
+    Pulls stats from Dispatcharr's /api/channels/streams/by-ids/ endpoint and
+    updates the stream_stats / stream_stats_updated_at columns in
+    managed_channel_streams. Streams Dispatcharr hasn't probed yet return
+    stream_stats=null and are left unchanged.
+
+    Args:
+        conn: Database connection
+        managed_channel_id: Managed channel whose streams should be refreshed
+
+    Returns:
+        Number of streams whose stats were updated
+    """
+    from teamarr.dispatcharr.factory import get_dispatcharr_client
+
+    cursor = conn.execute(
+        """SELECT dispatcharr_stream_id FROM managed_channel_streams
+           WHERE managed_channel_id = ? AND removed_at IS NULL""",
+        (managed_channel_id,),
+    )
+    stream_ids = [row[0] for row in cursor.fetchall()]
+    if not stream_ids:
+        return 0
+
+    client = get_dispatcharr_client()
+    if client is None:
+        return 0
+
+    stats_list = client.get_stream_stats_by_ids(stream_ids)
+    if not stats_list:
+        return 0
+
+    updated = 0
+    for entry in stats_list:
+        sid = entry.get("id")
+        raw_stats = entry.get("stream_stats")
+        updated_at = entry.get("stream_stats_updated_at")
+        if sid is None or raw_stats is None:
+            continue
+        stats_json = json.dumps(raw_stats) if isinstance(raw_stats, dict) else raw_stats
+        result = conn.execute(
+            """UPDATE managed_channel_streams
+               SET stream_stats = ?, stream_stats_updated_at = ?
+               WHERE managed_channel_id = ? AND dispatcharr_stream_id = ? AND removed_at IS NULL""",
+            (stats_json, updated_at, managed_channel_id, sid),
+        )
+        if result.rowcount > 0:
+            updated += 1
+
+    if updated:
+        logger.debug("[STREAM STATS] Updated stats for %d/%d streams on channel %d",
+                     updated, len(stream_ids), managed_channel_id)
+    return updated
 
 
 def get_ordered_stream_ids(

--- a/teamarr/database/channels/types.py
+++ b/teamarr/database/channels/types.py
@@ -127,10 +127,23 @@ class ManagedChannelStream:
     # Time-windowed membership (epic teamarrv2-183.5). NULL = full-life.
     attach_at: datetime | None = None
     detach_at: datetime | None = None
+    # Stream stats cached from Dispatcharr (video codec, resolution, bitrate, fps, etc.)
+    stream_stats: dict | None = None
+    stream_stats_updated_at: datetime | None = None
 
     @classmethod
     def from_row(cls, row: dict) -> "ManagedChannelStream":
         """Create from database row dict."""
+        import json as _json
+        raw_stats = row.get("stream_stats")
+        stream_stats = None
+        if isinstance(raw_stats, str):
+            try:
+                stream_stats = _json.loads(raw_stats)
+            except Exception:
+                stream_stats = None
+        elif isinstance(raw_stats, dict):
+            stream_stats = raw_stats
         return cls(
             id=row["id"],
             managed_channel_id=row["managed_channel_id"],
@@ -149,4 +162,6 @@ class ManagedChannelStream:
             removed_at=row.get("removed_at"),
             attach_at=row.get("attach_at"),
             detach_at=row.get("detach_at"),
+            stream_stats=stream_stats,
+            stream_stats_updated_at=row.get("stream_stats_updated_at"),
         )

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1372,6 +1372,10 @@ CREATE TABLE IF NOT EXISTS managed_channel_streams (
     attach_at TIMESTAMP,
     detach_at TIMESTAMP,
 
+    -- Stream stats cached from Dispatcharr (stream_stats JSON on the Stream object)
+    stream_stats JSON DEFAULT NULL,
+    stream_stats_updated_at TIMESTAMP DEFAULT NULL,
+
     -- Sync status
     last_verified_at TIMESTAMP,
     in_dispatcharr BOOLEAN DEFAULT 1,

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -181,7 +181,8 @@ class StreamOrderingRule:
 
 VALID_RULE_TYPES: frozenset[str] = frozenset({
     "m3u", "group", "regex", "stream_type",
-    "team_feed", "not_team_feed", "epg_match", "dispatcharr_group", "catch_all",
+    "team_feed", "not_team_feed", "epg_match", "dispatcharr_group",
+    "stats_metric", "catch_all",
 })
 NO_VALUE_RULE_TYPES: frozenset[str] = frozenset(
     {"team_feed", "not_team_feed", "epg_match", "catch_all"}

--- a/teamarr/dispatcharr/client.py
+++ b/teamarr/dispatcharr/client.py
@@ -362,6 +362,43 @@ class DispatcharrClient:
                 "message": f"Error: {e!s}",
             }
 
+    def get_stream_stats_by_ids(self, stream_ids: list[int]) -> list[dict]:
+        """Fetch stream_stats for a batch of streams by their Dispatcharr stream IDs.
+
+        Uses POST /api/channels/streams/by-ids/ which works for any stream
+        regardless of channel assignment. Returns only the fields needed for
+        stats caching; non-existent IDs are silently omitted by Dispatcharr.
+
+        Args:
+            stream_ids: List of Dispatcharr stream IDs to fetch stats for
+
+        Returns:
+            List of dicts with keys: id, stream_stats, stream_stats_updated_at
+        """
+        if not stream_ids:
+            return []
+        response = self.post(
+            "/api/channels/streams/by-ids/?page_size=1000",
+            {"ids": stream_ids},
+        )
+        if response is None or response.status_code != 200:
+            status = response.status_code if response else "no response"
+            logger.warning(
+                "[STREAM STATS] Failed to fetch stats for %d streams: %s", len(stream_ids), status
+            )
+            return []
+        data = response.json()
+        results = data.get("results", data) if isinstance(data, dict) else data
+        return [
+            {
+                "id": s["id"],
+                "stream_stats": s.get("stream_stats"),
+                "stream_stats_updated_at": s.get("stream_stats_updated_at"),
+            }
+            for s in results
+            if "id" in s
+        ]
+
     def close(self) -> None:
         """Close HTTP client.
 

--- a/teamarr/services/stream_ordering.py
+++ b/teamarr/services/stream_ordering.py
@@ -34,6 +34,16 @@ class StreamWithPriority:
     matched_rule_type: str | None = None  # Which rule type matched
 
 
+@dataclass
+class RuleEvaluation:
+    """One ordering rule that matched a stream, for the priority explainer popup."""
+
+    type: str
+    value: str
+    priority: int
+    is_winner: bool  # True for the rule that actually set the priority
+
+
 class StreamOrderingService:
     """Service for computing stream ordering based on rules.
 
@@ -124,6 +134,52 @@ class StreamOrderingService:
             computed_priority=catch_all_priority,
             matched_rule_type="catch_all" if catch_all_priority != NO_MATCH_PRIORITY else None,
         )
+
+    def evaluate_rules(
+        self,
+        stream: ManagedChannelStream,
+        source_group_name: str | None = None,
+    ) -> list[RuleEvaluation]:
+        """Return the rules that matched a stream, marking which one won.
+
+        Mirrors compute_priority's first-match-wins / catch_all-fallback logic,
+        but reports every matching rule (not just the winner) so the UI can
+        explain why a stream got its priority. Rules are already priority-sorted.
+
+        Args:
+            stream: The stream to evaluate
+            source_group_name: Optional pre-fetched group name (for 'group' rules)
+
+        Returns:
+            Matched rules in priority order, always followed by the "everything
+            else" baseline (the configured catch_all rule, or the implicit
+            no-match default). The rule that set the priority — first match, or
+            the baseline when nothing matched — has is_winner=True.
+        """
+        matched: list[RuleEvaluation] = []
+        catch_all: StreamOrderingRule | None = None
+        winner_found = False
+
+        for rule in self.rules:
+            if rule.type == "catch_all":
+                catch_all = rule
+                continue
+            if self._matches(stream, rule, source_group_name):
+                is_winner = not winner_found
+                winner_found = winner_found or is_winner
+                matched.append(
+                    RuleEvaluation(rule.type, rule.value, rule.priority, is_winner)
+                )
+
+        # Always surface the baseline so the popup shows what "everything else"
+        # falls back to, even when a specific rule won.
+        baseline_priority = catch_all.priority if catch_all else NO_MATCH_PRIORITY
+        baseline_value = catch_all.value if catch_all else ""
+        matched.append(
+            RuleEvaluation("catch_all", baseline_value, baseline_priority, not winner_found)
+        )
+
+        return matched
 
     def sort_streams(
         self,

--- a/teamarr/services/stream_ordering.py
+++ b/teamarr/services/stream_ordering.py
@@ -185,6 +185,8 @@ class StreamOrderingService:
             return self._match_epg_match(stream)
         elif rule.type == "dispatcharr_group":
             return self._match_dispatcharr_group(stream, rule.value)
+        elif rule.type == "stats_metric":
+            return self._match_stats_metric(stream, rule.value)
         return False
 
     def _match_m3u(self, stream: ManagedChannelStream, account_name: str) -> bool:
@@ -267,6 +269,88 @@ class StreamOrderingService:
         if not stream.dispatcharr_channel_group:
             return False
         return stream.dispatcharr_channel_group.lower() == group_name.lower()
+
+    _STATS_OPERATORS = {
+        ">": lambda a, b: a > b,
+        "<": lambda a, b: a < b,
+        ">=": lambda a, b: a >= b,
+        "<=": lambda a, b: a <= b,
+        "=": lambda a, b: a == b,
+    }
+
+    def _resolve_stat_value(self, stats: dict, metric: str) -> float | None:
+        """Resolve a metric name to a float, including virtual derived fields.
+
+        resolution_width / resolution_height extract from the "1920x1080" string
+        that Dispatcharr stores in the 'resolution' key.
+        """
+        if metric == "resolution_width":
+            res = str(stats.get("resolution") or "")
+            if "x" in res:
+                try:
+                    return float(res.split("x")[0])
+                except (ValueError, IndexError):
+                    return None
+            return None
+        if metric == "resolution_height":
+            res = str(stats.get("resolution") or "")
+            if "x" in res:
+                try:
+                    return float(res.split("x")[1])
+                except (ValueError, IndexError):
+                    return None
+            return None
+        raw = stats.get(metric)
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (ValueError, TypeError):
+            return None
+
+    def _match_stats_metric(self, stream: ManagedChannelStream, rule_value: str) -> bool:
+        """Match stream by numeric stat comparisons encoded in rule_value.
+
+        Supports multiple AND conditions separated by ";":
+          "ffmpeg_output_bitrate|>=|4000;source_fps|>=|50"
+
+        Each condition is "metric|operator|threshold". Actual field names match
+        Dispatcharr's stream_stats JSON: resolution, source_fps,
+        ffmpeg_output_bitrate, audio_bitrate, sample_rate. Virtual metrics
+        resolution_width / resolution_height are derived from the resolution string.
+        """
+        if not rule_value:
+            return False
+        try:
+            for cond in rule_value.split(";"):
+                parts = cond.split("|", 2)
+                if len(parts) < 2:
+                    return False
+                metric, operator = parts[0], parts[1]
+                threshold_str = parts[2] if len(parts) > 2 else ""
+
+                if operator == "is_unknown":
+                    # Matches when stats are absent entirely OR this metric has no value
+                    has_value = (
+                        stream.stream_stats is not None
+                        and self._resolve_stat_value(stream.stream_stats, metric) is not None
+                    )
+                    if has_value:
+                        return False
+                else:
+                    if not stream.stream_stats:
+                        return False
+                    val = self._resolve_stat_value(stream.stream_stats, metric)
+                    if val is None:
+                        return False
+                    compare = self._STATS_OPERATORS.get(operator)
+                    if compare is None:
+                        return False
+                    if not compare(val, float(threshold_str)):
+                        return False
+            return True
+        except (ValueError, TypeError, AttributeError):
+            return False
 
     def _match_stream_type(self, stream: ManagedChannelStream, rule_value: str) -> bool:
         """Match stream by type, with optional team filter (value may be 'team|key1,key2')."""

--- a/tests/test_clear_match_data.py
+++ b/tests/test_clear_match_data.py
@@ -1,0 +1,86 @@
+"""Tests for the clear_group_match_data / clear_all_match_data orchestrators.
+
+These pair the two halves of "redo this group from scratch": wiping the
+stream_match_cache AND nulling cached stream stats. The orchestrators keep them
+together so a caller can't clear one and forget the other.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teamarr.consumers.stream_match_cache import (
+    clear_all_match_data,
+    clear_group_match_data,
+)
+from teamarr.database.connection import get_connection, get_db, init_db
+
+
+@pytest.fixture
+def db_env(tmp_path: Path):
+    """Isolated DB: returns (get_db factory bound to a temp file, persistent conn)."""
+    db_path = tmp_path / "test.db"
+    init_db(db_path)
+    factory = lambda: get_db(db_path)  # noqa: E731 - bind the temp path for the orchestrators
+    conn = get_connection(db_path)
+    yield factory, conn
+    conn.close()
+
+
+def _seed(conn, group_id: int, stream_id: int):
+    """Insert one match-cache row and one stat-bearing stream for a group."""
+    conn.execute(
+        """INSERT INTO stream_match_cache
+           (fingerprint, group_id, stream_id, stream_name, event_id, league)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (f"fp-{group_id}-{stream_id}", group_id, stream_id, "ESPN", "e1", "nhl"),
+    )
+    cur = conn.execute(
+        "INSERT INTO managed_channels (event_id, event_provider, tvg_id, channel_name) "
+        "VALUES ('e1', 'espn', 'tvg-1', 'NHL | CAR / VGK')"
+    )
+    conn.execute(
+        """INSERT INTO managed_channel_streams
+           (managed_channel_id, dispatcharr_stream_id, source_group_id,
+            stream_stats, stream_stats_updated_at)
+           VALUES (?, ?, ?, '{"resolution": "1920x1080"}', '2026-06-16 00:00:00')""",
+        (cur.lastrowid, stream_id, group_id),
+    )
+    conn.commit()
+
+
+def _counts(conn, group_id: int):
+    cache = conn.execute(
+        "SELECT COUNT(*) FROM stream_match_cache WHERE group_id = ?", (group_id,)
+    ).fetchone()[0]
+    stats = conn.execute(
+        "SELECT COUNT(*) FROM managed_channel_streams "
+        "WHERE source_group_id = ? AND stream_stats IS NOT NULL",
+        (group_id,),
+    ).fetchone()[0]
+    return cache, stats
+
+
+def test_clear_group_clears_both_tables(db_env):
+    factory, conn = db_env
+    _seed(conn, group_id=1, stream_id=100)
+    _seed(conn, group_id=2, stream_id=200)
+
+    entries, stats = clear_group_match_data(factory, 1)
+
+    assert (entries, stats) == (1, 1)
+    assert _counts(conn, 1) == (0, 0)  # group 1 fully cleared
+    assert _counts(conn, 2) == (1, 1)  # group 2 untouched
+
+
+def test_clear_all_clears_every_group(db_env):
+    factory, conn = db_env
+    _seed(conn, group_id=1, stream_id=100)
+    _seed(conn, group_id=2, stream_id=200)
+
+    entries, stats = clear_all_match_data(factory)
+
+    assert entries == 2
+    assert stats == 2
+    assert _counts(conn, 1) == (0, 0)
+    assert _counts(conn, 2) == (0, 0)

--- a/tests/test_clear_stream_stats.py
+++ b/tests/test_clear_stream_stats.py
@@ -1,0 +1,119 @@
+"""Tests for clearing cached stream stats when a group's match cache is cleared.
+
+When a user clears an event group's stream match cache, the cached Dispatcharr
+stream stats (managed_channel_streams.stream_stats) should be dropped too so they
+get freshly pulled on the next run — like everything else the cache clear resets.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from teamarr.database.channels.streams import (
+    clear_all_stream_stats,
+    clear_stream_stats_for_group,
+)
+from teamarr.database.connection import get_connection, init_db
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db_path = tmp_path / "t.db"
+    init_db(db_path)
+    c = get_connection(db_path)
+    yield c
+    c.close()
+
+
+def _insert_channel(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO managed_channels (event_id, event_provider, tvg_id, channel_name) "
+        "VALUES ('e1', 'espn', 'tvg-1', 'NHL | CAR / VGK')"
+    )
+    return cur.lastrowid
+
+
+def _insert_stream(conn, channel_id, stream_id, source_group_id, *, with_stats=True, removed=False):
+    stats = json.dumps({"resolution": "1920x1080"}) if with_stats else None
+    updated_at = "2026-06-16 00:00:00" if with_stats else None
+    removed_at = "2026-06-16 01:00:00" if removed else None
+    conn.execute(
+        """INSERT INTO managed_channel_streams
+           (managed_channel_id, dispatcharr_stream_id, source_group_id,
+            stream_stats, stream_stats_updated_at, removed_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (channel_id, stream_id, source_group_id, stats, updated_at, removed_at),
+    )
+
+
+def _stats_row(conn, stream_id):
+    return conn.execute(
+        "SELECT stream_stats, stream_stats_updated_at FROM managed_channel_streams "
+        "WHERE dispatcharr_stream_id = ?",
+        (stream_id,),
+    ).fetchone()
+
+
+def test_clear_for_group_nulls_stats_and_returns_count(conn):
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, source_group_id=1)
+    _insert_stream(conn, cid, 101, source_group_id=1)
+    conn.commit()
+
+    cleared = clear_stream_stats_for_group(conn, 1)
+
+    assert cleared == 2
+    for sid in (100, 101):
+        row = _stats_row(conn, sid)
+        assert row["stream_stats"] is None
+        assert row["stream_stats_updated_at"] is None
+
+
+def test_clear_for_group_leaves_other_groups_untouched(conn):
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, source_group_id=1)
+    _insert_stream(conn, cid, 200, source_group_id=2)
+    conn.commit()
+
+    cleared = clear_stream_stats_for_group(conn, 1)
+
+    assert cleared == 1
+    assert _stats_row(conn, 200)["stream_stats"] is not None
+
+
+def test_clear_for_group_skips_removed_streams(conn):
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, source_group_id=1, removed=True)
+    conn.commit()
+
+    cleared = clear_stream_stats_for_group(conn, 1)
+
+    assert cleared == 0
+    # Removed-row stats are left as-is (it's out of the active set anyway).
+    assert _stats_row(conn, 100)["stream_stats"] is not None
+
+
+def test_clear_for_group_ignores_already_null_stats(conn):
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, source_group_id=1, with_stats=False)
+    conn.commit()
+
+    # Only rows that actually had stats count, so the log reflects real work.
+    assert clear_stream_stats_for_group(conn, 1) == 0
+
+
+def test_clear_all_nulls_every_active_stream(conn):
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, source_group_id=1)
+    _insert_stream(conn, cid, 200, source_group_id=2)
+    _insert_stream(conn, cid, 300, source_group_id=3, removed=True)
+    conn.commit()
+
+    cleared = clear_all_stream_stats(conn)
+
+    assert cleared == 2
+    assert _stats_row(conn, 100)["stream_stats"] is None
+    assert _stats_row(conn, 200)["stream_stats"] is None
+    # Removed stream untouched.
+    assert _stats_row(conn, 300)["stream_stats"] is not None

--- a/tests/test_clear_stream_stats.py
+++ b/tests/test_clear_stream_stats.py
@@ -10,10 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from teamarr.database.channels.streams import (
-    clear_all_stream_stats,
-    clear_stream_stats_for_group,
-)
+from teamarr.database.channels.streams import clear_stream_stats
 from teamarr.database.connection import get_connection, init_db
 
 
@@ -61,7 +58,7 @@ def test_clear_for_group_nulls_stats_and_returns_count(conn):
     _insert_stream(conn, cid, 101, source_group_id=1)
     conn.commit()
 
-    cleared = clear_stream_stats_for_group(conn, 1)
+    cleared = clear_stream_stats(conn, 1)
 
     assert cleared == 2
     for sid in (100, 101):
@@ -76,7 +73,7 @@ def test_clear_for_group_leaves_other_groups_untouched(conn):
     _insert_stream(conn, cid, 200, source_group_id=2)
     conn.commit()
 
-    cleared = clear_stream_stats_for_group(conn, 1)
+    cleared = clear_stream_stats(conn, 1)
 
     assert cleared == 1
     assert _stats_row(conn, 200)["stream_stats"] is not None
@@ -87,7 +84,7 @@ def test_clear_for_group_skips_removed_streams(conn):
     _insert_stream(conn, cid, 100, source_group_id=1, removed=True)
     conn.commit()
 
-    cleared = clear_stream_stats_for_group(conn, 1)
+    cleared = clear_stream_stats(conn, 1)
 
     assert cleared == 0
     # Removed-row stats are left as-is (it's out of the active set anyway).
@@ -100,7 +97,7 @@ def test_clear_for_group_ignores_already_null_stats(conn):
     conn.commit()
 
     # Only rows that actually had stats count, so the log reflects real work.
-    assert clear_stream_stats_for_group(conn, 1) == 0
+    assert clear_stream_stats(conn, 1) == 0
 
 
 def test_clear_all_nulls_every_active_stream(conn):
@@ -110,7 +107,7 @@ def test_clear_all_nulls_every_active_stream(conn):
     _insert_stream(conn, cid, 300, source_group_id=3, removed=True)
     conn.commit()
 
-    cleared = clear_all_stream_stats(conn)
+    cleared = clear_stream_stats(conn)
 
     assert cleared == 2
     assert _stats_row(conn, 100)["stream_stats"] is None

--- a/tests/test_dispatcharr_stream_stats.py
+++ b/tests/test_dispatcharr_stream_stats.py
@@ -1,0 +1,88 @@
+"""Tests for DispatcharrClient.get_stream_stats_by_ids.
+
+Fetches stream_stats for a batch of streams via POST
+/api/channels/streams/by-ids/, returning only id / stream_stats /
+stream_stats_updated_at. Non-existent ids are silently omitted by Dispatcharr.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from teamarr.dispatcharr.client import DispatcharrClient
+
+
+@pytest.fixture
+def client():
+    # __init__ does not authenticate, so a bare client is safe to construct.
+    return DispatcharrClient("http://dispatcharr.local", "user", "pass")
+
+
+def _resp(status_code, payload=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    return r
+
+
+def test_empty_ids_short_circuits(client):
+    client.post = MagicMock()
+    assert client.get_stream_stats_by_ids([]) == []
+    client.post.assert_not_called()
+
+
+def test_none_response_returns_empty(client):
+    client.post = MagicMock(return_value=None)
+    assert client.get_stream_stats_by_ids([1, 2]) == []
+
+
+def test_non_200_returns_empty(client):
+    client.post = MagicMock(return_value=_resp(500))
+    assert client.get_stream_stats_by_ids([1]) == []
+
+
+def test_results_wrapper_is_mapped(client):
+    payload = {
+        "results": [
+            {
+                "id": 1,
+                "stream_stats": {"resolution": "1920x1080"},
+                "stream_stats_updated_at": "t1",
+                "extra": "drop",
+            },
+            {"id": 2, "stream_stats": None, "stream_stats_updated_at": None},
+        ]
+    }
+    client.post = MagicMock(return_value=_resp(200, payload))
+
+    result = client.get_stream_stats_by_ids([1, 2])
+
+    assert result == [
+        {"id": 1, "stream_stats": {"resolution": "1920x1080"}, "stream_stats_updated_at": "t1"},
+        {"id": 2, "stream_stats": None, "stream_stats_updated_at": None},
+    ]
+    # endpoint + body sanity
+    endpoint, body = client.post.call_args[0]
+    assert "streams/by-ids/" in endpoint
+    assert body == {"ids": [1, 2]}
+
+
+def test_bare_list_payload_is_handled(client):
+    payload = [{"id": 5, "stream_stats": {"source_fps": 60}, "stream_stats_updated_at": "t"}]
+    client.post = MagicMock(return_value=_resp(200, payload))
+
+    result = client.get_stream_stats_by_ids([5])
+    assert result == [{"id": 5, "stream_stats": {"source_fps": 60}, "stream_stats_updated_at": "t"}]
+
+
+def test_entries_without_id_are_skipped(client):
+    payload = {
+        "results": [
+            {"stream_stats": {"x": 1}},
+            {"id": 9, "stream_stats": {"y": 2}, "stream_stats_updated_at": "t"},
+        ]
+    }
+    client.post = MagicMock(return_value=_resp(200, payload))
+
+    result = client.get_stream_stats_by_ids([9])
+    assert [r["id"] for r in result] == [9]

--- a/tests/test_managed_channel_stream_stats_parsing.py
+++ b/tests/test_managed_channel_stream_stats_parsing.py
@@ -1,0 +1,37 @@
+"""Tests for ManagedChannelStream.from_row stream_stats JSON handling.
+
+The DB stores stream_stats as a JSON string; from_row decodes it to a dict,
+tolerates malformed JSON (→ None), and passes a dict through unchanged.
+"""
+
+from teamarr.database.channels.types import ManagedChannelStream
+
+
+def _row(stream_stats):
+    return {
+        "id": 1,
+        "managed_channel_id": 1,
+        "dispatcharr_stream_id": 100,
+        "stream_stats": stream_stats,
+    }
+
+
+def test_valid_json_string_decoded_to_dict():
+    s = ManagedChannelStream.from_row(_row('{"resolution": "1920x1080"}'))
+    assert s.stream_stats == {"resolution": "1920x1080"}
+
+
+def test_invalid_json_string_becomes_none():
+    s = ManagedChannelStream.from_row(_row("{not valid json"))
+    assert s.stream_stats is None
+
+
+def test_dict_passthrough():
+    s = ManagedChannelStream.from_row(_row({"source_fps": 60}))
+    assert s.stream_stats == {"source_fps": 60}
+
+
+def test_missing_stats_is_none():
+    row = {"id": 1, "managed_channel_id": 1, "dispatcharr_stream_id": 100}
+    assert ManagedChannelStream.from_row(row).stream_stats is None
+    assert ManagedChannelStream.from_row(_row(None)).stream_stats is None

--- a/tests/test_refresh_stream_stats.py
+++ b/tests/test_refresh_stream_stats.py
@@ -1,0 +1,154 @@
+"""Tests for refresh_stream_stats — caching Dispatcharr stream_stats locally.
+
+refresh_stream_stats pulls stats for a managed channel's active streams from
+Dispatcharr (via get_stream_stats_by_ids) and writes them to the
+stream_stats / stream_stats_updated_at columns. Streams Dispatcharr hasn't
+probed yet (stream_stats=None) are left unchanged.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import teamarr.dispatcharr.factory as factory
+from teamarr.database.channels.streams import refresh_stream_stats
+from teamarr.database.connection import get_connection, init_db
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db_path = tmp_path / "t.db"
+    init_db(db_path)
+    c = get_connection(db_path)
+    yield c
+    c.close()
+
+
+class _StubClient:
+    def __init__(self, stats_list):
+        self._stats_list = stats_list
+        self.calls = []
+
+    def get_stream_stats_by_ids(self, stream_ids):
+        self.calls.append(list(stream_ids))
+        return self._stats_list
+
+
+@pytest.fixture
+def patch_client(monkeypatch):
+    """Install a stub Dispatcharr client; return a setter for the stub/None."""
+    holder = {}
+
+    def install(client):
+        holder["client"] = client
+        monkeypatch.setattr(factory, "get_dispatcharr_client", lambda: client)
+        return client
+
+    install(None)
+    return install, holder
+
+
+def _insert_channel(conn) -> int:
+    cur = conn.execute(
+        "INSERT INTO managed_channels (event_id, event_provider, tvg_id, channel_name) "
+        "VALUES ('e1', 'espn', 'tvg-1', 'NHL | CAR / VGK')"
+    )
+    return cur.lastrowid
+
+
+def _insert_stream(conn, channel_id, stream_id, *, removed=False):
+    conn.execute(
+        """INSERT INTO managed_channel_streams
+           (managed_channel_id, dispatcharr_stream_id, removed_at)
+           VALUES (?, ?, ?)""",
+        (channel_id, stream_id, "2026-06-16 01:00:00" if removed else None),
+    )
+
+
+def _stats_row(conn, stream_id):
+    return conn.execute(
+        "SELECT stream_stats, stream_stats_updated_at FROM managed_channel_streams "
+        "WHERE dispatcharr_stream_id = ?",
+        (stream_id,),
+    ).fetchone()
+
+
+def test_no_active_streams_returns_zero_without_client(conn, patch_client):
+    install, _ = patch_client
+    stub = _StubClient([{"id": 1, "stream_stats": {"x": 1}, "stream_stats_updated_at": "t"}])
+    install(stub)
+    cid = _insert_channel(conn)  # channel with no streams
+    conn.commit()
+
+    assert refresh_stream_stats(conn, cid) == 0
+    assert stub.calls == []  # short-circuits before touching the client
+
+
+def test_client_none_returns_zero(conn, patch_client):
+    install, _ = patch_client
+    install(None)
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100)
+    conn.commit()
+
+    assert refresh_stream_stats(conn, cid) == 0
+
+
+def test_empty_stats_list_returns_zero(conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([]))
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100)
+    conn.commit()
+
+    assert refresh_stream_stats(conn, cid) == 0
+    assert _stats_row(conn, 100)["stream_stats"] is None
+
+
+def test_happy_path_persists_stats_as_json(conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([
+        {
+            "id": 100,
+            "stream_stats": {"resolution": "1920x1080"},
+            "stream_stats_updated_at": "2026-06-16T00:00:00Z",
+        },
+    ]))
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100)
+    conn.commit()
+
+    assert refresh_stream_stats(conn, cid) == 1
+    row = _stats_row(conn, 100)
+    assert json.loads(row["stream_stats"]) == {"resolution": "1920x1080"}
+    assert row["stream_stats_updated_at"] == "2026-06-16T00:00:00Z"
+
+
+def test_unprobed_stream_is_skipped(conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([
+        {"id": 100, "stream_stats": None, "stream_stats_updated_at": None},
+        {"id": 101, "stream_stats": {"source_fps": 60}, "stream_stats_updated_at": "t"},
+    ]))
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100)
+    _insert_stream(conn, cid, 101)
+    conn.commit()
+
+    assert refresh_stream_stats(conn, cid) == 1
+    assert _stats_row(conn, 100)["stream_stats"] is None
+    assert json.loads(_stats_row(conn, 101)["stream_stats"]) == {"source_fps": 60}
+
+
+def test_removed_streams_not_selected(conn, patch_client):
+    install, _ = patch_client
+    stub = _StubClient([{"id": 100, "stream_stats": {"x": 1}, "stream_stats_updated_at": "t"}])
+    install(stub)
+    cid = _insert_channel(conn)
+    _insert_stream(conn, cid, 100, removed=True)
+    conn.commit()
+
+    # No active streams → returns 0 and the client is never queried.
+    assert refresh_stream_stats(conn, cid) == 0
+    assert stub.calls == []

--- a/tests/test_stream_match_details.py
+++ b/tests/test_stream_match_details.py
@@ -78,3 +78,107 @@ def test_most_recent_row_wins_per_pair(conn):
 
 def test_empty_pairs_returns_empty(conn):
     assert get_stream_match_details(conn, []) == {}
+
+
+def _insert_event_with_teams(conn, group_id, stream_id, *, stream_name, league,
+                             home_id, home_name, away_id, away_name, method="alias"):
+    data = json.dumps({
+        "name": f"{away_name} at {home_name}",
+        "home_team": {"id": home_id, "name": home_name},
+        "away_team": {"id": away_id, "name": away_name},
+    })
+    conn.execute(
+        """INSERT INTO stream_match_cache
+           (fingerprint, group_id, stream_id, stream_name, event_id, league,
+            cached_event_data, match_method, user_corrected, corrected_at, updated_at)
+           VALUES (?, ?, ?, ?, 'e1', ?, ?, ?, 0, NULL, '2026-06-16 00:00:00')""",
+        (f"fp-{group_id}-{stream_id}", group_id, stream_id, stream_name, league, data, method),
+    )
+    conn.commit()
+
+
+def _insert_alias(conn, alias, league, team_id, team_name, provider="espn"):
+    conn.execute(
+        "INSERT INTO team_aliases (alias, league, provider, team_id, team_name) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (alias, league, provider, team_id, team_name),
+    )
+    conn.commit()
+
+
+def test_alias_mapping_reconstructed_for_alias_match(conn):
+    _insert_event_with_teams(
+        conn, 1, 100, stream_name="Spurs vs Lakers HD", league="nba",
+        home_id="13", home_name="Los Angeles Lakers",
+        away_id="24", away_name="San Antonio Spurs",
+    )
+    _insert_alias(conn, "spurs", "nba", "24", "San Antonio Spurs")
+    _insert_alias(conn, "celtics", "nba", "2", "Boston Celtics")  # not in this event/name
+
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    assert d["aliases"] == [{"alias": "spurs", "team": "San Antonio Spurs"}]
+
+
+def test_non_alias_match_has_no_aliases(conn):
+    _insert_event_with_teams(
+        conn, 1, 100, stream_name="Spurs vs Lakers HD", league="nba",
+        home_id="13", home_name="Los Angeles Lakers",
+        away_id="24", away_name="San Antonio Spurs", method="fuzzy",
+    )
+    _insert_alias(conn, "spurs", "nba", "24", "San Antonio Spurs")
+
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    assert d["aliases"] == []
+
+
+def _team(tid, name, short, abbr):
+    return {"id": tid, "name": name, "short_name": short, "abbreviation": abbr}
+
+
+def _insert_event_full_teams(conn, stream_name, method, *, home, away):
+    """home/away are dicts with id/name/short_name/abbreviation."""
+    data = json.dumps({
+        "name": f"{away['name']} at {home['name']}",
+        "home_team": home,
+        "away_team": away,
+    })
+    conn.execute(
+        """INSERT INTO stream_match_cache
+           (fingerprint, group_id, stream_id, stream_name, event_id, league,
+            cached_event_data, match_method, updated_at)
+           VALUES ('fp', 1, 100, ?, 'e1', 'mlb', ?, ?, '2026-06-16 00:00:00')""",
+        (stream_name, data, method),
+    )
+    conn.commit()
+
+
+def test_pattern_match_reconstructs_team_token(conn):
+    _insert_event_full_teams(
+        conn, "Phillies vs Athletics 1080p", "pattern",
+        home=_team("22", "Philadelphia Phillies", "Phillies", "PHI"),
+        away=_team("11", "Athletics", "Athletics", "ATH"),
+    )
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    # Short name "Phillies" appears; full name doesn't, so token is the short name.
+    assert {"token": "Phillies", "team": "Philadelphia Phillies"} in d["patterns"]
+    assert {"token": "Athletics", "team": "Athletics"} in d["patterns"]
+
+
+def test_pattern_abbreviation_matches_on_word_boundary(conn):
+    _insert_event_full_teams(
+        conn, "PHI feed", "pattern",
+        home=_team("22", "Philadelphia Phillies", "Phils", "PHI"),
+        away=_team("11", "New York Mets", "Mets", "NYM"),
+    )
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    assert d["patterns"] == [{"token": "PHI", "team": "Philadelphia Phillies"}]
+
+
+def test_non_pattern_match_has_no_patterns(conn):
+    _insert_event_full_teams(
+        conn, "Phillies vs Athletics", "fuzzy",
+        home=_team("22", "Philadelphia Phillies", "Phillies", "PHI"),
+        away=_team("11", "Athletics", "Athletics", "ATH"),
+    )
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    assert d["patterns"] == []

--- a/tests/test_stream_match_details.py
+++ b/tests/test_stream_match_details.py
@@ -1,0 +1,80 @@
+"""Tests for get_stream_match_details — cache-derived 'how it matched' detail.
+
+Reads stream_match_cache to explain a stream's match (matched event, method,
+user correction). Used by the Managed Channels method popover.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from teamarr.database.channels.streams import get_stream_match_details
+from teamarr.database.connection import get_connection, init_db
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db_path = tmp_path / "t.db"
+    init_db(db_path)
+    c = get_connection(db_path)
+    yield c
+    c.close()
+
+
+def _insert(conn, group_id, stream_id, *, event_id="e1", league="nhl",
+            event_name="Hurricanes at Golden Knights", method="fuzzy",
+            user_corrected=0, corrected_at=None, updated_at="2026-06-16 00:00:00",
+            fingerprint=None):
+    data = json.dumps({"name": event_name}) if event_name is not None else None
+    conn.execute(
+        """INSERT INTO stream_match_cache
+           (fingerprint, group_id, stream_id, stream_name, event_id, league,
+            cached_event_data, match_method, user_corrected, corrected_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (fingerprint or f"fp-{group_id}-{stream_id}-{updated_at}", group_id, stream_id,
+         "ESPN", event_id, league, data, method, user_corrected, corrected_at, updated_at),
+    )
+    conn.commit()
+
+
+def test_returns_match_detail_for_pair(conn):
+    _insert(conn, 1, 100, event_name="Hurricanes at Golden Knights", method="alias",
+            user_corrected=1, corrected_at="2026-06-15 12:00:00")
+
+    out = get_stream_match_details(conn, [(1, 100)])
+
+    assert (1, 100) in out
+    d = out[(1, 100)]
+    assert d["event_name"] == "Hurricanes at Golden Knights"
+    assert d["league"] == "nhl"
+    assert d["match_method"] == "alias"
+    assert d["user_corrected"] is True
+    assert d["corrected_at"] == "2026-06-15 12:00:00"
+
+
+def test_failed_match_is_excluded(conn):
+    _insert(conn, 1, 100, event_id="__FAILED__", event_name=None, method="no_match")
+    assert get_stream_match_details(conn, [(1, 100)]) == {}
+
+
+def test_unrequested_pairs_excluded(conn):
+    _insert(conn, 1, 100)
+    _insert(conn, 2, 200)
+    out = get_stream_match_details(conn, [(1, 100)])
+    assert set(out.keys()) == {(1, 100)}
+
+
+def test_most_recent_row_wins_per_pair(conn):
+    _insert(conn, 1, 100, event_name="Old Event", method="fuzzy",
+            updated_at="2026-06-10 00:00:00")
+    _insert(conn, 1, 100, event_name="New Event", method="alias",
+            updated_at="2026-06-16 00:00:00")
+
+    d = get_stream_match_details(conn, [(1, 100)])[(1, 100)]
+    assert d["event_name"] == "New Event"
+    assert d["match_method"] == "alias"
+
+
+def test_empty_pairs_returns_empty(conn):
+    assert get_stream_match_details(conn, []) == {}

--- a/tests/test_stream_ordering.py
+++ b/tests/test_stream_ordering.py
@@ -389,3 +389,64 @@ class TestStatsMetric:
         # no operator
         assert self._svc("source_fps").compute_priority(stream) == NO_MATCH_PRIORITY
         assert self._svc("source_fps|>=|notanumber").compute_priority(stream) == NO_MATCH_PRIORITY
+
+
+class TestEvaluateRules:
+    """evaluate_rules reports every matching rule plus the 'everything else'
+    baseline, flagging the one that won."""
+
+    def test_multiple_matches_only_lowest_priority_wins(self):
+        rules = [
+            StreamOrderingRule("regex", r"(?i)1080p", 5),
+            StreamOrderingRule("regex", r"(?i)espn", 2),
+        ]
+        svc = StreamOrderingService(rules)
+        evals = svc.evaluate_rules(_stream("ESPN 1080p"))
+
+        # Two regex matches + the implicit baseline (no catch_all configured).
+        assert [e.type for e in evals] == ["regex", "regex", "catch_all"]
+        winners = [e for e in evals if e.is_winner]
+        assert len(winners) == 1
+        # The priority-2 ESPN rule wins (lower number, evaluated first).
+        assert winners[0].priority == 2
+        assert winners[0].type == "regex"
+
+    def test_baseline_shown_with_default_priority_when_no_catch_all(self):
+        svc = StreamOrderingService([StreamOrderingRule("regex", r"(?i)espn", 2)])
+        baseline = svc.evaluate_rules(_stream("ESPN 1080p"))[-1]
+        assert baseline.type == "catch_all"
+        assert baseline.priority == NO_MATCH_PRIORITY
+        assert baseline.is_winner is False  # a specific rule won
+
+    def test_catch_all_wins_when_nothing_else_matches(self):
+        rules = [
+            StreamOrderingRule("regex", r"(?i)1080p", 5),
+            StreamOrderingRule("catch_all", "", 50),
+        ]
+        svc = StreamOrderingService(rules)
+        evals = svc.evaluate_rules(_stream("ESPN 720p"))
+
+        assert len(evals) == 1
+        assert evals[0].type == "catch_all"
+        assert evals[0].priority == 50
+        assert evals[0].is_winner is True
+
+    def test_catch_all_shown_as_baseline_when_a_rule_matches(self):
+        rules = [
+            StreamOrderingRule("regex", r"(?i)1080p", 5),
+            StreamOrderingRule("catch_all", "", 50),
+        ]
+        svc = StreamOrderingService(rules)
+        evals = svc.evaluate_rules(_stream("ESPN 1080p"))
+
+        assert [e.type for e in evals] == ["regex", "catch_all"]
+        assert evals[0].is_winner is True  # the regex rule won
+        assert evals[1].is_winner is False  # baseline shown but did not win
+        assert evals[1].priority == 50
+
+    def test_no_rules_returns_just_the_baseline(self):
+        evals = StreamOrderingService([]).evaluate_rules(_stream("anything"))
+        assert len(evals) == 1
+        assert evals[0].type == "catch_all"
+        assert evals[0].priority == NO_MATCH_PRIORITY
+        assert evals[0].is_winner is True

--- a/tests/test_stream_ordering.py
+++ b/tests/test_stream_ordering.py
@@ -313,3 +313,79 @@ class TestKeyParsing:
         rows = svc._query_team_cache_by_keys(["espn:23", "espn:mlb:16"])
         names = {r["team_name"] for r in rows}
         assert {"Pittsburgh Pirates", "Chicago Cubs"} <= names
+
+
+class TestStatsMetric:
+    """The stats_metric rule matches streams by Dispatcharr stream_stats values."""
+
+    def _stream(self, stats: dict | None) -> ManagedChannelStream:
+        return ManagedChannelStream(
+            id=1, managed_channel_id=1, dispatcharr_stream_id=1, stream_stats=stats
+        )
+
+    def _svc(self, value: str) -> StreamOrderingService:
+        return StreamOrderingService([StreamOrderingRule("stats_metric", value, 1)])
+
+    @pytest.mark.parametrize(
+        "operator,threshold,bitrate,expected",
+        [
+            (">=", "4000", 4000, True),
+            (">=", "4000", 3999, False),
+            ("<=", "4000", 4000, True),
+            ("<=", "4000", 4001, False),
+            (">", "4000", 4001, True),
+            (">", "4000", 4000, False),
+            ("<", "4000", 3999, True),
+            ("<", "4000", 4000, False),
+            ("=", "4000", 4000, True),
+            ("=", "4000", 4001, False),
+        ],
+    )
+    def test_operators(self, operator, threshold, bitrate, expected):
+        svc = self._svc(f"ffmpeg_output_bitrate|{operator}|{threshold}")
+        stream = self._stream({"ffmpeg_output_bitrate": bitrate})
+        matched = svc.compute_priority(stream) == 1
+        assert matched is expected
+
+    def test_virtual_resolution_width_and_height(self):
+        stream = self._stream({"resolution": "1920x1080"})
+        assert self._svc("resolution_width|>=|1920").compute_priority(stream) == 1
+        assert self._svc("resolution_height|>=|1080").compute_priority(stream) == 1
+        assert self._svc("resolution_width|>|1920").compute_priority(stream) == NO_MATCH_PRIORITY
+
+    def test_malformed_resolution_does_not_match(self):
+        stream = self._stream({"resolution": "1080"})  # no "x"
+        assert self._svc("resolution_width|>=|720").compute_priority(stream) == NO_MATCH_PRIORITY
+
+    def test_multi_condition_and(self):
+        rule = "source_fps|>=|50;ffmpeg_output_bitrate|>=|4000"
+        both = self._stream({"source_fps": 60, "ffmpeg_output_bitrate": 5000})
+        one = self._stream({"source_fps": 30, "ffmpeg_output_bitrate": 5000})
+        assert self._svc(rule).compute_priority(both) == 1
+        assert self._svc(rule).compute_priority(one) == NO_MATCH_PRIORITY
+
+    def test_is_unknown_matches_when_absent(self):
+        # No stats at all, or the specific metric missing → is_unknown matches.
+        assert self._svc("source_fps|is_unknown").compute_priority(self._stream(None)) == 1
+        assert (
+            self._svc("source_fps|is_unknown").compute_priority(
+                self._stream({"resolution": "1920x1080"})
+            )
+            == 1
+        )
+        # Metric present → is_unknown does not match.
+        assert (
+            self._svc("source_fps|is_unknown").compute_priority(self._stream({"source_fps": 60}))
+            == NO_MATCH_PRIORITY
+        )
+
+    def test_numeric_op_with_no_stats_does_not_match(self):
+        svc = self._svc("source_fps|>=|50")
+        assert svc.compute_priority(self._stream(None)) == NO_MATCH_PRIORITY
+
+    def test_malformed_rule_value_does_not_raise(self):
+        stream = self._stream({"source_fps": 60})
+        assert self._svc("").compute_priority(stream) == NO_MATCH_PRIORITY
+        # no operator
+        assert self._svc("source_fps").compute_priority(stream) == NO_MATCH_PRIORITY
+        assert self._svc("source_fps|>=|notanumber").compute_priority(stream) == NO_MATCH_PRIORITY


### PR DESCRIPTION
Adds stream quality stats to managed channels and a new ordering rule that sorts
  streams by those stats.

  ## What's included

  **Stream stats caching**
  - New `get_stream_stats_by_ids` client method pulls stats from Dispatcharr's
    `/api/channels/streams/by-ids/` endpoint (works regardless of channel assignment).
  - Caches stats in new `stream_stats` / `stream_stats_updated_at` columns on
    `managed_channel_streams`.
  - `GET /channels/managed/{id}/streams` returns each stream's group, account,
    match method, priority, and cached stats. Refreshes automatically when stats
    are missing or older than an hour.

  **Stat-based stream ordering**
  - New `stats_metric` ordering rule matches streams where a numeric stat
    (resolution, bitrate, fps, audio bitrate, sample rate) meets a threshold.
  - Supports multiple conditions per rule via a dedicated builder in the
    Stream Ordering UI.

  **Expandable channel rows**
  - Managed Channels table rows now expand to show their streams with stats badges
    (resolution, fps, bitrate, audio), group, account, match method, and priority.

  ## Notes
  - Schema gets two new columns; reconciliation handles the upgrade on startup.
  - `VALID_RULE_TYPES` updated on both backend and frontend to include `stats_metric`.