### PR TITLE
Fix: coalesce repeated event-status refreshes within a run

### DIFF
--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -2014,7 +2014,9 @@ class EventGroupProcessor:
             event = match.get("event")
             if event:
                 old_status = event.status.state if event.status else "N/A"
-                # Refresh event status from provider (invalidates cache, fetches fresh)
+                # Refresh event status from provider. The service coalesces
+                # repeated refreshes of the same event within a run, so an event
+                # matched to many channels triggers a single provider fetch.
                 refreshed = self._service.refresh_event_status(event)
                 new_status = refreshed.status.state if refreshed.status else "N/A"
                 if old_status != new_status:

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -39,6 +39,16 @@ from teamarr.utilities.event_status import is_event_final
 
 logger = logging.getLogger(__name__)
 
+# Coalesce window for refresh_event_status. The same event is matched to many
+# channels and re-checked by the filler, so during one generation run an event
+# can be refreshed dozens-to-hundreds of times — each call invalidating the
+# event cache and re-hitting the provider summary endpoint serially. The marker
+# lives in the shared cache (so the teams and event-group passes coordinate),
+# and the window is short enough that separate scheduled runs still pull fresh
+# scores. Must stay well under CACHE_TTL_SINGLE_EVENT so get_event can serve the
+# cached event during the window.
+REFRESH_COALESCE_TTL = 300  # seconds
+
 
 def _backfill_team_from_cache(team: Team | None, league: str) -> Team | None:
     """Patch a Team's short_name/abbreviation/name from team_cache when missing.
@@ -430,9 +440,19 @@ class SportsDataService:
         if not event:
             return event
 
-        # Invalidate cache to force fresh fetch from provider
+        # Coalesce repeated refreshes of the same event within a run. Normally we
+        # invalidate the event cache to force a fresh provider fetch, but the same
+        # event is refreshed once per channel (and again by the filler), so a
+        # popular event would otherwise trigger many identical serial summary
+        # fetches. Skip the invalidating delete when we've already refreshed this
+        # event inside the coalesce window — get_event then serves the fresh-enough
+        # copy from the (30-min) event cache. The marker is in the shared cache so
+        # the teams and event-group passes coordinate.
         cache_key = make_cache_key("event", event.league, event.id)
-        self._cache.delete(cache_key)
+        coalesce_key = make_cache_key("event_refresh", event.league, event.id)
+        if not self._cache.get(coalesce_key):
+            self._cache.delete(cache_key)
+            self._cache.set(coalesce_key, True, REFRESH_COALESCE_TTL)
 
         fresh_event = self.get_event(event.id, event.league)
         if not fresh_event:

--- a/tests/test_refresh_event_status_additive.py
+++ b/tests/test_refresh_event_status_additive.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 from teamarr.core.types import Event, EventStatus, Team
 from teamarr.services.sports_data import SportsDataService
+from teamarr.utilities.cache import make_cache_key
 
 
 def _make_event(status_state: str = "scheduled", **overrides) -> Event:
@@ -171,19 +172,30 @@ class TestRefreshIsAdditive:
 
 
 class TestRefreshCacheInvalidation:
-    """Refresh must invalidate the cache for the event so subsequent reads see fresh."""
+    """First refresh invalidates the event cache for a fresh fetch; repeats
+    within the coalesce window reuse it instead of re-hitting the provider."""
 
-    def test_cache_delete_called_with_correct_key(self):
+    def test_first_refresh_invalidates_then_coalesces(self):
         original = _make_event()
         service = SportsDataService(providers=[])
+        # The service cache is a process-wide singleton, so a prior test may have
+        # left a coalesce marker for this event — start from a clean state.
+        service._cache.delete(make_cache_key("event_refresh", original.league, original.id))
+
         mock_delete = MagicMock()
         with (
             patch.object(service, "get_event", return_value=original),
             patch.object(service._cache, "delete", mock_delete),
         ):
+            # First refresh: cache invalidated so the provider is hit fresh.
             service.refresh_event_status(original)
-        mock_delete.assert_called_once()
-        # Key shape: ("event", "mlb", "401")
-        call_args = mock_delete.call_args[0][0]
-        assert "401" in str(call_args)
-        assert "mlb" in str(call_args)
+            assert mock_delete.call_count == 1
+            # Key shape: ("event", "mlb", "401")
+            call_args = mock_delete.call_args[0][0]
+            assert "401" in str(call_args)
+            assert "mlb" in str(call_args)
+
+            # Second refresh within the window: coalesced — no re-invalidation,
+            # so a popular event matched to many channels fetches once per run.
+            service.refresh_event_status(original)
+            assert mock_delete.call_count == 1


### PR DESCRIPTION
## Summary

  Full EPG generation was dominated by redundant ESPN API calls, not by matching
  or channel writes. `refresh_event_status` invalidated the event cache and
  re-hit ESPN's `summary?event=` endpoint on **every** call — and the same event
  is refreshed once per channel and again by the filler. A single event was
  fetched **164×** in a 115-channel run; **2,027** summary calls per run total.

  This adds a run-scoped coalesce so each event hits the provider **once per run**.

  ## Problem

  `refresh_event_status(event)`:
  1. `self._cache.delete(event_key)`  → forces a cache miss
  2. `self.get_event(...)`            → re-fetches from ESPN summary endpoint

Called per matched stream (`_enrich_matched_events`), per channel final-check (`event_filler._check_event_final`), and during team EPG generation. With one event mapped to N channels, that's N identical serial HTTP round-trips.

  Measured baseline (115 channels, 144 teams, 123 groups):
  - **6,408** total HTTP requests — **4,447 to ESPN**
  - **2,027** calls to `summary?event=` across ~30 hot events (top event: 164×)

  ## Fix
A coalesce marker in the shared singleton cache (`services/sports_data.py`):
  - First refresh of an event within the window: invalidate + fetch fresh (unchanged).
  - Repeats within `REFRESH_COALESCE_TTL` (5 min): skip the invalidating delete, so
    `get_event` serves from the existing 30-min event cache — no HTTP.

Because the marker lives in the shared cache, it covers **all** callers (enrich, filler, team EPG) and coordinates the teams + event-group passes. The window is short enough that separately-scheduled runs still pull fresh scores (`REFRESH_COALESCE_TTL` ≪ `CACHE_TTL_SINGLE_EVENT`).

  ## Results

  | Metric | Before | After |
  |---|---|---|
  | Full generation duration | 427s | **228s** (−47%) |
  | ESPN `summary` calls | 2,027 | **289** |
  | Max fetches per event | 164× | 2× |