### PR TITLE
Channel numbering stability

### DIFF
--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -54,8 +54,22 @@ To stop gaps accumulating and to restore priority order, a full re-grid runs onc
 {: .note }
 Reset Time is the **server's** local time. In Docker this is usually UTC unless you set the container `TZ` — pick the value accordingly.
 
+### Re-grid now
+
+You don't have to wait for the daily window. **Re-grid channels now** queues a one-shot re-layout that runs on the **next generation** — renumbering every channel back into priority order and reclaiming gaps, regardless of the reset time (and even if the daily re-layout is turned off).
+
+Changing the **gap size**, switching **stability mode**, or reordering **sort priority / priority teams** queues the same re-grid automatically, so the change takes effect on the next run instead of silently waiting for the daily reset. (This is non-destructive — channels keep their identity and streams; only their numbers change.)
+
 {: .note }
 Number Stability applies to **Auto** mode. Manual mode uses its own per-league sequential numbering.
+
+### Trade-off: ordering vs. stability
+
+You can't have perfectly priority-ordered numbers *and* numbers that never move when the slate changes — so the sticky modes choose stability and reclaim ordering at the daily reset.
+
+Between resets, ordering is **best-effort**. A new event slots into a free number near where it sorts, but if it would sort **above every existing channel** and there's no room below them (for example a [Priority Team](#channel-ordering) game, or an earlier-starting game in your top league, that's only discovered on a later run), it is placed at the **end of the range** rather than displacing anyone. It stays there until the next daily re-layout puts it back in priority order.
+
+If keeping the top of your lineup in strict priority order matters more than holding numbers steady, run the daily reset more often (or keep **Compact** mode, which re-sorts every run at the cost of live channels shifting).
 
 ## Per-League Starting Channels (Manual Mode)
 

--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -52,6 +52,9 @@ To stop gaps accumulating and to restore priority order, a full re-grid runs onc
 | **Reset Time** | Local time of the low-traffic window for the re-layout (default `04:00`). |
 
 {: .note }
+Reset Time is the **server's** local time. In Docker this is usually UTC unless you set the container `TZ` — pick the value accordingly.
+
+{: .note }
 Number Stability applies to **Auto** mode. Manual mode uses its own per-league sequential numbering.
 
 ## Per-League Starting Channels (Manual Mode)

--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -29,6 +29,31 @@ Both modes use a global channel range:
 {: .tip }
 Set the range start above your existing Dispatcharr channels (e.g., start at 1000 if you already use 1–500) to avoid number collisions.
 
+## Number Stability (Auto Mode)
+
+Controls whether a channel can be **renumbered while its event is live**. Dispatcharr relies on channel numbers staying put, so a game shouldn't jump numbers just because another event started or ended.
+
+| Mode | Behaviour |
+|------|-----------|
+| **Compact** | Re-sorts every channel into tidy contiguous order on every run (legacy default). A live channel's number can shift when events start or end. |
+| **Gapped (sticky)** | Channels are spaced apart by the **gap size** (e.g. 3 → 101, 104, 107). A new event slots into a free number near where it sorts (filling the gap, or reusing a slot freed by an ended event); existing channels keep their number for the whole event lifecycle. |
+| **Strict (no drift)** | Existing channels never move. A new event that would displace others is appended to the end of the range instead. Gaps left by ended events are reclaimed only at the daily reset. |
+
+In both **Gapped** and **Strict** modes, a channel's number is fixed for the life of its event. The only time existing numbers change is the **daily re-layout**.
+
+### Daily Re-Layout
+
+To stop gaps accumulating and to restore priority order, a full re-grid runs once per day. It is gated into your generation schedule: the **first generation at or after the configured reset time** re-grids every channel, then it won't run again until the next day.
+
+| Field | Description |
+|-------|-------------|
+| **Gap Size** | (Gapped mode) spacing between channels at reset. Larger gaps leave more room for late events to slot in without moving anyone. |
+| **Daily re-layout** | Toggle the periodic re-grid on/off. With it off, numbers stay sticky indefinitely and gaps are never reclaimed automatically. |
+| **Reset Time** | Local time of the low-traffic window for the re-layout (default `04:00`). |
+
+{: .note }
+Number Stability applies to **Auto** mode. Manual mode uses its own per-league sequential numbering.
+
 ## Per-League Starting Channels (Manual Mode)
 
 When Manual mode is selected, a table lists all leagues with a configurable starting channel number for each. Use the search field and the **Subscribed only** toggle to filter the list.

--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -41,6 +41,9 @@ Controls whether a channel can be **renumbered while its event is live**. Dispat
 
 In both **Gapped** and **Strict** modes, a channel's number is fixed for the life of its event. The only time existing numbers change is the **daily re-layout**.
 
+{: .note }
+**Feeds stay together.** When feed separation splits an event into Home / Away / Regular channels, they're treated as one block and placed on **adjacent** numbers — the gap is only ever applied *between* events, never between feeds of the same game. A multi-feed event simply consumes more of its gap (e.g. with gap size 3, a 3-feed event fills 101–103 and the next event starts at 104).
+
 ### Daily Re-Layout
 
 To stop gaps accumulating and to restore priority order, a full re-grid runs once per day. It is gated into your generation schedule: the **first generation at or after the configured reset time** re-grids every channel, then it won't run again until the next day.

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -125,16 +125,26 @@ export interface TeamFilterSettingsUpdate {
   bypass_filter_for_playoffs?: boolean
 }
 
+export type ChannelStabilityMode = "compact" | "gap" | "strict"
+
 export interface ChannelNumberingSettings {
   global_channel_mode: "auto" | "manual"
   league_channel_starts: Record<string, number>
   global_consolidation_mode: "consolidate" | "separate"
+  channel_stability_mode: ChannelStabilityMode
+  channel_gap_size: number
+  channel_daily_reset_enabled: boolean
+  channel_daily_reset_time: string
 }
 
 export interface ChannelNumberingSettingsUpdate {
   global_channel_mode?: "auto" | "manual"
   league_channel_starts?: Record<string, number>
   global_consolidation_mode?: "consolidate" | "separate"
+  channel_stability_mode?: ChannelStabilityMode
+  channel_gap_size?: number
+  channel_daily_reset_enabled?: boolean
+  channel_daily_reset_time?: string
 }
 
 export interface StreamOrderingRule {

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -135,6 +135,8 @@ export interface ChannelNumberingSettings {
   channel_gap_size: number
   channel_daily_reset_enabled: boolean
   channel_daily_reset_time: string
+  // One-shot re-grid armed for the next generation (read-only; set via relayout endpoint)
+  force_channel_relayout_pending: boolean
 }
 
 export interface ChannelNumberingSettingsUpdate {
@@ -503,6 +505,11 @@ export async function updateChannelNumberingSettings(
   data: ChannelNumberingSettingsUpdate
 ): Promise<ChannelNumberingSettings> {
   return api.put("/settings/channel-numbering", data)
+}
+
+// Arm a one-shot full re-grid for the next generation (gap/strict modes only).
+export async function requestChannelRelayout(): Promise<ChannelNumberingSettings> {
+  return api.post("/settings/channel-numbering/relayout", {})
 }
 
 // Stream Ordering Settings API

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1897,8 +1897,6 @@ export function Settings() {
           <SaveButton onClick={handleSaveChannelsDVR} pending={updateChannelsDVR.isPending} />
         </CardContent>
       </Card>
-
-      <ScheduledChannelResetCard />
       </>
       )}
 
@@ -1911,6 +1909,9 @@ export function Settings() {
 
       {/* Backup & Restore */}
       <BackupRestoreCard />
+
+      {/* Scheduled Channel Reset */}
+      <ScheduledChannelResetCard />
 
       {/* Data Caches */}
       <Card>

--- a/frontend/src/pages/channels/ChannelConsolidation.tsx
+++ b/frontend/src/pages/channels/ChannelConsolidation.tsx
@@ -30,6 +30,10 @@ export function ChannelConsolidation() {
     global_channel_mode: "auto",
     league_channel_starts: {},
     global_consolidation_mode: "consolidate",
+    channel_stability_mode: "compact",
+    channel_gap_size: 1,
+    channel_daily_reset_enabled: true,
+    channel_daily_reset_time: "04:00",
   })
 
   useEffect(() => {

--- a/frontend/src/pages/channels/ChannelConsolidation.tsx
+++ b/frontend/src/pages/channels/ChannelConsolidation.tsx
@@ -34,6 +34,7 @@ export function ChannelConsolidation() {
     channel_gap_size: 1,
     channel_daily_reset_enabled: true,
     channel_daily_reset_time: "04:00",
+    force_channel_relayout_pending: false,
   })
 
   useEffect(() => {

--- a/frontend/src/pages/channels/ChannelConsolidation.tsx
+++ b/frontend/src/pages/channels/ChannelConsolidation.tsx
@@ -31,7 +31,7 @@ export function ChannelConsolidation() {
     league_channel_starts: {},
     global_consolidation_mode: "consolidate",
     channel_stability_mode: "compact",
-    channel_gap_size: 1,
+    channel_gap_size: 3,
     channel_daily_reset_enabled: true,
     channel_daily_reset_time: "04:00",
     force_channel_relayout_pending: false,

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -9,7 +9,9 @@ import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { RadioCards } from "@/components/ui/radio-cards"
 import { SortPriorityManager } from "@/components/SortPriorityManager"
+import { Button } from "@/components/ui/button"
 import { getLeagues, getSports } from "@/api/teams"
+import { requestChannelRelayout } from "@/api/settings"
 import { getSportDisplayName } from "@/lib/utils"
 import {
   useSettings,
@@ -60,6 +62,7 @@ export function ChannelNumbering() {
     channel_gap_size: 1,
     channel_daily_reset_enabled: true,
     channel_daily_reset_time: "04:00",
+    force_channel_relayout_pending: false,
   })
   const [channelRangeStart, setChannelRangeStart] = useState("")
   const [channelRangeEnd, setChannelRangeEnd] = useState("")
@@ -116,6 +119,20 @@ export function ChannelNumbering() {
       toast.success("Channel numbering settings saved")
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to save")
+    }
+  }
+
+  const [regridding, setRegridding] = useState(false)
+  const handleRegrid = async () => {
+    setRegridding(true)
+    try {
+      const updated = await requestChannelRelayout()
+      setChannelNumbering(updated)
+      toast.success("Re-grid queued — channels renumber on the next generation")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to queue re-grid")
+    } finally {
+      setRegridding(false)
     }
   }
 
@@ -317,6 +334,28 @@ export function ChannelNumbering() {
                       </p>
                     </div>
                   )}
+
+                  <div className="space-y-2 pt-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleRegrid}
+                      disabled={regridding || channelNumbering.force_channel_relayout_pending}
+                    >
+                      {channelNumbering.force_channel_relayout_pending
+                        ? "Re-grid queued ✓"
+                        : regridding
+                          ? "Queuing…"
+                          : "Re-grid channels now"}
+                    </Button>
+                    <p className="text-xs text-muted-foreground">
+                      Renumber every channel back into priority order on the next
+                      generation, without waiting for the daily window. Use after
+                      changing the gap size, mode, or sort priority. (These changes
+                      also queue a re-grid automatically.)
+                    </p>
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -59,7 +59,7 @@ export function ChannelNumbering() {
     league_channel_starts: {},
     global_consolidation_mode: "consolidate",
     channel_stability_mode: "compact",
-    channel_gap_size: 1,
+    channel_gap_size: 3,
     channel_daily_reset_enabled: true,
     channel_daily_reset_time: "04:00",
     force_channel_relayout_pending: false,

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -312,7 +312,8 @@ export function ChannelNumbering() {
                       <p className="text-xs text-muted-foreground">
                         The first generation at or after this time re-grids every
                         channel — the only moment existing numbers change. Pick a
-                        low-traffic window.
+                        low-traffic window. Uses the server's local time (usually
+                        UTC in Docker unless the container TZ is set).
                       </p>
                     </div>
                   )}

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -56,6 +56,10 @@ export function ChannelNumbering() {
     global_channel_mode: "auto",
     league_channel_starts: {},
     global_consolidation_mode: "consolidate",
+    channel_stability_mode: "compact",
+    channel_gap_size: 1,
+    channel_daily_reset_enabled: true,
+    channel_daily_reset_time: "04:00",
   })
   const [channelRangeStart, setChannelRangeStart] = useState("")
   const [channelRangeEnd, setChannelRangeEnd] = useState("")
@@ -212,6 +216,110 @@ export function ChannelNumbering() {
               </p>
             </div>
           </div>
+
+          {/* Number Stability (Auto mode only) */}
+          {channelNumbering.global_channel_mode === "auto" && (
+            <div className="space-y-3 pt-2 border-t">
+              <div>
+                <Label className="text-sm font-medium">Number Stability</Label>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Controls whether a channel can be renumbered while an event is
+                  live. Dispatcharr relies on stable numbers, so a game shouldn't
+                  move when another event starts or ends.
+                </p>
+              </div>
+              <RadioCards
+                name="channel-stability-mode"
+                value={channelNumbering.channel_stability_mode}
+                onChange={(v) =>
+                  setChannelNumbering({
+                    ...channelNumbering,
+                    channel_stability_mode: v as ChannelNumberingSettings["channel_stability_mode"],
+                  })
+                }
+                options={[
+                  {
+                    value: "compact",
+                    label: "Compact",
+                    description:
+                      "Re-sort everything into tidy contiguous order every run. A live channel's number can shift when events start or end.",
+                  },
+                  {
+                    value: "gap",
+                    label: "Gapped (sticky)",
+                    description:
+                      "Space channels apart on creation. New events fill a gap near where they sort; existing channels keep their number until the daily reset.",
+                  },
+                  {
+                    value: "strict",
+                    label: "Strict (no drift)",
+                    description:
+                      "Existing channels never move. New channels that would displace others are appended to the end; gaps are reclaimed at the daily reset.",
+                  },
+                ]}
+              />
+
+              {channelNumbering.channel_stability_mode === "gap" && (
+                <div className="space-y-2 max-w-xs">
+                  <Label htmlFor="ch-gap-size">Gap Size</Label>
+                  <Input
+                    id="ch-gap-size"
+                    type="number"
+                    min={1}
+                    value={channelNumbering.channel_gap_size}
+                    onChange={(e) =>
+                      setChannelNumbering({
+                        ...channelNumbering,
+                        channel_gap_size: Math.max(1, parseInt(e.target.value) || 1),
+                      })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Spacing between channels at reset (e.g. 3 → 101, 104, 107).
+                    Leaves room for late events to slot in without moving anyone.
+                  </p>
+                </div>
+              )}
+
+              {channelNumbering.channel_stability_mode !== "compact" && (
+                <div className="space-y-3">
+                  <label className="flex items-center gap-2 cursor-pointer text-sm">
+                    <Switch
+                      checked={channelNumbering.channel_daily_reset_enabled}
+                      onCheckedChange={(checked) =>
+                        setChannelNumbering({
+                          ...channelNumbering,
+                          channel_daily_reset_enabled: checked,
+                        })
+                      }
+                    />
+                    Daily re-layout (reclaim gaps &amp; restore priority order)
+                  </label>
+                  {channelNumbering.channel_daily_reset_enabled && (
+                    <div className="space-y-2 max-w-xs">
+                      <Label htmlFor="ch-reset-time">Reset Time (local)</Label>
+                      <Input
+                        id="ch-reset-time"
+                        type="time"
+                        value={channelNumbering.channel_daily_reset_time}
+                        onChange={(e) =>
+                          setChannelNumbering({
+                            ...channelNumbering,
+                            channel_daily_reset_time: e.target.value,
+                          })
+                        }
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        The first generation at or after this time re-grids every
+                        channel — the only moment existing numbers change. Pick a
+                        low-traffic window.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Per-League Start Numbers (Manual mode only) */}
           {channelNumbering.global_channel_mode === "manual" && (

--- a/teamarr/api/routes/settings/channel_numbering.py
+++ b/teamarr/api/routes/settings/channel_numbering.py
@@ -13,6 +13,19 @@ router = APIRouter()
 
 VALID_CHANNEL_MODES = {"auto", "manual"}
 VALID_CONSOLIDATION_MODES = {"consolidate", "separate"}
+VALID_STABILITY_MODES = {"compact", "gap", "strict"}
+
+
+def _to_model(settings) -> ChannelNumberingSettingsModel:
+    return ChannelNumberingSettingsModel(
+        global_channel_mode=settings.global_channel_mode,
+        league_channel_starts=settings.league_channel_starts,
+        global_consolidation_mode=settings.global_consolidation_mode,
+        channel_stability_mode=settings.channel_stability_mode,
+        channel_gap_size=settings.channel_gap_size,
+        channel_daily_reset_enabled=settings.channel_daily_reset_enabled,
+        channel_daily_reset_time=settings.channel_daily_reset_time,
+    )
 
 
 @router.get("/settings/channel-numbering", response_model=ChannelNumberingSettingsModel)
@@ -23,11 +36,7 @@ def get_channel_numbering_settings():
     with get_db() as conn:
         settings = get_channel_numbering_settings(conn)
 
-    return ChannelNumberingSettingsModel(
-        global_channel_mode=settings.global_channel_mode,
-        league_channel_starts=settings.league_channel_starts,
-        global_consolidation_mode=settings.global_consolidation_mode,
-    )
+    return _to_model(settings)
 
 
 @router.put("/settings/channel-numbering", response_model=ChannelNumberingSettingsModel)
@@ -52,19 +61,48 @@ def update_channel_numbering_settings(update: ChannelNumberingSettingsUpdate):
                 detail=f"Invalid global_consolidation_mode. Valid: {VALID_CONSOLIDATION_MODES}",
             )
 
+    if update.channel_stability_mode is not None:
+        if update.channel_stability_mode not in VALID_STABILITY_MODES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid channel_stability_mode. Valid: {VALID_STABILITY_MODES}",
+            )
+
+    if update.channel_gap_size is not None and update.channel_gap_size < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="channel_gap_size must be >= 1",
+        )
+
+    if update.channel_daily_reset_time is not None:
+        if not _valid_hhmm(update.channel_daily_reset_time):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="channel_daily_reset_time must be in HH:MM (24h) format",
+            )
+
     with get_db() as conn:
         update_channel_numbering_settings(
             conn,
             global_channel_mode=update.global_channel_mode,
             league_channel_starts=update.league_channel_starts,
             global_consolidation_mode=update.global_consolidation_mode,
+            channel_stability_mode=update.channel_stability_mode,
+            channel_gap_size=update.channel_gap_size,
+            channel_daily_reset_enabled=update.channel_daily_reset_enabled,
+            channel_daily_reset_time=update.channel_daily_reset_time,
         )
 
     with get_db() as conn:
         settings = get_channel_numbering_settings(conn)
 
-    return ChannelNumberingSettingsModel(
-        global_channel_mode=settings.global_channel_mode,
-        league_channel_starts=settings.league_channel_starts,
-        global_consolidation_mode=settings.global_consolidation_mode,
-    )
+    return _to_model(settings)
+
+
+def _valid_hhmm(value: str) -> bool:
+    """Validate an HH:MM (24h) time string."""
+    try:
+        hh, mm = str(value).split(":")
+        return 0 <= int(hh) <= 23 and 0 <= int(mm) <= 59
+    except (ValueError, AttributeError):
+        return False

--- a/teamarr/api/routes/settings/channel_numbering.py
+++ b/teamarr/api/routes/settings/channel_numbering.py
@@ -25,6 +25,7 @@ def _to_model(settings) -> ChannelNumberingSettingsModel:
         channel_gap_size=settings.channel_gap_size,
         channel_daily_reset_enabled=settings.channel_daily_reset_enabled,
         channel_daily_reset_time=settings.channel_daily_reset_time,
+        force_channel_relayout_pending=settings.force_channel_relayout_pending,
     )
 
 
@@ -92,6 +93,43 @@ def update_channel_numbering_settings(update: ChannelNumberingSettingsUpdate):
             channel_daily_reset_enabled=update.channel_daily_reset_enabled,
             channel_daily_reset_time=update.channel_daily_reset_time,
         )
+
+    with get_db() as conn:
+        settings = get_channel_numbering_settings(conn)
+
+    return _to_model(settings)
+
+
+@router.post(
+    "/settings/channel-numbering/relayout",
+    response_model=ChannelNumberingSettingsModel,
+)
+def request_channel_relayout():
+    """Arm a one-shot full channel re-grid for the next generation run.
+
+    Renumbers every channel back into priority order (re-applying gap spacing and
+    reclaiming gaps) on the next run, bypassing the daily reset window. Only
+    meaningful in gap/strict stability modes; harmless otherwise.
+    """
+    from teamarr.database.channel_numbers import (
+        arm_channel_relayout,
+        get_global_channel_mode,
+    )
+    from teamarr.database.settings import get_channel_numbering_settings
+
+    with get_db() as conn:
+        if get_global_channel_mode(conn) == "manual":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Re-grid applies to Auto numbering mode only.",
+            )
+        settings = get_channel_numbering_settings(conn)
+        if settings.channel_stability_mode == "compact":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Re-grid applies to Gapped/Strict stability modes only.",
+            )
+        arm_channel_relayout(conn)
 
     with get_db() as conn:
         settings = get_channel_numbering_settings(conn)

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -298,7 +298,7 @@ class ChannelNumberingSettingsModel(BaseModel):
     league_channel_starts: dict = {}  # {"nfl": 1001, "nba": 2001}
     global_consolidation_mode: str = "consolidate"  # 'consolidate', 'separate'
     channel_stability_mode: str = "compact"  # 'compact', 'gap', 'strict'
-    channel_gap_size: int = 1
+    channel_gap_size: int = 3
     channel_daily_reset_enabled: bool = True
     channel_daily_reset_time: str = "04:00"
     force_channel_relayout_pending: bool = False  # one-shot re-grid armed for next run

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -301,6 +301,7 @@ class ChannelNumberingSettingsModel(BaseModel):
     channel_gap_size: int = 1
     channel_daily_reset_enabled: bool = True
     channel_daily_reset_time: str = "04:00"
+    force_channel_relayout_pending: bool = False  # one-shot re-grid armed for next run
 
 
 class ChannelNumberingSettingsUpdate(BaseModel):

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -297,6 +297,10 @@ class ChannelNumberingSettingsModel(BaseModel):
     global_channel_mode: str = "auto"  # 'auto', 'manual'
     league_channel_starts: dict = {}  # {"nfl": 1001, "nba": 2001}
     global_consolidation_mode: str = "consolidate"  # 'consolidate', 'separate'
+    channel_stability_mode: str = "compact"  # 'compact', 'gap', 'strict'
+    channel_gap_size: int = 1
+    channel_daily_reset_enabled: bool = True
+    channel_daily_reset_time: str = "04:00"
 
 
 class ChannelNumberingSettingsUpdate(BaseModel):
@@ -305,6 +309,10 @@ class ChannelNumberingSettingsUpdate(BaseModel):
     global_channel_mode: str | None = None
     league_channel_starts: dict | None = None
     global_consolidation_mode: str | None = None
+    channel_stability_mode: str | None = None
+    channel_gap_size: int | None = None
+    channel_daily_reset_enabled: bool | None = None
+    channel_daily_reset_time: str | None = None
 
 
 # =============================================================================

--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -2655,18 +2655,25 @@ class EventGroupProcessor:
         combined_result = StreamProcessResult()
 
         # v59: Global channel reassignment before processing
-        # Ensures all channels have correct numbers based on global mode
+        # Ensures all channels have correct numbers based on global mode.
+        # Skipped in sticky (gap/strict) modes — those defer all placement to the
+        # single end-of-run pass in generation, which is the only one that pushes
+        # to Dispatcharr (see is_sticky_mode).
         try:
-            from teamarr.database.channel_numbers import reassign_all_channels
+            from teamarr.database.channel_numbers import (
+                is_sticky_mode,
+                reassign_all_channels,
+            )
             with lifecycle_service._db_factory() as conn:
-                reassign_result = reassign_all_channels(
-                    conn, external_occupied=lifecycle_service._external_occupied
-                )
-                if reassign_result.get("channels_moved"):
-                    logger.info(
-                        "[EVENT_EPG] Pre-process reassignment: %d channels moved",
-                        reassign_result["channels_moved"],
+                if not is_sticky_mode(conn):
+                    reassign_result = reassign_all_channels(
+                        conn, external_occupied=lifecycle_service._external_occupied
                     )
+                    if reassign_result.get("channels_moved"):
+                        logger.info(
+                            "[EVENT_EPG] Pre-process reassignment: %d channels moved",
+                            reassign_result["channels_moved"],
+                        )
         except Exception as e:
             logger.debug("[EVENT_EPG] Error in global reassignment: %s", e)
 
@@ -2698,17 +2705,18 @@ class EventGroupProcessor:
         )
         combined_result.merge(process_result)
 
-        # v59: Post-process global reassignment
+        # v59: Post-process global reassignment (skipped in sticky modes — see above)
         try:
             with lifecycle_service._db_factory() as conn:
-                reassign_result = reassign_all_channels(
-                    conn, external_occupied=lifecycle_service._external_occupied
-                )
-                if reassign_result.get("channels_moved"):
-                    logger.info(
-                        "[EVENT_EPG] Post-process reassignment: %d channels moved",
-                        reassign_result["channels_moved"],
+                if not is_sticky_mode(conn):
+                    reassign_result = reassign_all_channels(
+                        conn, external_occupied=lifecycle_service._external_occupied
                     )
+                    if reassign_result.get("channels_moved"):
+                        logger.info(
+                            "[EVENT_EPG] Post-process reassignment: %d channels moved",
+                            reassign_result["channels_moved"],
+                        )
         except Exception as e:
             logger.debug("[EVENT_EPG] Error reassigning channel numbers: %s", e)
 

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -837,12 +837,26 @@ def _sync_global_channels(
     update_progress: Callable,
     external_occupied: set[int] | None = None,
 ) -> None:
-    """Reassign channel numbers globally by sort priority."""
-    from teamarr.database.channel_numbers import reassign_all_channels
+    """Reassign channel numbers globally by sort priority.
+
+    This is the single authoritative pass that pushes numbers to Dispatcharr.
+    In sticky (gap/strict) modes it places only new channels, unless the daily
+    reset window has arrived (should_run_channel_reset) — then it re-grids
+    everything once.
+    """
+    from teamarr.database.channel_numbers import (
+        reassign_all_channels,
+        should_run_channel_reset,
+    )
 
     update_progress("groups", 94, "Reassigning channels globally by sport/league priority...")
     with db_factory() as conn:
-        global_result = reassign_all_channels(conn, external_occupied=external_occupied)
+        force_reset = should_run_channel_reset(conn)
+        if force_reset:
+            update_progress("groups", 94, "Daily channel re-layout (low-traffic reset)...")
+        global_result = reassign_all_channels(
+            conn, external_occupied=external_occupied, force_reset=force_reset
+        )
         if global_result["channels_moved"] == 0:
             return
 

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -904,14 +904,22 @@ class ChannelLifecycleService:
         stream_id = stream.get("id")
         disp_channel = None  # Dispatcharr's view of this channel (for phantom detection)
 
-        # Verify channel exists in Dispatcharr
-        # If missing, mark as deleted and return None to signal caller to create new
+        # Verify channel exists in Dispatcharr.
+        # Only a CONFIRMED 404 means the channel is really gone; a transient blip
+        # (timeout, 5xx, auth/network error) must NOT trigger delete + recreate,
+        # or we abandon the live channel and create a duplicate (which in gap/
+        # strict modes lands far away in the range). On an inconclusive result we
+        # leave the channel intact and re-verify next run (DB is source of truth).
         if self._channel_manager and existing.dispatcharr_channel_id:
             with self._dispatcharr_lock:
-                disp_channel = self._channel_manager.get_channel(existing.dispatcharr_channel_id)
-                if not disp_channel:
-                    # Channel missing from Dispatcharr - mark old record deleted
-                    # Return None to signal caller should create new channel
+                disp_channel, confirmed_absent = (
+                    self._channel_manager.get_channel_existence(
+                        existing.dispatcharr_channel_id
+                    )
+                )
+                if disp_channel is None and confirmed_absent:
+                    # Channel confirmed missing from Dispatcharr - mark old record
+                    # deleted and return None so the caller creates a new one.
                     logger.warning(
                         f"Channel {existing.dispatcharr_channel_id} missing from "
                         f"Dispatcharr, marking deleted and will create new: {existing.channel_name}"
@@ -930,6 +938,14 @@ class ChannelLifecycleService:
                     )
                     # Return None to signal caller to create new channel
                     return None
+                if disp_channel is None:
+                    # Inconclusive — could not verify. Keep the channel as-is and
+                    # skip phantom-stream purge (disp_channel stays None).
+                    logger.warning(
+                        "Could not verify channel %s in Dispatcharr (transient error); "
+                        "leaving intact, will re-verify next run: %s",
+                        existing.dispatcharr_channel_id, existing.channel_name,
+                    )
 
         if effective_mode == "ignore":
             # Skip - don't add stream, but still sync settings

--- a/teamarr/consumers/reconciliation.py
+++ b/teamarr/consumers/reconciliation.py
@@ -233,11 +233,18 @@ class ChannelReconciler:
             if not channel.dispatcharr_channel_id:
                 continue
 
-            # Check if channel exists in Dispatcharr
+            # Check if channel exists in Dispatcharr. Only a confirmed 404 is a
+            # real orphan; a transient failure must not mark a live channel
+            # deleted (that recreates a duplicate next run).
             with self._dispatcharr_lock:
-                dispatcharr_channel = self._channel_manager.get_channel(
-                    channel.dispatcharr_channel_id
+                dispatcharr_channel, confirmed_absent = (
+                    self._channel_manager.get_channel_existence(
+                        channel.dispatcharr_channel_id
+                    )
                 )
+
+            if dispatcharr_channel is None and not confirmed_absent:
+                continue  # Inconclusive — re-verify next run
 
             if not dispatcharr_channel:
                 issues.append(
@@ -687,21 +694,26 @@ class ChannelReconciler:
                     suggested_action="sync_to_dispatcharr",
                 )
 
-            # Check if exists in Dispatcharr
+            # Check if exists in Dispatcharr. Only a confirmed 404 is a real
+            # orphan; an inconclusive result is re-verified on a later run.
             with self._dispatcharr_lock:
-                dispatcharr_channel = self._channel_manager.get_channel(
-                    channel.dispatcharr_channel_id
+                dispatcharr_channel, confirmed_absent = (
+                    self._channel_manager.get_channel_existence(
+                        channel.dispatcharr_channel_id
+                    )
                 )
 
-            if not dispatcharr_channel:
-                return ReconciliationIssue(
-                    issue_type="orphan_teamarr",
-                    severity="warning",
-                    managed_channel_id=channel.id,
-                    dispatcharr_channel_id=channel.dispatcharr_channel_id,
-                    channel_name=channel.channel_name,
-                    suggested_action="mark_deleted",
-                )
+            if dispatcharr_channel is None:
+                if confirmed_absent:
+                    return ReconciliationIssue(
+                        issue_type="orphan_teamarr",
+                        severity="warning",
+                        managed_channel_id=channel.id,
+                        dispatcharr_channel_id=channel.dispatcharr_channel_id,
+                        channel_name=channel.channel_name,
+                        suggested_action="mark_deleted",
+                    )
+                return None  # Inconclusive — re-verify on a later run
 
             # Check for drift
             if channel.tvg_id and channel.tvg_id != dispatcharr_channel.tvg_id:

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -602,6 +602,56 @@ def _channel_num_as_int(value) -> int | None:
         return None
 
 
+def _event_group_key(ch) -> object:
+    """Placement-grouping key for a channel.
+
+    Channels for the same event (home / away / regular feeds, keyword variants)
+    share an ``event_id`` and must be placed as one contiguous block — no gap and
+    no unrelated event slotted between them, since they're all the same game.
+    Channels without an event_id are each their own group.
+    """
+    eid = ch.get("event_id")
+    if not eid:
+        return ("__solo__", ch["id"])
+    return ("event", str(eid))
+
+
+def _group_consecutive(channels: list[dict]) -> list[list[dict]]:
+    """Collapse an already-sorted channel list into consecutive runs that share an
+    event group key, preserving order. The global sort keys on event_id, so a
+    single event's channels are always adjacent."""
+    groups: list[list[dict]] = []
+    for ch in channels:
+        if groups and _event_group_key(groups[-1][0]) == _event_group_key(ch):
+            groups[-1].append(ch)
+        else:
+            groups.append([ch])
+    return groups
+
+
+def _apply_number(conn: Connection, ch: dict, target: int, mode: str, drift: list[dict]) -> bool:
+    """Persist a channel's placed number and lock it; record drift if it moved.
+
+    Returns True when the number changed (a Dispatcharr push is needed)."""
+    cur = _channel_num_as_int(ch["channel_number"])
+    if cur != target:
+        conn.execute(_SET_NUMBER_LOCKED_SQL, (target, ch["id"]))
+        drift.append({
+            "channel_id": ch["id"],
+            "dispatcharr_channel_id": ch["dispatcharr_channel_id"],
+            "channel_name": ch["channel_name"],
+            "old_number": cur,
+            "new_number": target,
+        })
+        logger.debug(
+            "[CHANNEL_NUM] '%s' placed #%s → #%d (%s)", ch["channel_name"], cur, target, mode,
+        )
+        return True
+    # Number already correct — just lock it so it's sticky from now on.
+    conn.execute(_LOCK_SQL, (ch["id"],))
+    return False
+
+
 def _reassign_sticky(
     conn: Connection,
     mode: str,
@@ -648,14 +698,22 @@ def _reassign_sticky(
             used.add(num)
             locked_teamarr.add(num)
 
-    # For gap mode: the next locked anchor's number after each index bounds insertion.
-    n = len(sorted_channels)
-    next_anchor: list[int | None] = [None] * n
+    # Feeds of one event are placed as a contiguous block — no gap or other event
+    # may land between home/away/regular feeds of the same game.
+    groups = _group_consecutive(sorted_channels)
+
+    # The next locked anchor's number after each group bounds gap insertion so a
+    # placed block never crosses into an existing anchored event's range.
+    ng = len(groups)
+    next_anchor_after: list[int | None] = [None] * ng
     upcoming: int | None = None
-    for i in range(n - 1, -1, -1):
-        next_anchor[i] = upcoming
-        if is_anchor(sorted_channels[i]):
-            upcoming = _channel_num_as_int(sorted_channels[i]["channel_number"])
+    for gi in range(ng - 1, -1, -1):
+        next_anchor_after[gi] = upcoming
+        anchor_nums = [
+            _channel_num_as_int(ch["channel_number"]) for ch in groups[gi] if is_anchor(ch)
+        ]
+        if anchor_nums:
+            upcoming = min(anchor_nums)
 
     def first_grid_at_or_after(x: int) -> int:
         """Lowest grid slot (range_start + k*step) that is >= x."""
@@ -664,79 +722,110 @@ def _reassign_sticky(
         k = (x - range_start + step - 1) // step  # ceil division
         return range_start + k * step
 
-    def append_to_end(on_grid: bool) -> int:
-        base = max(locked_teamarr) if locked_teamarr else (range_start - 1)
-        candidate = first_grid_at_or_after(max(base + 1, range_start)) if on_grid \
-            else max(base + 1, range_start)
-        while candidate in used:
-            candidate += step if on_grid else 1
-        return candidate
+    def free_run(start: int, k: int) -> bool:
+        """True if the k contiguous slots from `start` are all free and in range."""
+        return start + (k - 1) <= effective_end and all(
+            (start + j) not in used for j in range(k)
+        )
 
-    def place_gap(lo: int, hi: int) -> int | None:
-        """Lowest free slot in (lo, hi) for gap mode: prefer an on-grid slot
-        (leaving room), else reuse the lowest free in-between (fragmentation) slot."""
+    def place_block(lo: int, hi: int, k: int) -> int | None:
+        """Lowest start for a contiguous run of k free slots in (lo, hi): prefer an
+        on-grid start (leaving room for late events), else the lowest free run."""
         grid = first_grid_at_or_after(lo + 1)
-        while grid in used:
+        while grid + (k - 1) < hi and grid + (k - 1) <= effective_end:
+            if free_run(grid, k):
+                return grid
             grid += step
-        if grid < hi and grid <= effective_end:
-            return grid
-        candidate = lo + 1
-        while candidate in used:
-            candidate += 1
-        if candidate < hi and candidate <= effective_end:
-            return candidate
+        cand = lo + 1
+        while cand + (k - 1) < hi and cand + (k - 1) <= effective_end:
+            if free_run(cand, k):
+                return cand
+            cand += 1
         return None
+
+    def append_block(on_grid: bool, k: int) -> int | None:
+        """A contiguous run of k free slots past the current frontier."""
+        base = max(locked_teamarr) if locked_teamarr else (range_start - 1)
+        start = (
+            first_grid_at_or_after(max(base + 1, range_start))
+            if on_grid
+            else max(base + 1, range_start)
+        )
+        while start <= effective_end:
+            if free_run(start, k):
+                return start
+            start += step if on_grid else 1
+        return None
+
+    def claim(ch, target) -> None:
+        """Record a placement: mark slot used and persist (+lock)."""
+        nonlocal channels_moved
+        used.add(target)
+        locked_teamarr.add(target)
+        if _apply_number(conn, ch, target, mode, drift_details):
+            channels_moved += 1
 
     drift_details: list[dict] = []
     channels_moved = 0
     lo = range_start - 1  # so the first grid slot considered is range_start
 
-    for i, ch in enumerate(sorted_channels):
-        cur = _channel_num_as_int(ch["channel_number"])
+    for gi, group in enumerate(groups):
+        anchors = [ch for ch in group if is_anchor(ch)]
+        unplaced = [ch for ch in group if not is_anchor(ch)]
 
-        if is_anchor(ch):
-            lo = cur
+        if not unplaced:
+            # Fully anchored event — fixed; advance the neighbourhood low-water mark.
+            anchor_nums = [_channel_num_as_int(ch["channel_number"]) for ch in anchors]
+            if anchor_nums:
+                lo = max(lo, max(anchor_nums))
             continue
 
-        # Place this unlocked (or invalidated) channel.
-        if mode == "strict":
-            target = append_to_end(on_grid=False)
-        else:  # gap
-            hi = next_anchor[i] if next_anchor[i] is not None else (effective_end + 1)
-            target = place_gap(lo, hi)
-            if target is None:
-                target = append_to_end(on_grid=True)
+        hi = next_anchor_after[gi] if next_anchor_after[gi] is not None else (effective_end + 1)
 
-        if target > effective_end:
+        if anchors:
+            # Mixed event (rare: a feed added to an already-locked game). Anchors keep
+            # their numbers; place each new feed individually near the group.
+            lo = max(lo, max(_channel_num_as_int(c["channel_number"]) for c in anchors))
+            stopped = False
+            for ch in unplaced:
+                if mode == "strict":
+                    target = append_block(on_grid=False, k=1)
+                else:
+                    target = place_block(lo, hi, 1)
+                    if target is None:
+                        target = append_block(on_grid=True, k=1)
+                if target is None or target > effective_end:
+                    logger.warning(
+                        "[CHANNEL_SORT] %s sticky stopped (event=%s) - range exhausted",
+                        mode.upper(), group[0].get("event_id"),
+                    )
+                    stopped = True
+                    break
+                claim(ch, target)
+                lo = max(lo, target)
+            if stopped:
+                break
+            continue
+
+        # Fully new event — place all its feeds as one contiguous block.
+        k = len(group)
+        if mode == "strict":
+            start = append_block(on_grid=False, k=k)
+        else:
+            start = place_block(lo, hi, k)
+            if start is None:
+                start = append_block(on_grid=True, k=k)
+
+        if start is None or start + (k - 1) > effective_end:
             logger.warning(
-                "[CHANNEL_SORT] %s sticky stopped at channel %d - range exhausted",
-                mode.upper(), ch["id"],
+                "[CHANNEL_SORT] %s sticky stopped (event=%s, %d feed(s)) - range exhausted",
+                mode.upper(), group[0].get("event_id"), k,
             )
             break
 
-        used.add(target)
-        lo = target
-
-        if cur != target:
-            conn.execute(
-                _SET_NUMBER_LOCKED_SQL,
-                (target, ch["id"]),
-            )
-            drift_details.append({
-                "channel_id": ch["id"],
-                "dispatcharr_channel_id": ch["dispatcharr_channel_id"],
-                "channel_name": ch["channel_name"],
-                "old_number": cur,
-                "new_number": target,
-            })
-            channels_moved += 1
-            logger.debug(
-                "[CHANNEL_NUM] '%s' placed #%s → #%d (%s)",
-                ch["channel_name"], cur, target, mode,
-            )
-        else:
-            # Number already correct — just lock it so it's sticky from now on.
-            conn.execute(_LOCK_SQL, (ch["id"],))
+        for j, ch in enumerate(group):
+            claim(ch, start + j)
+        lo = start + (k - 1)
 
     logger.info(
         "[CHANNEL_SORT] %s sticky: %d channels processed, %d placed",
@@ -757,9 +846,10 @@ def _reassign_reset(
 ) -> dict:
     """Full re-layout for gap/strict modes (the daily reset window).
 
-    Re-grids every channel by priority order and re-locks them: contiguous for
-    strict, spaced by gap_size for gap. This is the only path that moves a
-    channel that is already locked.
+    Re-grids every channel by priority order and re-locks them. Feeds of one event
+    are placed contiguously (no gap between home/away/regular); the gap_size spacing
+    is applied only *between* events (strict is fully contiguous). This is the only
+    path that moves a channel that is already locked.
     """
     range_start, range_end = get_global_channel_range(conn)
     effective_end = range_end if range_end else MAX_CHANNEL
@@ -771,39 +861,40 @@ def _reassign_reset(
 
     drift_details: list[dict] = []
     channels_moved = 0
+    used: set[int] = set(ext)
 
-    num = range_start
-    while num in ext:
-        num += 1
+    def first_grid_at_or_after(x: int) -> int:
+        if x <= range_start:
+            return range_start
+        k = (x - range_start + step - 1) // step
+        return range_start + k * step
 
-    for ch in sorted_channels:
-        if num > effective_end:
+    def free_run(start: int, k: int) -> bool:
+        return start + (k - 1) <= effective_end and all(
+            (start + j) not in used for j in range(k)
+        )
+
+    # Each event is a grid-aligned contiguous block; the next event starts at the
+    # next grid slot, so gap_size spacing sits between events (a wide multi-feed
+    # event simply consumes more of its gap). Matches the sticky allocator so the
+    # reset doesn't shift events that sticky already placed.
+    frontier = range_start
+    for group in _group_consecutive(sorted_channels):
+        k = len(group)
+        start = first_grid_at_or_after(frontier)
+        while start + (k - 1) <= effective_end and not free_run(start, k):
+            start += step
+        if start + (k - 1) > effective_end:
             logger.warning(
-                "[CHANNEL_SORT] %s reset stopped at channel %d - range exhausted",
-                mode.upper(), ch["id"],
+                "[CHANNEL_SORT] %s reset stopped (event=%s, %d feed(s)) - range exhausted",
+                mode.upper(), group[0].get("event_id"), k,
             )
             break
-
-        cur = _channel_num_as_int(ch["channel_number"])
-        if cur != num:
-            conn.execute(
-                _SET_NUMBER_LOCKED_SQL,
-                (num, ch["id"]),
-            )
-            drift_details.append({
-                "channel_id": ch["id"],
-                "dispatcharr_channel_id": ch["dispatcharr_channel_id"],
-                "channel_name": ch["channel_name"],
-                "old_number": cur,
-                "new_number": num,
-            })
-            channels_moved += 1
-        else:
-            conn.execute(_LOCK_SQL, (ch["id"],))
-
-        num += step
-        while num in ext:
-            num += 1
+        for j, ch in enumerate(group):
+            if _apply_number(conn, ch, start + j, mode, drift_details):
+                channels_moved += 1
+            used.add(start + j)
+        frontier = start + k
 
     logger.info(
         "[CHANNEL_SORT] %s reset re-layout: %d channels processed, %d moved",

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -177,7 +177,16 @@ def should_run_channel_reset(conn: Connection) -> bool:
     if get_global_channel_mode(conn) == "manual":
         return False
     settings = get_channel_stability_settings(conn)
-    if settings["mode"] == "compact" or not settings["reset_enabled"]:
+    if settings["mode"] == "compact":
+        return False
+
+    # An explicitly armed re-grid (manual button or auto-armed by a gap-size /
+    # stability-mode / sort-priority change) runs on the very next generation,
+    # bypassing both the daily time gate and the reset_enabled toggle.
+    if _relayout_pending(conn):
+        return True
+
+    if not settings["reset_enabled"]:
         return False
 
     from datetime import time as _time
@@ -204,11 +213,50 @@ def should_run_channel_reset(conn: Connection) -> bool:
 
 
 def _mark_channel_reset(conn: Connection) -> None:
-    """Record that the daily full re-layout has run (resets the daily gate)."""
+    """Record that the full re-layout has run: reset the daily gate and clear any
+    armed one-shot re-grid flag."""
+    if _table_has_column(conn, "settings", "force_channel_relayout_pending"):
+        conn.execute(
+            "UPDATE settings SET last_channel_reset_at = ?, "
+            "force_channel_relayout_pending = 0 WHERE id = 1",
+            (datetime.now().isoformat(),),
+        )
+    else:
+        conn.execute(
+            "UPDATE settings SET last_channel_reset_at = ? WHERE id = 1",
+            (datetime.now().isoformat(),),
+        )
+
+
+def _relayout_pending(conn: Connection) -> bool:
+    """True if a one-shot full re-layout has been armed (manual "Re-grid now" or
+    auto-armed by a gap-size / stability-mode / sort-priority change)."""
+    if not _table_has_column(conn, "settings", "force_channel_relayout_pending"):
+        return False
+    try:
+        row = conn.execute(
+            "SELECT force_channel_relayout_pending FROM settings WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    return bool(row and row[0])
+
+
+def arm_channel_relayout(conn: Connection) -> bool:
+    """Arm a one-shot full re-layout to run on the next generation.
+
+    Used by the manual "Re-grid now" action and auto-armed when a setting that
+    only takes effect at re-layout changes (gap size, stability mode, sort
+    priority) — existing locked channels otherwise keep their numbers until the
+    daily reset. No-op (returns False) if the column is absent on an
+    un-reconciled DB / partial test schema.
+    """
+    if not _table_has_column(conn, "settings", "force_channel_relayout_pending"):
+        return False
     conn.execute(
-        "UPDATE settings SET last_channel_reset_at = ? WHERE id = 1",
-        (datetime.now().isoformat(),),
+        "UPDATE settings SET force_channel_relayout_pending = 1 WHERE id = 1"
     )
+    return True
 
 
 def _table_has_column(conn: Connection, table: str, column: str) -> bool:

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 
 MAX_CHANNEL = 999999  # Effectively no limit per Dispatcharr update
 
+# Assign a channel its number and mark it sticky (gap/strict modes).
+_SET_NUMBER_LOCKED_SQL = (
+    "UPDATE managed_channels SET channel_number = ?, channel_number_locked = 1 WHERE id = ?"
+)
+# Lock a channel in place without changing its number.
+_LOCK_SQL = "UPDATE managed_channels SET channel_number_locked = 1 WHERE id = ?"
+
 
 # =============================================================================
 # Settings Accessors
@@ -87,6 +94,130 @@ def get_global_consolidation_mode(conn: Connection) -> str:
         return "consolidate"
     mode = row["global_consolidation_mode"]
     return mode if mode in ("consolidate", "separate") else "consolidate"
+
+
+def get_channel_stability_settings(conn: Connection) -> dict:
+    """Get channel numbering stability settings.
+
+    Stability mode governs how *existing* channel numbers behave across runs
+    (AUTO mode only — MANUAL keeps its per-league sequential behavior):
+
+    - 'compact': re-sort everyone into contiguous priority order every run (legacy).
+    - 'gap':     sticky; new channels slot into a free number in their sorted
+                 neighbourhood (gap_size spacing) or append; existing channels
+                 never move except at the daily reset.
+    - 'strict':  sticky; new channels append to the end of the used range so they
+                 never displace anyone; gaps reclaimed only at the daily reset.
+
+    Returns:
+        Dict with keys: mode, gap_size, reset_enabled, reset_time, last_reset_at
+    """
+    defaults = {
+        "mode": "compact",
+        "gap_size": 1,
+        "reset_enabled": True,
+        "reset_time": "04:00",
+        "last_reset_at": None,
+    }
+    try:
+        cursor = conn.execute(
+            """SELECT channel_stability_mode, channel_gap_size,
+                      channel_daily_reset_enabled, channel_daily_reset_time,
+                      last_channel_reset_at
+               FROM settings WHERE id = 1"""
+        )
+        row = cursor.fetchone()
+    except sqlite3.OperationalError:
+        return defaults
+
+    if not row:
+        return defaults
+
+    mode = row["channel_stability_mode"] or "compact"
+    if mode not in ("compact", "gap", "strict"):
+        mode = "compact"
+
+    try:
+        gap = int(row["channel_gap_size"]) if row["channel_gap_size"] else 1
+    except (ValueError, TypeError):
+        gap = 1
+    gap = max(1, gap)
+
+    reset_enabled = row["channel_daily_reset_enabled"]
+    reset_enabled = True if reset_enabled is None else bool(reset_enabled)
+
+    return {
+        "mode": mode,
+        "gap_size": gap,
+        "reset_enabled": reset_enabled,
+        "reset_time": row["channel_daily_reset_time"] or "04:00",
+        "last_reset_at": row["last_channel_reset_at"],
+    }
+
+
+def is_sticky_mode(conn: Connection) -> bool:
+    """True when channels should be sticky (AUTO + gap/strict stability mode).
+
+    Used to skip the mid-run reassign passes: in sticky modes the only place
+    numbers are (re)assigned is the single end-of-run pass, which also pushes to
+    Dispatcharr, so intermediate passes would write DB numbers that never sync.
+    """
+    if get_global_channel_mode(conn) == "manual":
+        return False
+    return get_channel_stability_settings(conn)["mode"] in ("gap", "strict")
+
+
+def should_run_channel_reset(conn: Connection) -> bool:
+    """Whether the daily full re-layout should run on this generation.
+
+    True only for gap/strict modes when the reset is enabled and this is the
+    first generation at/after the configured local reset time today. This is
+    how the reset "fits into generation windows" — no separate scheduler.
+    """
+    if get_global_channel_mode(conn) == "manual":
+        return False
+    settings = get_channel_stability_settings(conn)
+    if settings["mode"] == "compact" or not settings["reset_enabled"]:
+        return False
+
+    from datetime import time as _time
+
+    try:
+        hh, mm = str(settings["reset_time"]).split(":")
+        boundary_time = _time(int(hh), int(mm))
+    except (ValueError, AttributeError):
+        boundary_time = _time(4, 0)
+
+    now = datetime.now()
+    boundary = datetime.combine(now.date(), boundary_time)
+    if now < boundary:
+        return False
+
+    last = settings["last_reset_at"]
+    if not last:
+        return True
+    try:
+        last_dt = datetime.fromisoformat(last)
+    except (ValueError, TypeError):
+        return True
+    return last_dt < boundary
+
+
+def _mark_channel_reset(conn: Connection) -> None:
+    """Record that the daily full re-layout has run (resets the daily gate)."""
+    conn.execute(
+        "UPDATE settings SET last_channel_reset_at = ? WHERE id = 1",
+        (datetime.now().isoformat(),),
+    )
+
+
+def _table_has_column(conn: Connection, table: str, column: str) -> bool:
+    """Return True if `table` has `column` (defensive for un-reconciled DBs/tests)."""
+    try:
+        cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.OperationalError:
+        return False
+    return column in cols
 
 
 # =============================================================================
@@ -270,12 +401,20 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
     # top if either its home or away team matches one (see channel_priority_teams).
     priority_keys = get_priority_team_match_keys(conn)
 
-    # 2. Get all channels from enabled groups with event info
-    cursor = conn.execute("""
+    # 2. Get all channels from enabled groups with event info.
+    # channel_number_locked may be absent on un-reconciled DBs / partial test
+    # schemas — fall back to 0 (treated as not-yet-placed) when missing.
+    locked_col = (
+        "mc.channel_number_locked"
+        if _table_has_column(conn, "managed_channels", "channel_number_locked")
+        else "0 AS channel_number_locked"
+    )
+    cursor = conn.execute(f"""
         SELECT
             mc.id,
             mc.dispatcharr_channel_id,
             mc.channel_number,
+            {locked_col},
             mc.channel_name,
             mc.event_epg_group_id,
             mc.primary_stream_id,
@@ -300,6 +439,7 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
                 "id": row["id"],
                 "dispatcharr_channel_id": row["dispatcharr_channel_id"],
                 "channel_number": row["channel_number"],
+                "channel_number_locked": row["channel_number_locked"],
                 "channel_name": row["channel_name"],
                 "event_epg_group_id": row["event_epg_group_id"],
                 "primary_stream_id": row["primary_stream_id"],
@@ -367,15 +507,22 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
 def reassign_all_channels(
     conn: Connection,
     external_occupied: set[int] | None = None,
+    force_reset: bool = False,
 ) -> dict:
     """Reassign all active channel numbers based on global mode.
 
-    AUTO: Sequential numbers from range_start by sort priority order.
-    MANUAL: Sequential within each league's configured range.
+    AUTO: behaviour depends on the channel stability mode:
+        - compact: sequential numbers from range_start by sort priority (legacy).
+        - gap/strict: sticky — existing (locked) channels keep their number; only
+          unplaced channels are assigned. A full re-layout runs only when
+          force_reset=True (the daily reset window).
+    MANUAL: Sequential within each league's configured range (stability modes N/A).
 
     Args:
         conn: Database connection
         external_occupied: Channel numbers occupied by non-Teamarr channels (#146)
+        force_reset: When True (gap/strict only), perform the full re-layout that
+            re-grids every channel by priority — the one time existing channels move.
 
     Returns:
         Dict with statistics: channels_processed, channels_moved, drift_details
@@ -383,7 +530,209 @@ def reassign_all_channels(
     mode = get_global_channel_mode(conn)
     if mode == "manual":
         return _reassign_manual(conn, external_occupied)
-    return _reassign_auto(conn, external_occupied)
+
+    stability = get_channel_stability_settings(conn)
+    smode = stability["mode"]
+    if smode == "compact":
+        return _reassign_auto(conn, external_occupied)
+
+    ext = external_occupied or set()
+    if force_reset:
+        result = _reassign_reset(conn, smode, stability["gap_size"], ext)
+        _mark_channel_reset(conn)
+        return result
+    return _reassign_sticky(conn, smode, stability["gap_size"], ext)
+
+
+def _channel_num_as_int(value) -> int | None:
+    """Parse a stored channel_number (TEXT) into an int, or None."""
+    if value is None or value == "":
+        return None
+    try:
+        return int(float(value))
+    except (ValueError, TypeError):
+        return None
+
+
+def _reassign_sticky(
+    conn: Connection,
+    mode: str,
+    gap_size: int,
+    ext: set[int],
+) -> dict:
+    """Sticky placement for gap/strict modes (no full re-layout).
+
+    Locked channels never move. Unlocked channels (newly created, or existing
+    channels the first time the mode is active) are assigned a number and locked:
+
+    - gap:    the lowest free number in the channel's sorted neighbourhood
+              (between the surrounding locked anchors); reuses freed slots. Falls
+              back to appending at the end of the range when the neighbourhood is full.
+    - strict: appended to the end of the used range, so nothing existing is displaced.
+    """
+    range_start, range_end = get_global_channel_range(conn)
+    effective_end = range_end if range_end else MAX_CHANNEL
+
+    sorted_channels = get_all_channels_sorted(conn)
+    if not sorted_channels:
+        return {"channels_processed": 0, "channels_moved": 0, "drift_details": []}
+
+    # Locked anchors (and external channels) occupy their numbers permanently here.
+    used: set[int] = set(ext)
+    for ch in sorted_channels:
+        num = _channel_num_as_int(ch["channel_number"])
+        if ch.get("channel_number_locked") and num is not None:
+            used.add(num)
+
+    # For gap mode: the next locked anchor's number after each index bounds insertion.
+    n = len(sorted_channels)
+    next_anchor: list[int | None] = [None] * n
+    upcoming: int | None = None
+    for i in range(n - 1, -1, -1):
+        next_anchor[i] = upcoming
+        ch = sorted_channels[i]
+        num = _channel_num_as_int(ch["channel_number"])
+        if ch.get("channel_number_locked") and num is not None:
+            upcoming = num
+
+    def append_to_end() -> int:
+        base = max(used) if used else (range_start - 1)
+        candidate = max(base + 1, range_start)
+        while candidate in used:
+            candidate += 1
+        return candidate
+
+    drift_details: list[dict] = []
+    channels_moved = 0
+    lo = range_start - 1  # so the first grid slot considered is range_start
+
+    for i, ch in enumerate(sorted_channels):
+        cur = _channel_num_as_int(ch["channel_number"])
+
+        if ch.get("channel_number_locked") and cur is not None:
+            lo = cur
+            continue
+
+        # Place this unlocked channel.
+        if mode == "strict":
+            target = append_to_end()
+        else:  # gap
+            hi = next_anchor[i] if next_anchor[i] is not None else (effective_end + 1)
+            candidate = lo + 1
+            while candidate in used:
+                candidate += 1
+            if candidate < hi and candidate <= effective_end:
+                target = candidate
+            else:
+                target = append_to_end()
+
+        if target > effective_end:
+            logger.warning(
+                "[CHANNEL_SORT] %s sticky stopped at channel %d - range exhausted",
+                mode.upper(), ch["id"],
+            )
+            break
+
+        used.add(target)
+        lo = target
+
+        if cur != target:
+            conn.execute(
+                _SET_NUMBER_LOCKED_SQL,
+                (target, ch["id"]),
+            )
+            drift_details.append({
+                "channel_id": ch["id"],
+                "dispatcharr_channel_id": ch["dispatcharr_channel_id"],
+                "channel_name": ch["channel_name"],
+                "old_number": cur,
+                "new_number": target,
+            })
+            channels_moved += 1
+            logger.debug(
+                "[CHANNEL_NUM] '%s' placed #%s → #%d (%s)",
+                ch["channel_name"], cur, target, mode,
+            )
+        else:
+            # Number already correct — just lock it so it's sticky from now on.
+            conn.execute(_LOCK_SQL, (ch["id"],))
+
+    logger.info(
+        "[CHANNEL_SORT] %s sticky: %d channels processed, %d placed",
+        mode.upper(), len(sorted_channels), channels_moved,
+    )
+    return {
+        "channels_processed": len(sorted_channels),
+        "channels_moved": channels_moved,
+        "drift_details": drift_details,
+    }
+
+
+def _reassign_reset(
+    conn: Connection,
+    mode: str,
+    gap_size: int,
+    ext: set[int],
+) -> dict:
+    """Full re-layout for gap/strict modes (the daily reset window).
+
+    Re-grids every channel by priority order and re-locks them: contiguous for
+    strict, spaced by gap_size for gap. This is the only path that moves a
+    channel that is already locked.
+    """
+    range_start, range_end = get_global_channel_range(conn)
+    effective_end = range_end if range_end else MAX_CHANNEL
+    step = gap_size if (mode == "gap" and gap_size > 0) else 1
+
+    sorted_channels = get_all_channels_sorted(conn)
+    if not sorted_channels:
+        return {"channels_processed": 0, "channels_moved": 0, "drift_details": []}
+
+    drift_details: list[dict] = []
+    channels_moved = 0
+
+    num = range_start
+    while num in ext:
+        num += 1
+
+    for ch in sorted_channels:
+        if num > effective_end:
+            logger.warning(
+                "[CHANNEL_SORT] %s reset stopped at channel %d - range exhausted",
+                mode.upper(), ch["id"],
+            )
+            break
+
+        cur = _channel_num_as_int(ch["channel_number"])
+        if cur != num:
+            conn.execute(
+                _SET_NUMBER_LOCKED_SQL,
+                (num, ch["id"]),
+            )
+            drift_details.append({
+                "channel_id": ch["id"],
+                "dispatcharr_channel_id": ch["dispatcharr_channel_id"],
+                "channel_name": ch["channel_name"],
+                "old_number": cur,
+                "new_number": num,
+            })
+            channels_moved += 1
+        else:
+            conn.execute(_LOCK_SQL, (ch["id"],))
+
+        num += step
+        while num in ext:
+            num += 1
+
+    logger.info(
+        "[CHANNEL_SORT] %s reset re-layout: %d channels processed, %d moved",
+        mode.upper(), len(sorted_channels), channels_moved,
+    )
+    return {
+        "channels_processed": len(sorted_channels),
+        "channels_moved": channels_moved,
+        "drift_details": drift_details,
+    }
 
 
 def _reassign_auto(

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -114,7 +114,7 @@ def get_channel_stability_settings(conn: Connection) -> dict:
     """
     defaults = {
         "mode": "compact",
-        "gap_size": 1,
+        "gap_size": 3,
         "reset_enabled": True,
         "reset_time": "04:00",
         "last_reset_at": None,
@@ -138,9 +138,9 @@ def get_channel_stability_settings(conn: Connection) -> dict:
         mode = "compact"
 
     try:
-        gap = int(row["channel_gap_size"]) if row["channel_gap_size"] else 1
+        gap = int(row["channel_gap_size"]) if row["channel_gap_size"] else 3
     except (ValueError, TypeError):
-        gap = 1
+        gap = 3
     gap = max(1, gap)
 
     reset_enabled = row["channel_daily_reset_enabled"]

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -566,23 +566,39 @@ def _reassign_sticky(
     channels the first time the mode is active) are assigned a number and locked:
 
     - gap:    the lowest free number in the channel's sorted neighbourhood
-              (between the surrounding locked anchors); reuses freed slots. Falls
-              back to appending at the end of the range when the neighbourhood is full.
+              (between the surrounding locked anchors), preferring on-grid slots
+              spaced by gap_size so room is left for late events; reuses freed
+              slots. Falls back to appending past the frontier when full.
     - strict: appended to the end of the used range, so nothing existing is displaced.
+
+    A locked channel whose number now collides with an external channel or has
+    fallen outside the configured range is treated as unplaced and re-gridded on
+    this run (rather than waiting for the daily reset to clear the conflict).
     """
     range_start, range_end = get_global_channel_range(conn)
     effective_end = range_end if range_end else MAX_CHANNEL
+    step = gap_size if (mode == "gap" and gap_size > 0) else 1
 
     sorted_channels = get_all_channels_sorted(conn)
     if not sorted_channels:
         return {"channels_processed": 0, "channels_moved": 0, "drift_details": []}
 
-    # Locked anchors (and external channels) occupy their numbers permanently here.
-    used: set[int] = set(ext)
-    for ch in sorted_channels:
+    def is_anchor(ch) -> bool:
+        """A locked channel still acts as a fixed anchor only while its number is
+        valid — within range and not clashing with an external channel."""
         num = _channel_num_as_int(ch["channel_number"])
-        if ch.get("channel_number_locked") and num is not None:
+        if not (ch.get("channel_number_locked") and num is not None):
+            return False
+        return num not in ext and range_start <= num <= effective_end
+
+    # Locked anchors occupy their numbers permanently here; external channels too.
+    used: set[int] = set(ext)
+    locked_teamarr: set[int] = set()
+    for ch in sorted_channels:
+        if is_anchor(ch):
+            num = _channel_num_as_int(ch["channel_number"])
             used.add(num)
+            locked_teamarr.add(num)
 
     # For gap mode: the next locked anchor's number after each index bounds insertion.
     n = len(sorted_channels)
@@ -590,17 +606,38 @@ def _reassign_sticky(
     upcoming: int | None = None
     for i in range(n - 1, -1, -1):
         next_anchor[i] = upcoming
-        ch = sorted_channels[i]
-        num = _channel_num_as_int(ch["channel_number"])
-        if ch.get("channel_number_locked") and num is not None:
-            upcoming = num
+        if is_anchor(sorted_channels[i]):
+            upcoming = _channel_num_as_int(sorted_channels[i]["channel_number"])
 
-    def append_to_end() -> int:
-        base = max(used) if used else (range_start - 1)
-        candidate = max(base + 1, range_start)
+    def first_grid_at_or_after(x: int) -> int:
+        """Lowest grid slot (range_start + k*step) that is >= x."""
+        if x <= range_start:
+            return range_start
+        k = (x - range_start + step - 1) // step  # ceil division
+        return range_start + k * step
+
+    def append_to_end(on_grid: bool) -> int:
+        base = max(locked_teamarr) if locked_teamarr else (range_start - 1)
+        candidate = first_grid_at_or_after(max(base + 1, range_start)) if on_grid \
+            else max(base + 1, range_start)
+        while candidate in used:
+            candidate += step if on_grid else 1
+        return candidate
+
+    def place_gap(lo: int, hi: int) -> int | None:
+        """Lowest free slot in (lo, hi) for gap mode: prefer an on-grid slot
+        (leaving room), else reuse the lowest free in-between (fragmentation) slot."""
+        grid = first_grid_at_or_after(lo + 1)
+        while grid in used:
+            grid += step
+        if grid < hi and grid <= effective_end:
+            return grid
+        candidate = lo + 1
         while candidate in used:
             candidate += 1
-        return candidate
+        if candidate < hi and candidate <= effective_end:
+            return candidate
+        return None
 
     drift_details: list[dict] = []
     channels_moved = 0
@@ -609,22 +646,18 @@ def _reassign_sticky(
     for i, ch in enumerate(sorted_channels):
         cur = _channel_num_as_int(ch["channel_number"])
 
-        if ch.get("channel_number_locked") and cur is not None:
+        if is_anchor(ch):
             lo = cur
             continue
 
-        # Place this unlocked channel.
+        # Place this unlocked (or invalidated) channel.
         if mode == "strict":
-            target = append_to_end()
+            target = append_to_end(on_grid=False)
         else:  # gap
             hi = next_anchor[i] if next_anchor[i] is not None else (effective_end + 1)
-            candidate = lo + 1
-            while candidate in used:
-                candidate += 1
-            if candidate < hi and candidate <= effective_end:
-                target = candidate
-            else:
-                target = append_to_end()
+            target = place_gap(lo, hi)
+            if target is None:
+                target = append_to_end(on_grid=True)
 
         if target > effective_end:
             logger.warning(

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -715,27 +715,29 @@ def _reassign_sticky(
         if anchor_nums:
             upcoming = min(anchor_nums)
 
-    def first_grid_at_or_after(x: int) -> int:
-        """Lowest grid slot (range_start + k*step) that is >= x."""
-        if x <= range_start:
-            return range_start
-        k = (x - range_start + step - 1) // step  # ceil division
-        return range_start + k * step
-
     def free_run(start: int, k: int) -> bool:
         """True if the k contiguous slots from `start` are all free and in range."""
         return start + (k - 1) <= effective_end and all(
             (start + j) not in used for j in range(k)
         )
 
+    def gap_start(prev_end: int) -> int:
+        """Preferred start for the next block: a full gap_size step past the previous
+        block's END, so a multi-feed block consumes its own slots and the inter-event
+        gap follows *after* it (not measured from the block's first slot). The very
+        first block starts at range_start."""
+        return range_start if prev_end < range_start else prev_end + step
+
     def place_block(lo: int, hi: int, k: int) -> int | None:
-        """Lowest start for a contiguous run of k free slots in (lo, hi): prefer an
-        on-grid start (leaving room for late events), else the lowest free run."""
-        grid = first_grid_at_or_after(lo + 1)
-        while grid + (k - 1) < hi and grid + (k - 1) <= effective_end:
-            if free_run(grid, k):
-                return grid
-            grid += step
+        """Lowest start for a contiguous run of k free slots in (lo, hi): prefer the
+        gap-after-block position (a full gap past `lo`, the previous block's end),
+        else the lowest free run that still fits (reuses slots freed by deletions)."""
+        pref = gap_start(lo)
+        cand = pref
+        while cand + (k - 1) < hi and cand + (k - 1) <= effective_end:
+            if free_run(cand, k):
+                return cand
+            cand += 1
         cand = lo + 1
         while cand + (k - 1) < hi and cand + (k - 1) <= effective_end:
             if free_run(cand, k):
@@ -744,13 +746,11 @@ def _reassign_sticky(
         return None
 
     def append_block(on_grid: bool, k: int) -> int | None:
-        """A contiguous run of k free slots past the current frontier."""
+        """A contiguous run of k free slots past the current frontier. With on_grid
+        (gap mode) the run starts a full gap past the last placed block; strict
+        appends contiguously."""
         base = max(locked_teamarr) if locked_teamarr else (range_start - 1)
-        start = (
-            first_grid_at_or_after(max(base + 1, range_start))
-            if on_grid
-            else max(base + 1, range_start)
-        )
+        start = gap_start(base) if on_grid else max(base + 1, range_start)
         while start <= effective_end:
             if free_run(start, k):
                 return start
@@ -863,27 +863,22 @@ def _reassign_reset(
     channels_moved = 0
     used: set[int] = set(ext)
 
-    def first_grid_at_or_after(x: int) -> int:
-        if x <= range_start:
-            return range_start
-        k = (x - range_start + step - 1) // step
-        return range_start + k * step
-
     def free_run(start: int, k: int) -> bool:
         return start + (k - 1) <= effective_end and all(
             (start + j) not in used for j in range(k)
         )
 
-    # Each event is a grid-aligned contiguous block; the next event starts at the
-    # next grid slot, so gap_size spacing sits between events (a wide multi-feed
-    # event simply consumes more of its gap). Matches the sticky allocator so the
+    # Each event is a contiguous block; the next event starts a full gap_size step
+    # past the previous block's END — so a multi-feed block consumes its own slots
+    # and the inter-event gap follows *after* it (not eaten by the extra feeds).
+    # Strict (step=1) packs everything tight. Matches the sticky allocator so the
     # reset doesn't shift events that sticky already placed.
     frontier = range_start
     for group in _group_consecutive(sorted_channels):
         k = len(group)
-        start = first_grid_at_or_after(frontier)
+        start = frontier
         while start + (k - 1) <= effective_end and not free_run(start, k):
-            start += step
+            start += 1
         if start + (k - 1) > effective_end:
             logger.warning(
                 "[CHANNEL_SORT] %s reset stopped (event=%s, %d feed(s)) - range exhausted",
@@ -894,7 +889,7 @@ def _reassign_reset(
             if _apply_number(conn, ch, start + j, mode, drift_details):
                 channels_moved += 1
             used.add(start + j)
-        frontier = start + k
+        frontier = start + (k - 1) + step
 
     logger.info(
         "[CHANNEL_SORT] %s reset re-layout: %d channels processed, %d moved",

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -728,22 +728,26 @@ def _reassign_sticky(
         first block starts at range_start."""
         return range_start if prev_end < range_start else prev_end + step
 
-    def place_block(lo: int, hi: int, k: int) -> int | None:
-        """Lowest start for a contiguous run of k free slots in (lo, hi): prefer the
-        gap-after-block position (a full gap past `lo`, the previous block's end),
-        else the lowest free run that still fits (reuses slots freed by deletions)."""
-        pref = gap_start(lo)
-        cand = pref
-        while cand + (k - 1) < hi and cand + (k - 1) <= effective_end:
-            if free_run(cand, k):
-                return cand
-            cand += 1
-        cand = lo + 1
+    def first_free_run(start: int, hi: int, k: int) -> int | None:
+        """Lowest position >= `start` whose k contiguous slots are all free, staying
+        below `hi` (the next anchored event) and in range. Scanning forward by 1 also
+        reclaims holes left by deletions that fall at/after `start`."""
+        cand = max(start, range_start)
         while cand + (k - 1) < hi and cand + (k - 1) <= effective_end:
             if free_run(cand, k):
                 return cand
             cand += 1
         return None
+
+    def place_block(lo: int, hi: int, k: int) -> int | None:
+        """Lowest start for a contiguous run of k free slots in (lo, hi): prefer the
+        gap-after-block position (a full gap past `lo`, the previous block's end),
+        else the lowest free run that still fits — letting a new event slot into its
+        sorted neighbourhood and reusing slots freed by deletions."""
+        start = first_free_run(gap_start(lo), hi, k)
+        if start is not None:
+            return start
+        return first_free_run(lo + 1, hi, k)
 
     def append_block(on_grid: bool, k: int) -> int | None:
         """A contiguous run of k free slots past the current frontier. With on_grid
@@ -783,17 +787,17 @@ def _reassign_sticky(
         hi = next_anchor_after[gi] if next_anchor_after[gi] is not None else (effective_end + 1)
 
         if anchors:
-            # Mixed event (rare: a feed added to an already-locked game). Anchors keep
-            # their numbers; place each new feed individually near the group.
+            # Mixed event: a feed was added to an already-locked game (feeds are
+            # discovered across runs). Anchors keep their numbers; each new feed
+            # extends the event's run *contiguously* into the gap reserved right
+            # after its existing feeds — so all feeds of one game stay together
+            # instead of being scattered a full gap (or out to the frontier) away.
             lo = max(lo, max(_channel_num_as_int(c["channel_number"]) for c in anchors))
             stopped = False
             for ch in unplaced:
-                if mode == "strict":
-                    target = append_block(on_grid=False, k=1)
-                else:
-                    target = place_block(lo, hi, 1)
-                    if target is None:
-                        target = append_block(on_grid=True, k=1)
+                target = first_free_run(lo + 1, hi, 1)
+                if target is None:
+                    target = append_block(on_grid=(mode == "gap"), k=1)
                 if target is None or target > effective_end:
                     logger.warning(
                         "[CHANNEL_SORT] %s sticky stopped (event=%s) - range exhausted",

--- a/teamarr/database/priority_teams.py
+++ b/teamarr/database/priority_teams.py
@@ -76,6 +76,12 @@ def add_priority_team(
         """,
         (provider, provider_team_id, league, league),
     ).fetchone()
+    if row:
+        # Priority teams float to the top of the lineup; arm a one-shot re-grid so
+        # the change applies on the next generation rather than at the daily reset.
+        from teamarr.database.channel_numbers import arm_channel_relayout
+
+        arm_channel_relayout(conn)
     return dict(row) if row else None
 
 
@@ -85,7 +91,12 @@ def delete_priority_team(conn: sqlite3.Connection, team_pk: int) -> bool:
         "DELETE FROM channel_priority_teams WHERE id = ?",
         (team_pk,),
     )
-    return cursor.rowcount > 0
+    if cursor.rowcount > 0:
+        from teamarr.database.channel_numbers import arm_channel_relayout
+
+        arm_channel_relayout(conn)
+        return True
+    return False
 
 
 def get_priority_team_match_keys(conn: sqlite3.Connection) -> set[tuple[str, str]]:

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -405,6 +405,11 @@ CREATE TABLE IF NOT EXISTS settings (
     channel_daily_reset_enabled BOOLEAN DEFAULT 1,      -- Run the periodic full re-layout (gap/strict only)
     channel_daily_reset_time TEXT DEFAULT '04:00',      -- Local HH:MM low-traffic window for the reset
     last_channel_reset_at TEXT,                          -- Internal: timestamp of last full reset
+    -- Internal: one-shot "re-grid on the next generation" flag. Set by the manual
+    -- "Re-grid now" action and auto-armed when a setting that only takes effect at
+    -- re-layout changes (gap size, stability mode, sort priority). Bypasses the
+    -- daily time gate and reset_enabled; cleared once the re-layout runs.
+    force_channel_relayout_pending BOOLEAN DEFAULT 0,
 
     -- Feed Separation (HOME/AWAY stream detection)
     -- When enabled, detects feed indicators in stream names and creates separate channels per feed

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -388,6 +388,24 @@ CREATE TABLE IF NOT EXISTS settings (
     global_consolidation_mode TEXT DEFAULT 'consolidate'
         CHECK(global_consolidation_mode IN ('consolidate', 'separate')),
 
+    -- Channel Numbering Stability Mode (how existing channel numbers behave across runs)
+    -- 'compact': Re-sort all channels into contiguous priority order every run (legacy default).
+    --            Tidy guide, but a live channel's number can shift when events start/end.
+    -- 'gap':     Sticky + gap-aware. Existing channels keep their number for their whole
+    --            lifecycle; new channels slot into a free number in their sorted neighborhood
+    --            (using channel_gap_size spacing) or append. Deleted slots are reused.
+    -- 'strict':  Sticky + no-drift. Existing channels never move; new channels that would
+    --            displace others are appended to the end of the used range. Gaps are reclaimed
+    --            only at the daily reset.
+    -- For 'gap'/'strict', a full re-layout (the only time existing channels move) runs on the
+    -- first generation at/after channel_daily_reset_time each day, if channel_daily_reset_enabled.
+    channel_stability_mode TEXT DEFAULT 'compact'
+        CHECK(channel_stability_mode IN ('compact', 'gap', 'strict')),
+    channel_gap_size INTEGER DEFAULT 1,                 -- Spacing between channels in 'gap' mode (1 = none)
+    channel_daily_reset_enabled BOOLEAN DEFAULT 1,      -- Run the periodic full re-layout (gap/strict only)
+    channel_daily_reset_time TEXT DEFAULT '04:00',      -- Local HH:MM low-traffic window for the reset
+    last_channel_reset_at TEXT,                          -- Internal: timestamp of last full reset
+
     -- Feed Separation (HOME/AWAY stream detection)
     -- When enabled, detects feed indicators in stream names and creates separate channels per feed
     feed_separation_enabled BOOLEAN DEFAULT 0,          -- Master toggle (off by default)
@@ -677,6 +695,10 @@ CREATE TABLE IF NOT EXISTS managed_channels (
     tvg_id TEXT NOT NULL,  -- Not UNIQUE: soft-deleted records can share tvg_id with active
     channel_name TEXT NOT NULL,
     channel_number TEXT,
+    -- Stability lock (gap/strict modes only; ignored in compact mode):
+    -- 0 = not yet placed by the stability allocator (newly created, or mode just enabled)
+    -- 1 = number finalized and sticky — never moved except by the daily reset re-layout
+    channel_number_locked INTEGER DEFAULT 0,
     logo_url TEXT,
 
     -- Dispatcharr Integration

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -401,7 +401,7 @@ CREATE TABLE IF NOT EXISTS settings (
     -- first generation at/after channel_daily_reset_time each day, if channel_daily_reset_enabled.
     channel_stability_mode TEXT DEFAULT 'compact'
         CHECK(channel_stability_mode IN ('compact', 'gap', 'strict')),
-    channel_gap_size INTEGER DEFAULT 1,                 -- Spacing between channels in 'gap' mode (1 = none)
+    channel_gap_size INTEGER DEFAULT 3,                 -- Spacing between channels in 'gap' mode (1 = none)
     channel_daily_reset_enabled BOOLEAN DEFAULT 1,      -- Run the periodic full re-layout (gap/strict only)
     channel_daily_reset_time TEXT DEFAULT '04:00',      -- Local HH:MM low-traffic window for the reset
     last_channel_reset_at TEXT,                          -- Internal: timestamp of last full reset

--- a/teamarr/database/settings/read.py
+++ b/teamarr/database/settings/read.py
@@ -521,7 +521,7 @@ def _build_channel_numbering_settings(row) -> ChannelNumberingSettings:
         league_channel_starts=league_starts,
         global_consolidation_mode=row["global_consolidation_mode"] or "consolidate",
         channel_stability_mode=_get("channel_stability_mode", None) or "compact",
-        channel_gap_size=_get("channel_gap_size", None) or 1,
+        channel_gap_size=_get("channel_gap_size", None) or 3,
         channel_daily_reset_enabled=True if reset_enabled is None else bool(reset_enabled),
         channel_daily_reset_time=_get("channel_daily_reset_time", None) or "04:00",
         force_channel_relayout_pending=bool(_get("force_channel_relayout_pending", 0)),

--- a/teamarr/database/settings/read.py
+++ b/teamarr/database/settings/read.py
@@ -524,6 +524,7 @@ def _build_channel_numbering_settings(row) -> ChannelNumberingSettings:
         channel_gap_size=_get("channel_gap_size", None) or 1,
         channel_daily_reset_enabled=True if reset_enabled is None else bool(reset_enabled),
         channel_daily_reset_time=_get("channel_daily_reset_time", None) or "04:00",
+        force_channel_relayout_pending=bool(_get("force_channel_relayout_pending", 0)),
     )
 
 
@@ -540,7 +541,8 @@ def get_channel_numbering_settings(conn: Connection) -> ChannelNumberingSettings
         cursor = conn.execute(
             """SELECT global_channel_mode, league_channel_starts, global_consolidation_mode,
                       channel_stability_mode, channel_gap_size,
-                      channel_daily_reset_enabled, channel_daily_reset_time
+                      channel_daily_reset_enabled, channel_daily_reset_time,
+                      force_channel_relayout_pending
                FROM settings WHERE id = 1"""
         )
         row = cursor.fetchone()

--- a/teamarr/database/settings/read.py
+++ b/teamarr/database/settings/read.py
@@ -4,6 +4,7 @@ Query functions to fetch settings from the database.
 """
 
 import json
+import sqlite3
 from sqlite3 import Connection
 
 from .types import (
@@ -508,10 +509,21 @@ def _build_channel_numbering_settings(row) -> ChannelNumberingSettings:
         except (ValueError, TypeError, json.JSONDecodeError):
             pass
 
+    # Stability columns may be absent on un-reconciled DBs / partial test schemas.
+    keys = set(row.keys())
+
+    def _get(key, default):
+        return row[key] if key in keys else default
+
+    reset_enabled = _get("channel_daily_reset_enabled", None)
     return ChannelNumberingSettings(
         global_channel_mode=row["global_channel_mode"] or "auto",
         league_channel_starts=league_starts,
         global_consolidation_mode=row["global_consolidation_mode"] or "consolidate",
+        channel_stability_mode=_get("channel_stability_mode", None) or "compact",
+        channel_gap_size=_get("channel_gap_size", None) or 1,
+        channel_daily_reset_enabled=True if reset_enabled is None else bool(reset_enabled),
+        channel_daily_reset_time=_get("channel_daily_reset_time", None) or "04:00",
     )
 
 
@@ -524,11 +536,21 @@ def get_channel_numbering_settings(conn: Connection) -> ChannelNumberingSettings
     Returns:
         ChannelNumberingSettings with global channel mode, league starts, consolidation
     """
-    cursor = conn.execute(
-        """SELECT global_channel_mode, league_channel_starts, global_consolidation_mode
-           FROM settings WHERE id = 1"""
-    )
-    row = cursor.fetchone()
+    try:
+        cursor = conn.execute(
+            """SELECT global_channel_mode, league_channel_starts, global_consolidation_mode,
+                      channel_stability_mode, channel_gap_size,
+                      channel_daily_reset_enabled, channel_daily_reset_time
+               FROM settings WHERE id = 1"""
+        )
+        row = cursor.fetchone()
+    except sqlite3.OperationalError:
+        # Stability columns not present yet (un-reconciled DB / partial test schema).
+        cursor = conn.execute(
+            """SELECT global_channel_mode, league_channel_starts, global_consolidation_mode
+               FROM settings WHERE id = 1"""
+        )
+        row = cursor.fetchone()
 
     if not row:
         return ChannelNumberingSettings()

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -259,6 +259,7 @@ class ChannelNumberingSettings:
     channel_gap_size: int = 1  # spacing between channels in 'gap' mode
     channel_daily_reset_enabled: bool = True  # run the periodic full re-layout
     channel_daily_reset_time: str = "04:00"  # local HH:MM reset window
+    force_channel_relayout_pending: bool = False  # one-shot re-grid armed for next run
 
 
 @dataclass

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -256,7 +256,7 @@ class ChannelNumberingSettings:
 
     # Stability (AUTO mode only): how existing numbers behave across runs.
     channel_stability_mode: str = "compact"  # 'compact', 'gap', 'strict'
-    channel_gap_size: int = 1  # spacing between channels in 'gap' mode
+    channel_gap_size: int = 3  # spacing between channels in 'gap' mode
     channel_daily_reset_enabled: bool = True  # run the periodic full re-layout
     channel_daily_reset_time: str = "04:00"  # local HH:MM reset window
     force_channel_relayout_pending: bool = False  # one-shot re-grid armed for next run

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -254,6 +254,12 @@ class ChannelNumberingSettings:
     league_channel_starts: dict = field(default_factory=dict)  # {"nfl": 1001, ...}
     global_consolidation_mode: str = "consolidate"  # 'consolidate', 'separate'
 
+    # Stability (AUTO mode only): how existing numbers behave across runs.
+    channel_stability_mode: str = "compact"  # 'compact', 'gap', 'strict'
+    channel_gap_size: int = 1  # spacing between channels in 'gap' mode
+    channel_daily_reset_enabled: bool = True  # run the periodic full re-layout
+    channel_daily_reset_time: str = "04:00"  # local HH:MM reset window
+
 
 @dataclass
 class FeedSeparationSettings:

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -563,7 +563,7 @@ def update_channel_numbering_settings(
                 "SELECT channel_stability_mode, channel_gap_size FROM settings WHERE id = 1"
             ).fetchone()
             cur_mode = (cur["channel_stability_mode"] if cur else None) or "compact"
-            cur_gap = int((cur["channel_gap_size"] if cur else None) or 1)
+            cur_gap = int((cur["channel_gap_size"] if cur else None) or 3)
             new_mode = channel_stability_mode or cur_mode
             gap_changed = (
                 channel_gap_size is not None and int(channel_gap_size) != cur_gap

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -551,10 +551,39 @@ def update_channel_numbering_settings(
     if not updates:
         return False
 
+    # Auto-arm a one-shot re-grid when a layout-affecting setting actually changes
+    # while in (or switching into) a sticky mode — existing locked channels
+    # otherwise keep their numbers until the daily reset, so the change would
+    # silently do nothing. Compare against current values to avoid arming on every
+    # unrelated save (the UI full-PUTs the whole settings object).
+    arm_relayout = False
+    if channel_gap_size is not None or channel_stability_mode is not None:
+        try:
+            cur = conn.execute(
+                "SELECT channel_stability_mode, channel_gap_size FROM settings WHERE id = 1"
+            ).fetchone()
+            cur_mode = (cur["channel_stability_mode"] if cur else None) or "compact"
+            cur_gap = int((cur["channel_gap_size"] if cur else None) or 1)
+            new_mode = channel_stability_mode or cur_mode
+            gap_changed = (
+                channel_gap_size is not None and int(channel_gap_size) != cur_gap
+            )
+            mode_changed = (
+                channel_stability_mode is not None and channel_stability_mode != cur_mode
+            )
+            arm_relayout = (gap_changed or mode_changed) and new_mode in ("gap", "strict")
+        except Exception:
+            arm_relayout = False
+
     query = f"UPDATE settings SET {', '.join(updates)} WHERE id = 1"
     cursor = conn.execute(query, values)
     if cursor.rowcount > 0:
         logger.info("[CHANNEL_NUM] Updated settings: %s", [u.split(" = ")[0] for u in updates])
+        if arm_relayout:
+            from teamarr.database.channel_numbers import arm_channel_relayout
+
+            if arm_channel_relayout(conn):
+                logger.info("[CHANNEL_NUM] Armed one-shot re-grid (layout setting changed)")
         return True
     return False
 

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -482,6 +482,10 @@ def update_channel_numbering_settings(
     global_channel_mode: str | None = None,
     league_channel_starts: dict | None = None,
     global_consolidation_mode: str | None = None,
+    channel_stability_mode: str | None = None,
+    channel_gap_size: int | None = None,
+    channel_daily_reset_enabled: bool | None = None,
+    channel_daily_reset_time: str | None = None,
 ) -> bool:
     """Update channel numbering and consolidation settings.
 
@@ -490,6 +494,10 @@ def update_channel_numbering_settings(
         global_channel_mode: 'auto' or 'manual'
         league_channel_starts: Dict mapping league_code → starting channel number
         global_consolidation_mode: 'consolidate' or 'separate'
+        channel_stability_mode: 'compact', 'gap', or 'strict'
+        channel_gap_size: spacing between channels in 'gap' mode (>= 1)
+        channel_daily_reset_enabled: run the periodic full re-layout
+        channel_daily_reset_time: local HH:MM reset window
 
     Returns:
         True if updated
@@ -518,6 +526,27 @@ def update_channel_numbering_settings(
             return False
         updates.append("global_consolidation_mode = ?")
         values.append(global_consolidation_mode)
+
+    if channel_stability_mode is not None:
+        if channel_stability_mode not in ("compact", "gap", "strict"):
+            logger.warning(
+                "[CHANNEL_NUM] Invalid channel_stability_mode '%s'", channel_stability_mode,
+            )
+            return False
+        updates.append("channel_stability_mode = ?")
+        values.append(channel_stability_mode)
+
+    if channel_gap_size is not None:
+        updates.append("channel_gap_size = ?")
+        values.append(max(1, int(channel_gap_size)))
+
+    if channel_daily_reset_enabled is not None:
+        updates.append("channel_daily_reset_enabled = ?")
+        values.append(1 if channel_daily_reset_enabled else 0)
+
+    if channel_daily_reset_time is not None:
+        updates.append("channel_daily_reset_time = ?")
+        values.append(channel_daily_reset_time)
 
     if not updates:
         return False

--- a/teamarr/database/sort_priorities.py
+++ b/teamarr/database/sort_priorities.py
@@ -256,6 +256,13 @@ def reorder_sort_priorities(conn: Connection, ordered_list: list[dict]) -> bool:
                     (priority, sport, league_code),
                 )
 
+        # Sort priority drives both the sticky-mode neighbourhood and the reset
+        # layout; arm a one-shot re-grid so the new order takes effect on the next
+        # generation instead of waiting for the daily reset (no-op in compact).
+        from teamarr.database.channel_numbers import arm_channel_relayout
+
+        arm_channel_relayout(conn)
+
         conn.commit()
         logger.info("[SORT_PRIORITY] Reordered %d entries", len(ordered_list))
         return True

--- a/teamarr/dispatcharr/managers/channels.py
+++ b/teamarr/dispatcharr/managers/channels.py
@@ -209,6 +209,43 @@ class ChannelManager:
                 return channel
             return None
 
+    def get_channel_existence(
+        self,
+        channel_id: int,
+        use_cache: bool = True,
+    ) -> tuple[DispatcharrChannel | None, bool]:
+        """Fetch a channel, distinguishing "confirmed gone" from "couldn't verify".
+
+        ``get_channel`` collapses a real 404 and a transient failure (timeout,
+        5xx, auth/network error) into the same ``None`` return. Callers that take
+        a *destructive* action on a missing channel (soft-delete + recreate, or
+        flag as orphan) must not act on a transient blip — doing so abandons the
+        live Dispatcharr channel and recreates a duplicate, which in gap/strict
+        numbering modes appears far away in the range (see lifecycle
+        ``_handle_existing_channel`` and reconciliation orphan detection).
+
+        Returns ``(channel, confirmed_absent)``:
+          - ``(channel, False)`` — exists (cache hit or HTTP 200).
+          - ``(None, True)``    — Dispatcharr returned HTTP 404; really gone.
+          - ``(None, False)``   — inconclusive (no response, 5xx, network/auth
+            error). Treat the channel as still present and re-verify next run.
+        """
+        with self._lock:
+            if use_cache:
+                self._ensure_cache()
+                cached = self._cache.get_by_id(channel_id)
+                if cached:
+                    return cached, False
+
+            response = self._client.get(f"/api/channels/channels/{channel_id}/")
+            if response is not None and response.status_code == 200:
+                channel = DispatcharrChannel.from_api(response.json())
+                if use_cache:
+                    self._cache.update(channel)
+                return channel, False
+            confirmed_absent = response is not None and response.status_code == 404
+            return None, confirmed_absent
+
     def create_channel(
         self,
         name: str,

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -55,13 +55,13 @@ def db():
     return conn
 
 
-def _add(conn, cid, name, number, locked, event_date, event_id):
+def _add(conn, cid, name, number, locked, event_date, event_id, keyword=None):
     conn.execute(
         """INSERT INTO managed_channels
            (id, channel_name, channel_number, channel_number_locked,
-            event_date, event_id, sport, league)
-           VALUES (?, ?, ?, ?, ?, ?, 'football', 'nfl')""",
-        (cid, name, number, locked, event_date, event_id),
+            event_date, event_id, exception_keyword, sport, league)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'football', 'nfl')""",
+        (cid, name, number, locked, event_date, event_id, keyword),
     )
 
 
@@ -227,6 +227,41 @@ def test_strict_feeds_append_contiguously(db):
     nums = _numbers(db)
     assert nums["A"] == 101
     assert {nums["Home"], nums["Away"]} == {102, 103}
+
+
+def test_gap_sticky_keyword_variants_stay_contiguous(db):
+    # An exception keyword breaks a stream out onto its own channel, but that
+    # channel shares the event's event_id — so the main channel and its keyword
+    # variant(s) must be placed as one contiguous block, just like home/away feeds.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "NEW", "500", 0, "2026-06-18 11:00:00", "e3")
+    _add(db, 4, "NEW (Spanish)", "501", 0, "2026-06-18 11:00:00", "e3", keyword="Spanish")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101 and nums["B"] == 104  # anchors untouched
+    # Main channel + keyword variant slot into the 102/103 gap, adjacent.
+    assert {nums["NEW"], nums["NEW (Spanish)"]} == {102, 103}
+    # Main channel sorts before the keyword variant.
+    assert nums["NEW"] < nums["NEW (Spanish)"]
+
+
+def test_gap_reset_keyword_variant_contiguous_with_gap_between_events(db):
+    # Reset: a main + keyword channel for one event pack adjacently (101-102), and
+    # the next event still gets its inter-event gap before its grid slot.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "Main", "200", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "Main (Spanish)", "201", 1, "2026-06-18 10:00:00", "e1", keyword="Spanish")
+    _add(db, 3, "Solo", "150", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+
+    cn.reassign_all_channels(db, force_reset=True)
+    nums = _numbers(db)
+    assert nums["Main"] == 101 and nums["Main (Spanish)"] == 102  # adjacent block
+    assert nums["Solo"] == 104  # 103 left free as the inter-event gap
 
 
 def test_gap_reset_feeds_contiguous_with_gap_between_events(db):

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -216,6 +216,23 @@ def test_gap_sticky_feed_block_appends_together_when_gap_too_small(db):
     assert feeds[0] > 104  # appended past the anchors, none displaced
 
 
+def test_gap_sticky_multi_feed_block_then_full_gap(db):
+    # Sticky initial placement: a 3-feed event packs 101-103, and the next event
+    # starts a full gap *after* the block end (103 + 3 = 106) — the inter-event gap
+    # follows the whole home/away block instead of being measured from its first slot.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "H", "500", 0, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "A", "501", 0, "2026-06-18 10:00:00", "e1")
+    _add(db, 3, "R", "502", 0, "2026-06-18 10:00:00", "e1")
+    _add(db, 4, "Solo", "503", 0, "2026-06-18 12:00:00", "e2")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert sorted([nums["H"], nums["A"], nums["R"]]) == [101, 102, 103]
+    assert nums["Solo"] == 106  # full gap after the block end (103 + gap)
+
+
 def test_strict_feeds_append_contiguously(db):
     _set_mode(db, "strict")
     _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
@@ -251,7 +268,7 @@ def test_gap_sticky_keyword_variants_stay_contiguous(db):
 
 def test_gap_reset_keyword_variant_contiguous_with_gap_between_events(db):
     # Reset: a main + keyword channel for one event pack adjacently (101-102), and
-    # the next event still gets its inter-event gap before its grid slot.
+    # the next event starts a full gap *after* the block's end (102 + 3 = 105).
     _set_mode(db, "gap", gap=3)
     _add(db, 1, "Main", "200", 1, "2026-06-18 10:00:00", "e1")
     _add(db, 2, "Main (Spanish)", "201", 1, "2026-06-18 10:00:00", "e1", keyword="Spanish")
@@ -261,12 +278,13 @@ def test_gap_reset_keyword_variant_contiguous_with_gap_between_events(db):
     cn.reassign_all_channels(db, force_reset=True)
     nums = _numbers(db)
     assert nums["Main"] == 101 and nums["Main (Spanish)"] == 102  # adjacent block
-    assert nums["Solo"] == 104  # 103 left free as the inter-event gap
+    assert nums["Solo"] == 105  # full gap after the block end (102 + gap)
 
 
 def test_gap_reset_feeds_contiguous_with_gap_between_events(db):
-    # Reset: a 3-feed event packs 101-103, the next event starts at the next grid
-    # slot (104 here, since the feeds consumed the gap), feeds never spaced apart.
+    # Reset: a 3-feed event packs 101-103, and the next event starts a full gap
+    # *after* the block's end (103 + 3 = 106) — the gap follows the block instead
+    # of being eaten by the extra feeds; feeds themselves are never spaced apart.
     _set_mode(db, "gap", gap=3)
     _add(db, 1, "H", "200", 1, "2026-06-18 10:00:00", "e1")
     _add(db, 2, "A", "201", 1, "2026-06-18 10:00:00", "e1")
@@ -277,11 +295,12 @@ def test_gap_reset_feeds_contiguous_with_gap_between_events(db):
     cn.reassign_all_channels(db, force_reset=True)
     nums = _numbers(db)
     assert sorted([nums["H"], nums["A"], nums["R"]]) == [101, 102, 103]
-    assert nums["Solo"] == 104  # next grid slot after the block
+    assert nums["Solo"] == 106  # full gap after the block end (103 + gap)
 
 
 def test_gap_reset_two_feed_event_then_gap(db):
-    # A 2-feed event leaves one free slot before the next event's grid slot.
+    # A 2-feed event packs 101-102, then a full gap follows the block end
+    # (102 + 3 = 105) — same inter-event spacing regardless of block width.
     _set_mode(db, "gap", gap=3)
     _add(db, 1, "H", "200", 1, "2026-06-18 10:00:00", "e1")
     _add(db, 2, "A", "201", 1, "2026-06-18 10:00:00", "e1")
@@ -291,7 +310,7 @@ def test_gap_reset_two_feed_event_then_gap(db):
     cn.reassign_all_channels(db, force_reset=True)
     nums = _numbers(db)
     assert sorted([nums["H"], nums["A"]]) == [101, 102]
-    assert nums["Solo"] == 104  # 103 left free as the inter-event gap
+    assert nums["Solo"] == 105  # full gap after the block end (102 + gap)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -126,6 +126,34 @@ def test_gap_locked_channels_never_move_on_sticky(db):
     assert _numbers(db) == {"A": 101, "B": 104}
 
 
+def test_gap_initial_placement_leaves_gaps(db):
+    # All-new channels (nothing locked yet) must space out on the grid so late
+    # events have room to slot in — not pack contiguously.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "500", 0, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "501", 0, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "C", "502", 0, "2026-06-18 14:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    assert _numbers(db) == {"A": 101, "B": 104, "C": 107}
+
+
+def test_gap_invalidated_lock_is_replaced(db):
+    # A locked channel whose number fell outside the range (e.g. range was
+    # shrunk) is re-gridded on the next sticky run, not stranded until reset.
+    db.execute("UPDATE settings SET channel_range_end = 110")
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "OUT", "9999", 1, "2026-06-18 12:00:00", "e2")  # out of range
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101  # valid anchor, untouched
+    assert 101 < nums["OUT"] <= 110  # pulled back into range
+
+
 # ---------------------------------------------------------------------------
 # strict mode
 # ---------------------------------------------------------------------------

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -33,7 +33,8 @@ def db():
           channel_gap_size INTEGER DEFAULT 1,
           channel_daily_reset_enabled INTEGER DEFAULT 1,
           channel_daily_reset_time TEXT DEFAULT '04:00',
-          last_channel_reset_at TEXT
+          last_channel_reset_at TEXT,
+          force_channel_relayout_pending INTEGER DEFAULT 0
         );
         CREATE TABLE event_epg_groups (id INTEGER PRIMARY KEY, enabled INTEGER DEFAULT 1);
         CREATE TABLE managed_channels (
@@ -265,3 +266,55 @@ def test_sticky_mode_detection(db):
     db.execute("UPDATE settings SET global_channel_mode = 'manual'")
     db.commit()
     assert cn.is_sticky_mode(db) is False
+
+
+# ---------------------------------------------------------------------------
+# one-shot manual / auto-armed re-grid
+# ---------------------------------------------------------------------------
+
+
+def test_armed_relayout_fires_before_window(db):
+    # Armed re-grid bypasses the daily time gate (reset time in the future today).
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_time = '23:59'")
+    db.execute(
+        "UPDATE settings SET last_channel_reset_at = ?",
+        (datetime.now().isoformat(),),  # already reset today → time gate would block
+    )
+    db.commit()
+    assert cn.should_run_channel_reset(db) is False
+    assert cn.arm_channel_relayout(db) is True
+    assert cn.should_run_channel_reset(db) is True
+
+
+def test_armed_relayout_bypasses_reset_disabled(db):
+    # An explicit re-grid runs even when the daily auto-reset is turned off.
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_enabled = 0")
+    db.commit()
+    assert cn.should_run_channel_reset(db) is False
+    cn.arm_channel_relayout(db)
+    assert cn.should_run_channel_reset(db) is True
+
+
+def test_armed_relayout_ignored_in_compact(db):
+    _set_mode(db, "compact")
+    cn.arm_channel_relayout(db)
+    assert cn.should_run_channel_reset(db) is False
+
+
+def test_reset_clears_armed_flag(db):
+    # Running the re-layout consumes the one-shot flag so it won't refire.
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_enabled = 0")
+    db.commit()
+    cn.arm_channel_relayout(db)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    db.commit()
+
+    cn.reassign_all_channels(db, force_reset=cn.should_run_channel_reset(db))
+    assert cn.should_run_channel_reset(db) is False
+    row = db.execute(
+        "SELECT force_channel_relayout_pending FROM settings WHERE id = 1"
+    ).fetchone()
+    assert not row[0]

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -176,6 +176,90 @@ def test_strict_new_channel_appends_to_end(db):
 
 
 # ---------------------------------------------------------------------------
+# event feeds — home/away/regular stay contiguous (no gap between them)
+# ---------------------------------------------------------------------------
+
+
+def test_gap_sticky_feeds_placed_as_contiguous_block(db):
+    # A new event's feeds (same event_id) must land on adjacent numbers, even in
+    # gap mode — the gap belongs between events, not between feeds of one game.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "NEW-Home", "500", 0, "2026-06-18 11:00:00", "e3")
+    _add(db, 4, "NEW-Away", "501", 0, "2026-06-18 11:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101 and nums["B"] == 104  # anchors untouched
+    # Both feeds slot into the 102/103 gap, adjacent, nothing between them.
+    assert {nums["NEW-Home"], nums["NEW-Away"]} == {102, 103}
+
+
+def test_gap_sticky_feed_block_appends_together_when_gap_too_small(db):
+    # 3 feeds can't fit in a 2-slot gap → the whole block appends past the frontier,
+    # still contiguous, without splitting or displacing the anchors.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "F1", "500", 0, "2026-06-18 11:00:00", "e3")
+    _add(db, 4, "F2", "501", 0, "2026-06-18 11:00:00", "e3")
+    _add(db, 5, "F3", "502", 0, "2026-06-18 11:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101 and nums["B"] == 104
+    feeds = sorted([nums["F1"], nums["F2"], nums["F3"]])
+    assert feeds == [feeds[0], feeds[0] + 1, feeds[0] + 2]  # contiguous
+    assert feeds[0] > 104  # appended past the anchors, none displaced
+
+
+def test_strict_feeds_append_contiguously(db):
+    _set_mode(db, "strict")
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "Home", "500", 0, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "Away", "501", 0, "2026-06-18 12:00:00", "e2")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101
+    assert {nums["Home"], nums["Away"]} == {102, 103}
+
+
+def test_gap_reset_feeds_contiguous_with_gap_between_events(db):
+    # Reset: a 3-feed event packs 101-103, the next event starts at the next grid
+    # slot (104 here, since the feeds consumed the gap), feeds never spaced apart.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "H", "200", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "A", "201", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 3, "R", "202", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 4, "Solo", "150", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+
+    cn.reassign_all_channels(db, force_reset=True)
+    nums = _numbers(db)
+    assert sorted([nums["H"], nums["A"], nums["R"]]) == [101, 102, 103]
+    assert nums["Solo"] == 104  # next grid slot after the block
+
+
+def test_gap_reset_two_feed_event_then_gap(db):
+    # A 2-feed event leaves one free slot before the next event's grid slot.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "H", "200", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "A", "201", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 3, "Solo", "150", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+
+    cn.reassign_all_channels(db, force_reset=True)
+    nums = _numbers(db)
+    assert sorted([nums["H"], nums["A"]]) == [101, 102]
+    assert nums["Solo"] == 104  # 103 left free as the inter-event gap
+
+
+# ---------------------------------------------------------------------------
 # daily reset
 # ---------------------------------------------------------------------------
 

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -1,0 +1,239 @@
+"""Tests for channel numbering stability modes (gap / strict) and the daily reset.
+
+Covers the invariants behind stable channel numbers across an event's lifecycle:
+- gap:    new channels slot into a free number in their sorted neighbourhood;
+          existing (locked) channels never move; freed slots are reused.
+- strict: new channels append to the end of the used range so nothing is displaced.
+- reset:  the full re-layout (the only time locked channels move) re-grids by priority.
+- gating: should_run_channel_reset fires once per day at/after the configured time.
+"""
+
+import sqlite3
+from datetime import datetime, timedelta
+
+import pytest
+
+from teamarr.database import channel_numbers as cn
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE settings (
+          id INTEGER PRIMARY KEY,
+          channel_range_start INTEGER DEFAULT 101,
+          channel_range_end INTEGER,
+          global_channel_mode TEXT DEFAULT 'auto',
+          league_channel_starts TEXT DEFAULT '{}',
+          global_consolidation_mode TEXT DEFAULT 'consolidate',
+          channel_stability_mode TEXT DEFAULT 'compact',
+          channel_gap_size INTEGER DEFAULT 1,
+          channel_daily_reset_enabled INTEGER DEFAULT 1,
+          channel_daily_reset_time TEXT DEFAULT '04:00',
+          last_channel_reset_at TEXT
+        );
+        CREATE TABLE event_epg_groups (id INTEGER PRIMARY KEY, enabled INTEGER DEFAULT 1);
+        CREATE TABLE managed_channels (
+          id INTEGER PRIMARY KEY, dispatcharr_channel_id INTEGER, channel_number TEXT,
+          channel_number_locked INTEGER DEFAULT 0, channel_name TEXT, event_epg_group_id INTEGER,
+          primary_stream_id INTEGER, event_id TEXT, sport TEXT, league TEXT,
+          home_team TEXT, away_team TEXT, event_date TEXT, exception_keyword TEXT,
+          created_at TEXT, deleted_at TEXT
+        );
+        CREATE TABLE channel_sort_priorities (
+          id INTEGER PRIMARY KEY, sport TEXT, league_code TEXT, sort_priority INTEGER,
+          created_at TEXT, updated_at TEXT
+        );
+        CREATE TABLE channel_priority_teams (id INTEGER PRIMARY KEY, sport TEXT, team_name TEXT);
+        INSERT INTO settings (id) VALUES (1);
+        """
+    )
+    return conn
+
+
+def _add(conn, cid, name, number, locked, event_date, event_id):
+    conn.execute(
+        """INSERT INTO managed_channels
+           (id, channel_name, channel_number, channel_number_locked,
+            event_date, event_id, sport, league)
+           VALUES (?, ?, ?, ?, ?, ?, 'football', 'nfl')""",
+        (cid, name, number, locked, event_date, event_id),
+    )
+
+
+def _numbers(conn):
+    rows = conn.execute(
+        "SELECT channel_name, channel_number FROM managed_channels "
+        "WHERE deleted_at IS NULL ORDER BY CAST(channel_number AS INT)"
+    ).fetchall()
+    return {r["channel_name"]: int(r["channel_number"]) for r in rows}
+
+
+def _set_mode(conn, mode, gap=1):
+    conn.execute(
+        "UPDATE settings SET channel_stability_mode = ?, channel_gap_size = ?",
+        (mode, gap),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# gap mode
+# ---------------------------------------------------------------------------
+
+
+def test_gap_new_channel_slots_into_neighbourhood(db):
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    # New channel sorts (by time) between A and B; provisional number is irrelevant.
+    _add(db, 3, "NEW", "500", 0, "2026-06-18 11:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101  # locked, unmoved
+    assert nums["B"] == 104  # locked, unmoved
+    assert 101 < nums["NEW"] < 104  # slotted into the gap
+
+
+def test_gap_reuses_freed_slot(db):
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+    # A ends → its slot (101) is freed; a new earliest event should reclaim it.
+    db.execute("UPDATE managed_channels SET deleted_at = 'x' WHERE id = 1")
+    _add(db, 3, "NEW", "500", 0, "2026-06-18 09:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["NEW"] == 101
+    assert nums["B"] == 104  # untouched
+
+
+def test_gap_locked_channels_never_move_on_sticky(db):
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "104", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+    result = cn.reassign_all_channels(db)
+    assert result["channels_moved"] == 0
+    assert _numbers(db) == {"A": 101, "B": 104}
+
+
+# ---------------------------------------------------------------------------
+# strict mode
+# ---------------------------------------------------------------------------
+
+
+def test_strict_new_channel_appends_to_end(db):
+    _set_mode(db, "strict")
+    _add(db, 1, "A", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "102", 1, "2026-06-18 12:00:00", "e2")
+    # New event sorts FIRST by time, but strict must append it to the end.
+    _add(db, 3, "NEW", "500", 0, "2026-06-18 08:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["A"] == 101
+    assert nums["B"] == 102
+    assert nums["NEW"] == 103  # appended, did not displace A/B
+
+
+# ---------------------------------------------------------------------------
+# daily reset
+# ---------------------------------------------------------------------------
+
+
+def test_reset_relayout_regrids_by_priority(db):
+    _set_mode(db, "gap", gap=3)
+    # Out-of-order numbers; reset should re-grid by event time at 101, 104, 107.
+    _add(db, 1, "A", "120", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "101", 1, "2026-06-18 12:00:00", "e2")
+    _add(db, 3, "C", "150", 1, "2026-06-18 14:00:00", "e3")
+    db.commit()
+
+    cn.reassign_all_channels(db, force_reset=True)
+    nums = _numbers(db)
+    assert nums == {"A": 101, "B": 104, "C": 107}
+    # Reset stamps last_channel_reset_at so the daily gate closes.
+    stamp = db.execute("SELECT last_channel_reset_at FROM settings WHERE id = 1").fetchone()[0]
+    assert stamp is not None
+
+
+def test_strict_reset_is_contiguous(db):
+    _set_mode(db, "strict")
+    _add(db, 1, "A", "120", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "B", "101", 1, "2026-06-18 12:00:00", "e2")
+    db.commit()
+    cn.reassign_all_channels(db, force_reset=True)
+    assert _numbers(db) == {"A": 101, "B": 102}
+
+
+# ---------------------------------------------------------------------------
+# reset gating
+# ---------------------------------------------------------------------------
+
+
+def test_compact_mode_never_resets(db):
+    _set_mode(db, "compact")
+    assert cn.should_run_channel_reset(db) is False
+    assert cn.is_sticky_mode(db) is False
+
+
+def test_reset_fires_first_run_after_window(db):
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_time = '00:00'")  # always passed today
+    db.commit()
+    # No prior reset → should fire.
+    assert cn.should_run_channel_reset(db) is True
+
+
+def test_reset_does_not_refire_same_day(db):
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_time = '00:00'")
+    # Already reset earlier today.
+    db.execute(
+        "UPDATE settings SET last_channel_reset_at = ?",
+        (datetime.now().isoformat(),),
+    )
+    db.commit()
+    assert cn.should_run_channel_reset(db) is False
+
+
+def test_reset_refires_next_day(db):
+    _set_mode(db, "gap", gap=3)
+    db.execute("UPDATE settings SET channel_daily_reset_time = '00:00'")
+    db.execute(
+        "UPDATE settings SET last_channel_reset_at = ?",
+        ((datetime.now() - timedelta(days=1)).isoformat(),),
+    )
+    db.commit()
+    assert cn.should_run_channel_reset(db) is True
+
+
+def test_reset_disabled_never_fires(db):
+    _set_mode(db, "gap", gap=3)
+    db.execute(
+        "UPDATE settings SET channel_daily_reset_time = '00:00', "
+        "channel_daily_reset_enabled = 0"
+    )
+    db.commit()
+    assert cn.should_run_channel_reset(db) is False
+
+
+def test_sticky_mode_detection(db):
+    _set_mode(db, "gap")
+    assert cn.is_sticky_mode(db) is True
+    _set_mode(db, "strict")
+    assert cn.is_sticky_mode(db) is True
+    # Manual global mode overrides stability (per-league sequential).
+    db.execute("UPDATE settings SET global_channel_mode = 'manual'")
+    db.commit()
+    assert cn.is_sticky_mode(db) is False

--- a/tests/test_channel_stability.py
+++ b/tests/test_channel_stability.py
@@ -140,6 +140,23 @@ def test_gap_initial_placement_leaves_gaps(db):
     assert _numbers(db) == {"A": 101, "B": 104, "C": 107}
 
 
+def test_gap_late_feed_extends_event_contiguously(db):
+    # Feeds of one game are discovered across runs: the base feed locks first, then
+    # home/away feeds appear later. A late feed must extend the event's run into the
+    # gap reserved right after it (102/103) — NOT jump a full gap_size away (105),
+    # which scatters one game's feeds across the channel list.
+    _set_mode(db, "gap", gap=3)
+    _add(db, 1, "GAME", "101", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 2, "GAME (Home)", "102", 1, "2026-06-18 10:00:00", "e1")
+    _add(db, 3, "GAME (Away)", "500", 0, "2026-06-18 10:00:00", "e1")  # new feed
+    db.commit()
+
+    cn.reassign_all_channels(db)
+    nums = _numbers(db)
+    assert nums["GAME"] == 101 and nums["GAME (Home)"] == 102  # anchors untouched
+    assert nums["GAME (Away)"] == 103  # contiguous, not 105 (a full gap away)
+
+
 def test_gap_invalidated_lock_is_replaced(db):
     # A locked channel whose number fell outside the range (e.g. range was
     # shrunk) is re-gridded on the next sticky run, not stranded until reset.

--- a/tests/test_dispatcharr_sync_reliability.py
+++ b/tests/test_dispatcharr_sync_reliability.py
@@ -641,6 +641,10 @@ class TestReconciliationDriftAutoFix:
             streams=(456,),
             channel_profile_ids=None,
         )
+        cm.get_channel_existence.return_value = (
+            _make_dispatcharr_channel(streams=(456,), channel_profile_ids=None),
+            False,
+        )
         cm.update_channel.return_value = OperationResult(success=True)
         cm.get_channels.return_value = []
         cm.clear_cache.return_value = None
@@ -722,3 +726,166 @@ class TestDispatcharrChannelProfileIds:
             }
         )
         assert ch.channel_profile_ids == ()
+
+
+# =============================================================================
+# get_channel_existence: "confirmed gone" vs "couldn't verify"
+# =============================================================================
+
+
+def _resp(status_code, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+class TestGetChannelExistence:
+    """get_channel_existence must distinguish a real 404 from a transient
+    failure, so destructive callers don't abandon a live channel."""
+
+    def _manager(self, client):
+        from teamarr.dispatcharr.managers.channels import ChannelManager
+
+        return ChannelManager(client)
+
+    def test_http_200_returns_channel_present(self):
+        client = MagicMock()
+        client.get.return_value = _resp(
+            200,
+            {"id": 100, "uuid": "u", "name": "CH", "channel_number": "5001", "streams": []},
+        )
+        channel, confirmed_absent = self._manager(client).get_channel_existence(
+            100, use_cache=False
+        )
+        assert channel is not None and channel.id == 100
+        assert confirmed_absent is False
+
+    def test_http_404_is_confirmed_absent(self):
+        client = MagicMock()
+        client.get.return_value = _resp(404)
+        assert self._manager(client).get_channel_existence(100, use_cache=False) == (None, True)
+
+    def test_http_500_is_inconclusive(self):
+        client = MagicMock()
+        client.get.return_value = _resp(500)
+        assert self._manager(client).get_channel_existence(100, use_cache=False) == (None, False)
+
+    def test_http_502_is_inconclusive(self):
+        client = MagicMock()
+        client.get.return_value = _resp(502)
+        assert self._manager(client).get_channel_existence(100, use_cache=False) == (None, False)
+
+    def test_none_response_is_inconclusive(self):
+        client = MagicMock()
+        client.get.return_value = None
+        assert self._manager(client).get_channel_existence(100, use_cache=False) == (None, False)
+
+
+# =============================================================================
+# Transient-failure safety: never delete + recreate on an unverifiable channel
+# =============================================================================
+
+
+def _insert_managed_channel(conn):
+    conn.execute(
+        "INSERT INTO managed_channels "
+        "(id, event_epg_group_id, event_id, event_provider, channel_name, "
+        "tvg_id, dispatcharr_channel_id, dispatcharr_uuid, channel_group_id, "
+        "channel_number) "
+        "VALUES (1, 1, '123', 'espn', 'Test', 'teamarr-event-123', "
+        "100, 'uuid-100', 10, '5001')"
+    )
+    conn.commit()
+
+
+class TestReconciliationOrphanTransientSafety:
+    """Reconciliation only flags an orphan on a confirmed 404."""
+
+    def test_verify_channel_confirmed_absent_flags_orphan(self, recon_conn):
+        _insert_managed_channel(recon_conn)
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, True)
+        reconciler = ChannelReconciler(db_factory=lambda: recon_conn, channel_manager=cm)
+        issue = reconciler.verify_channel(1)
+        assert issue is not None
+        assert issue.issue_type == "orphan_teamarr"
+        assert issue.suggested_action == "mark_deleted"
+
+    def test_verify_channel_inconclusive_is_healthy(self, recon_conn):
+        _insert_managed_channel(recon_conn)
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, False)
+        reconciler = ChannelReconciler(db_factory=lambda: recon_conn, channel_manager=cm)
+        assert reconciler.verify_channel(1) is None
+
+    def test_detect_orphan_skips_on_inconclusive(self, recon_conn):
+        _insert_managed_channel(recon_conn)
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, False)
+        reconciler = ChannelReconciler(db_factory=lambda: recon_conn, channel_manager=cm)
+        assert reconciler._detect_orphan_teamarr(recon_conn) == []
+
+    def test_detect_orphan_flags_on_confirmed_404(self, recon_conn):
+        _insert_managed_channel(recon_conn)
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, True)
+        reconciler = ChannelReconciler(db_factory=lambda: recon_conn, channel_manager=cm)
+        issues = reconciler._detect_orphan_teamarr(recon_conn)
+        assert len(issues) == 1
+        assert issues[0].issue_type == "orphan_teamarr"
+
+
+class TestExistingChannelVerificationSafety:
+    """_handle_existing_channel deletes + recreates only on a confirmed 404."""
+
+    def test_confirmed_absent_marks_deleted_and_signals_recreate(self):
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, True)
+        service = _make_service(channel_manager=cm)
+
+        with (
+            patch("teamarr.database.channels.mark_channel_deleted") as mock_del,
+            patch("teamarr.database.channels.log_channel_history"),
+        ):
+            result = service._handle_existing_channel(
+                conn=MagicMock(),
+                existing=FakeManagedChannel(),
+                stream={"id": 456, "name": "S"},
+                event=FakeEvent(),
+                effective_mode="consolidate",
+                matched_keyword=None,
+                group_config={},
+                template=None,
+            )
+
+        # None signals the caller to create a new channel.
+        assert result is None
+        mock_del.assert_called_once()
+
+    def test_inconclusive_keeps_channel_and_does_not_recreate(self):
+        cm = MagicMock()
+        cm.get_channel_existence.return_value = (None, False)
+        service = _make_service(channel_manager=cm)
+
+        with (
+            patch("teamarr.database.channels.mark_channel_deleted") as mock_del,
+            patch("teamarr.database.channels.log_channel_history"),
+            patch.object(
+                service, "_sync_channel_settings", return_value=StreamProcessResult()
+            ),
+        ):
+            result = service._handle_existing_channel(
+                conn=MagicMock(),
+                existing=FakeManagedChannel(),
+                stream={"id": 456, "name": "S"},
+                event=FakeEvent(),
+                effective_mode="ignore",
+                matched_keyword=None,
+                group_config={},
+                template=None,
+            )
+
+        # Channel left intact: not deleted, and not signalled for recreate.
+        assert result is not None
+        mock_del.assert_not_called()


### PR DESCRIPTION
### The Problem
Previously, Teamarr assigned channel numbers in "compact mode" (re-sorting every channel into contiguous priority order on every run). While this kept the guide tidy, a channel's number depended on the current slate of events. If a user was watching a game on channel 11, it could silently jump to 10 or 12 just because an unrelated event started or ended.

Because Dispatcharr relies on channel numbers staying put, we needed a way to prioritize stable numbering over strict contiguity.

### The Solution
This PR introduces Channel Stability Modes to prevent live events from drifting, while providing a scheduled "daily reset" to reclaim gaps and prevent unbounded channel growth. 
compact  remains the default, meaning no changes for existing users unless they opt-in.

### Key Features
- New Mode: Gapped (sticky)
 Channels are spaced apart by a configurable  channel_gap_size  (e.g., 3 -> 101, 104, 107). A new event slots into a free number in its sorted neighborhood, filling the gap or reusing a slot freed when an earlier event ended. Existing channels are locked and never move.
- New Mode: Strict (no drift)
Existing channels never move. A new event that would displace others is simply appended to the end of the active range. Gaps are completely ignored until the reset.
 - Daily Re-layout (Low-Traffic Reset)
  To prevent infinite fragmentation, a full re-layout runs once per day. It is natively gated into the generation schedule: the first generation run at or after  channel_daily_reset_time  (default 04:00) does a full re-grid, placing everythingback into clean priority order.
- Feed separation
  Home/away feeds stay in groups alongside to prevent event insertion between. i.e block of 3 events with consecutive numbering