### PR TITLE
Cut redundant ESPN scoreboard fetches during generation

### DIFF
--- a/teamarr/consumers/event_group_processor/__init__.py
+++ b/teamarr/consumers/event_group_processor/__init__.py
@@ -3,18 +3,17 @@
 Connects stream matching to channel lifecycle:
 1. Load group config from database
 2. Fetch M3U streams from Dispatcharr
-3. Fetch events from data providers (parallel with ThreadPoolExecutor)
-4. Match streams to events
-5. Create/update channels via ChannelLifecycleService
-6. Generate XMLTV EPG
-7. Optionally push EPG to Dispatcharr
+3. Match streams to events (the matcher fetches events itself, per league)
+4. Create/update channels via ChannelLifecycleService
+5. Generate XMLTV EPG
+6. Optionally push EPG to Dispatcharr
 
 This is the main entry point for event-based EPG generation.
 
 Package layout (iua3.7):
 - processor.py       — EventGroupProcessor coordinator + convenience functions
 - results.py         — result dataclasses (processing/batch/preview/enforcement)
-- stream_fetcher.py  — M3U stream fetching/filtering + provider event fetching
+- stream_fetcher.py  — M3U stream fetching/filtering + known-league lookup
 - matching.py        — stream→event matching, EPG index, feed/segment expansion
 - team_filter.py     — team include/exclude filtering + filtered-channel cleanup
 - persistence.py     — matched/failed stream persistence for run analysis
@@ -37,10 +36,8 @@ from .results import (
     PreviewStream,
     ProcessingResult,
 )
-from .stream_fetcher import MAX_WORKERS
 
 __all__ = [
-    "MAX_WORKERS",
     "SEASON_POSTSEASON",
     "BatchProcessingResult",
     "EnforcementStepResult",

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -656,33 +656,11 @@ class EventGroupProcessor(
                 )
                 return result
 
-            # Step 2: Fetch events from data providers
-            # Use subscription leagues (per-group override → global fallback)
+            # Step 2: Resolve subscription leagues (per-group override → global
+            # fallback). The matcher fetches its own events with a 30-day window,
+            # so there is no separate pre-flight event fetch here — an eventless
+            # group simply produces zero matches downstream.
             effective_leagues = self._get_subscription_leagues(conn, group)
-            events = self._fetch_events(effective_leagues, target_date)
-            logger.info(
-                f"Fetched {len(events)} events for group '{group.name}' leagues={effective_leagues}"
-            )
-
-            if not events:
-                result.errors.append(f"No events found for leagues: {effective_leagues}")
-                result.completed_at = datetime.now()
-                stats_run.complete(status="completed", error="No events found")
-                save_run(conn, stats_run)
-                # Update stats - streams are eligible but no events to match against
-                update_group_stats(
-                    conn,
-                    group.id,
-                    stream_count=result.streams_after_filter,  # Eligible streams
-                    matched_count=0,
-                    filtered_stale=filter_result.filtered_stale,
-                    filtered_include_regex=filter_result.filtered_include,
-                    filtered_exclude_regex=filter_result.filtered_exclude,
-                    failed_count=result.streams_after_filter,  # All unmatched due to no events
-                    filtered_not_event=filter_result.filtered_not_event,
-                    total_stream_count=result.streams_fetched,
-                )
-                return result
 
             # Step 3: Match streams to events (uses fingerprint cache)
             match_result = self._match_streams(

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -1,20 +1,12 @@
 """Stream fetching/filtering and provider event fetching for event groups."""
 
 import logging
-import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any
 
-from teamarr.core import Event
 from teamarr.database.groups import EventEPGGroup
 from teamarr.services.stream_filter import FilterResult, StreamFilter, StreamFilterConfig
 
 logger = logging.getLogger(__name__)
-
-# Number of parallel workers for event fetching
-# Configurable via ESPN_MAX_WORKERS for users with DNS throttling (PiHole, AdGuard)
-MAX_WORKERS = int(os.environ.get("ESPN_MAX_WORKERS", 100))
 
 
 class StreamFetcher:
@@ -327,71 +319,3 @@ class StreamFetcher:
         with self._db_factory() as conn:
             cursor = conn.execute("SELECT league_slug FROM league_cache")
             return [row[0] for row in cursor.fetchall()]
-
-    def _fetch_events(self, leagues: list[str], target_date: date) -> list[Event]:
-        """Fetch events from data providers for leagues in parallel.
-
-        Uses a fixed 7-day lookback (for weekly sports like NFL) and
-        event_match_days_ahead setting for future events.
-        """
-        if not leagues:
-            return []
-
-        all_events: list[Event] = []
-        num_workers = min(MAX_WORKERS, len(leagues))
-
-        # Load date range settings
-        # Note: days_back is hardcoded to 7 for weekly sports like NFL
-        with self._db_factory() as conn:
-            row = conn.execute(
-                "SELECT event_match_days_ahead FROM settings WHERE id = 1"
-            ).fetchone()
-            days_back = 7  # Hardcoded for weekly sports
-            days_ahead = (
-                row["event_match_days_ahead"] if row and row["event_match_days_ahead"] else 3
-            )
-
-        # Build date range: [target - days_back, target + days_ahead]
-        dates_to_fetch = [
-            target_date + timedelta(days=offset) for offset in range(-days_back, days_ahead + 1)
-        ]
-        logger.debug(
-            "[EVENT_EPG] Fetching events from %s to %s (%d days)",
-            dates_to_fetch[0],
-            dates_to_fetch[-1],
-            len(dates_to_fetch),
-        )
-
-        def fetch_league_events(league: str, fetch_date: date) -> tuple[str, date, list[Event]]:
-            """Fetch events for a single league/date (for parallel execution)."""
-            try:
-                # TSDB leagues: cache-only (don't hit API during EPG generation)
-                # TSDB cache builds organically from startup/scheduled refresh
-                is_tsdb = self._service.get_provider_name(league) == "tsdb"
-                events = self._service.get_events(league, fetch_date, cache_only=is_tsdb)
-                return (league, fetch_date, events)
-            except Exception as e:
-                logger.warning(
-                    "[EVENT_EPG] Failed to fetch events for %s on %s: %s", league, fetch_date, e
-                )
-                return (league, fetch_date, [])
-
-        with ThreadPoolExecutor(max_workers=num_workers) as executor:
-            # Create tasks for all league/date combinations
-            futures = {}
-            for league in leagues:
-                for fetch_date in dates_to_fetch:
-                    future = executor.submit(fetch_league_events, league, fetch_date)
-                    futures[future] = (league, fetch_date)
-
-            for future in as_completed(futures):
-                try:
-                    league, fetch_date, events = future.result()
-                    all_events.extend(events)
-                except Exception as e:
-                    league, fetch_date = futures[future]
-                    logger.warning(
-                        "[EVENT_EPG] Failed to fetch events for %s on %s: %s", league, fetch_date, e
-                    )
-
-        return all_events

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -1,4 +1,4 @@
-"""Stream fetching/filtering and provider event fetching for event groups."""
+"""M3U stream fetching/filtering and known-league lookup for event groups."""
 
 import logging
 from typing import TYPE_CHECKING, Any
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class StreamFetcher:
-    """Fetches M3U streams from Dispatcharr and events from data providers.
+    """Fetches and filters M3U streams from Dispatcharr for event groups.
 
     Mixin for EventGroupProcessor — relies on the coordinator's
     ``_db_factory``, ``_dispatcharr_client`` and ``_service`` attributes.

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -6,6 +6,7 @@ Pure fetch + normalize - no caching (caching is in service layer).
 
 import logging
 import re
+from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta
 
 from teamarr.core import (
@@ -46,10 +47,26 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
     ):
         self._client = client or ESPNClient()
         self._league_mapping_source = league_mapping_source
+        # Optional cached, league-wide events fetcher injected by SportsDataService.
+        # When set, the future-day team scan reuses the shared per-(league, date)
+        # events cache instead of fetching each day's scoreboard once per team —
+        # so a league's daily scoreboard is fetched once per run, not N_teams times.
+        self._cached_events_fn: Callable[[str, date], list[Event]] | None = None
 
     @property
     def name(self) -> str:
         return "espn"
+
+    def set_cached_events_fn(
+        self, fn: Callable[[str, date], list[Event]] | None
+    ) -> None:
+        """Inject a cached league-wide events fetcher (SportsDataService.get_events).
+
+        Used by the future-day team scan so all teams in a league share one
+        scoreboard fetch per day. When unset (provider used standalone, e.g. in
+        tests or cache refresh), the scan falls back to direct per-day fetches.
+        """
+        self._cached_events_fn = fn
 
     def supports_league(self, league: str) -> bool:
         # Database is the source of truth
@@ -373,14 +390,28 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
         Scans the scoreboard for the next N days, filtering for games
         involving the specified team. This approach works for all sports
         and captures both regular season and playoff games.
+
+        When a cached events fetcher is injected (the normal path via
+        SportsDataService), each day's full-league scoreboard is fetched once
+        and shared across every team in the league — and with event-group
+        matching, which reads the same cache. Falls back to direct per-day
+        scoreboard fetches when used standalone (no cache wired).
         """
         events = []
         today = date.today()
 
         for day_offset in range(days_ahead):
             target_date = today + timedelta(days=day_offset)
-            date_str = target_date.strftime("%Y%m%d")
 
+            if self._cached_events_fn is not None:
+                # Shared, cached league-wide events; league name is captured
+                # inside the underlying get_events → no separate capture needed.
+                for event in self._cached_events_fn(league, target_date):
+                    if self._event_has_team(team_id, event):
+                        events.append(event)
+                continue
+
+            date_str = target_date.strftime("%Y%m%d")
             data = self._client.get_scoreboard(league, date_str, sport_league)
             if not data:
                 continue
@@ -398,7 +429,7 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
         return events
 
     def _team_in_event(self, team_id: str, event_data: dict) -> bool:
-        """Check if a team is playing in this event."""
+        """Check if a team is playing in this event (raw scoreboard dict)."""
         competitions = event_data.get("competitions", [])
         if not competitions:
             return False
@@ -406,6 +437,15 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
         for competitor in competitions[0].get("competitors", []):
             comp_team = competitor.get("team", {})
             if str(comp_team.get("id")) == str(team_id):
+                return True
+        return False
+
+    @staticmethod
+    def _event_has_team(team_id: str, event: Event) -> bool:
+        """Check if a team is playing in this event (parsed Event)."""
+        tid = str(team_id)
+        for team in (event.home_team, event.away_team):
+            if team and str(team.id) == tid:
                 return True
         return False
 

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -231,6 +231,14 @@ class SportsDataService:
     def __init__(self, providers: list[SportsProvider] | None = None):
         self._providers: list[SportsProvider] = providers or []
         self._cache = _get_shared_cache()
+        # Let providers that scan day-by-day (ESPN team schedules) reuse the
+        # cached, league-wide get_events so a league's daily scoreboard is
+        # fetched once per run instead of once per team. Providers that don't
+        # expose the hook are unaffected.
+        for provider in self._providers:
+            setter = getattr(provider, "set_cached_events_fn", None)
+            if callable(setter):
+                setter(self.get_events)
 
     def add_provider(self, provider: SportsProvider) -> None:
         """Register a provider."""

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -59,6 +59,10 @@ REFRESH_COALESCE_TTL = 300  # seconds
 # hundreds of live 404s per run for a single event.
 _EVENT_NOT_FOUND = {"__event_not_found__": True}
 
+# Sentinel distinguishing "no usable cache entry" from a legitimately cached
+# empty result (e.g. a league with no games that day, cached as []).
+_CACHE_MISS = object()
+
 # In-memory memo for team_cache identity lookups. Enrichment runs for the home
 # and away team of every event on every get_events cache hit, so without this
 # each degraded team costs a fresh SQLite connection (+3 PRAGMAs) per event —
@@ -258,9 +262,11 @@ class SportsDataService:
         """
         cache_key = make_cache_key("events", league, target_date.isoformat())
 
-        # Check cache (deserialize from dict)
-        cached = self._cache.get(cache_key)
-        if cached is not None:
+        def load_from_cache() -> list[Event] | object:
+            """Return cached events, or _CACHE_MISS if absent/stale/corrupt."""
+            cached = self._cache.get(cache_key)
+            if cached is None:
+                return _CACHE_MISS
             if isinstance(cached, list) and any(
                 _event_dict_is_stale(e) for e in cached if isinstance(e, dict)
             ):
@@ -269,29 +275,43 @@ class SportsDataService:
                     cache_key,
                 )
                 self._cache.delete(cache_key)
-            else:
-                logger.debug("[CACHE_HIT] %s", cache_key)
-                try:
-                    return [_enrich_event_teams(dict_to_event(e)) for e in cached]
-                except (KeyError, TypeError) as e:
-                    logger.warning("[CACHE_ERROR] Deserialization failed: %s", e)
+                return _CACHE_MISS
+            logger.debug("[CACHE_HIT] %s", cache_key)
+            try:
+                return [_enrich_event_teams(dict_to_event(e)) for e in cached]
+            except (KeyError, TypeError) as e:
+                logger.warning("[CACHE_ERROR] Deserialization failed: %s", e)
+                return _CACHE_MISS
+
+        hit = load_from_cache()
+        if hit is not _CACHE_MISS:
+            return hit  # type: ignore[return-value]
 
         # If cache_only, don't fetch from API
         if cache_only:
             return []
 
-        # Iterate through providers
-        for provider in self._providers:
-            if provider.supports_league(league):
-                events = provider.get_events(league, target_date)
-                # Check if all events are final (for past dates, enables 30-day cache)
-                # Empty list counts as "all final" (no games = nothing to update)
-                all_final = len(events) == 0 or all(is_event_final(e) for e in events)
-                ttl = get_events_cache_ttl(target_date, all_events_final=all_final)
-                # Cache ALL results including empty lists to avoid repeated API calls
-                # for leagues with no events on a given day
-                self._cache.set(cache_key, [event_to_dict(e) for e in events], ttl)
-                return [_enrich_event_teams(e) for e in events]
+        # Single-flight: one thread fetches a given (league, date); concurrent
+        # callers (parallel stream matching, the team scan) wait and read the
+        # freshly cached result instead of each issuing a duplicate scoreboard
+        # request.
+        with self._cache.lock_key(cache_key):
+            hit = load_from_cache()
+            if hit is not _CACHE_MISS:
+                return hit  # type: ignore[return-value]
+
+            # Iterate through providers
+            for provider in self._providers:
+                if provider.supports_league(league):
+                    events = provider.get_events(league, target_date)
+                    # Check if all events are final (for past dates, enables 30-day
+                    # cache). Empty list counts as "all final" (nothing to update).
+                    all_final = len(events) == 0 or all(is_event_final(e) for e in events)
+                    ttl = get_events_cache_ttl(target_date, all_events_final=all_final)
+                    # Cache ALL results including empty lists to avoid repeated API
+                    # calls for leagues with no events on a given day
+                    self._cache.set(cache_key, [event_to_dict(e) for e in events], ttl)
+                    return [_enrich_event_teams(e) for e in events]
         return []
 
     def get_sample_event(self, league: str) -> Event | None:
@@ -437,9 +457,11 @@ class SportsDataService:
 
         cache_key = make_cache_key("event", league, event_id)
 
-        # Check cache (deserialize from dict)
-        cached = self._cache.get(cache_key)
-        if cached is not None:
+        def load_from_cache() -> Event | None | object:
+            """Return cached event, or _CACHE_MISS if absent/stale/corrupt."""
+            cached = self._cache.get(cache_key)
+            if cached is None:
+                return _CACHE_MISS
             if isinstance(cached, dict) and cached.get("__event_not_found__"):
                 logger.debug("[CACHE_HIT] %s (negative — provider miss)", cache_key)
                 return None
@@ -449,24 +471,37 @@ class SportsDataService:
                     cache_key,
                 )
                 self._cache.delete(cache_key)
-            else:
-                logger.debug("[CACHE_HIT] %s", cache_key)
-                try:
-                    return _enrich_event_teams(dict_to_event(cached))
-                except (KeyError, TypeError) as e:
-                    logger.warning("[CACHE_ERROR] Deserialization failed: %s", e)
+                return _CACHE_MISS
+            logger.debug("[CACHE_HIT] %s", cache_key)
+            try:
+                return _enrich_event_teams(dict_to_event(cached))
+            except (KeyError, TypeError) as e:
+                logger.warning("[CACHE_ERROR] Deserialization failed: %s", e)
+                return _CACHE_MISS
 
-        for provider in self._providers:
-            if provider.supports_league(league):
-                event = provider.get_event(event_id, league)
-                if event:
-                    # Serialize to dict before caching
-                    self._cache.set(cache_key, event_to_dict(event), CACHE_TTL_SINGLE_EVENT)
-                    return _enrich_event_teams(event)
+        hit = load_from_cache()
+        if hit is not _CACHE_MISS:
+            return hit  # type: ignore[return-value]
 
-        # Short TTL: don't mask an event that becomes available, just absorb
-        # the per-channel refresh fan-out within one coalesce window.
-        self._cache.set(cache_key, _EVENT_NOT_FOUND, REFRESH_COALESCE_TTL)
+        # Single-flight: collapse concurrent identical summary fetches (the
+        # coalesce marker in refresh_event_status has a check-then-act race when
+        # two threads enter together) into one upstream request.
+        with self._cache.lock_key(cache_key):
+            hit = load_from_cache()
+            if hit is not _CACHE_MISS:
+                return hit  # type: ignore[return-value]
+
+            for provider in self._providers:
+                if provider.supports_league(league):
+                    event = provider.get_event(event_id, league)
+                    if event:
+                        # Serialize to dict before caching
+                        self._cache.set(cache_key, event_to_dict(event), CACHE_TTL_SINGLE_EVENT)
+                        return _enrich_event_teams(event)
+
+            # Short TTL: don't mask an event that becomes available, just absorb
+            # the per-channel refresh fan-out within one coalesce window.
+            self._cache.set(cache_key, _EVENT_NOT_FOUND, REFRESH_COALESCE_TTL)
         return None
 
     # Fields refreshed onto the original event by refresh_event_status. Anything

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -60,8 +60,14 @@ REFRESH_COALESCE_TTL = 300  # seconds
 _EVENT_NOT_FOUND = {"__event_not_found__": True}
 
 # Sentinel distinguishing "no usable cache entry" from a legitimately cached
-# empty result (e.g. a league with no games that day, cached as []).
-_CACHE_MISS = object()
+# empty result (e.g. a league with no games that day, cached as []). A distinct
+# class (not bare object()) lets callers narrow the load_from_cache() union with
+# isinstance, so the real payload type flows through without a type: ignore.
+class _CacheMiss:
+    __slots__ = ()
+
+
+_CACHE_MISS = _CacheMiss()
 
 # In-memory memo for team_cache identity lookups. Enrichment runs for the home
 # and away team of every event on every get_events cache hit, so without this
@@ -262,7 +268,7 @@ class SportsDataService:
         """
         cache_key = make_cache_key("events", league, target_date.isoformat())
 
-        def load_from_cache() -> list[Event] | object:
+        def load_from_cache() -> list[Event] | _CacheMiss:
             """Return cached events, or _CACHE_MISS if absent/stale/corrupt."""
             cached = self._cache.get(cache_key)
             if cached is None:
@@ -284,8 +290,8 @@ class SportsDataService:
                 return _CACHE_MISS
 
         hit = load_from_cache()
-        if hit is not _CACHE_MISS:
-            return hit  # type: ignore[return-value]
+        if not isinstance(hit, _CacheMiss):
+            return hit
 
         # If cache_only, don't fetch from API
         if cache_only:
@@ -297,8 +303,8 @@ class SportsDataService:
         # request.
         with self._cache.lock_key(cache_key):
             hit = load_from_cache()
-            if hit is not _CACHE_MISS:
-                return hit  # type: ignore[return-value]
+            if not isinstance(hit, _CacheMiss):
+                return hit
 
             # Iterate through providers
             for provider in self._providers:
@@ -457,7 +463,7 @@ class SportsDataService:
 
         cache_key = make_cache_key("event", league, event_id)
 
-        def load_from_cache() -> Event | None | object:
+        def load_from_cache() -> Event | None | _CacheMiss:
             """Return cached event, or _CACHE_MISS if absent/stale/corrupt."""
             cached = self._cache.get(cache_key)
             if cached is None:
@@ -480,16 +486,16 @@ class SportsDataService:
                 return _CACHE_MISS
 
         hit = load_from_cache()
-        if hit is not _CACHE_MISS:
-            return hit  # type: ignore[return-value]
+        if not isinstance(hit, _CacheMiss):
+            return hit
 
         # Single-flight: collapse concurrent identical summary fetches (the
         # coalesce marker in refresh_event_status has a check-then-act race when
         # two threads enter together) into one upstream request.
         with self._cache.lock_key(cache_key):
             hit = load_from_cache()
-            if hit is not _CACHE_MISS:
-                return hit  # type: ignore[return-value]
+            if not isinstance(hit, _CacheMiss):
+                return hit
 
             for provider in self._providers:
                 if provider.supports_league(league):

--- a/teamarr/utilities/cache.py
+++ b/teamarr/utilities/cache.py
@@ -20,6 +20,8 @@ import atexit
 import json
 import logging
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
@@ -243,6 +245,12 @@ class PersistentTTLCache:
         self._deleted_keys: set[str] = set()
         self._dirty_lock = threading.Lock()
 
+        # Per-key locks for single-flight fetches (see lock_key). Refcounted so
+        # an idle key's lock is dropped once no callers hold or wait on it,
+        # keeping the map bounded to keys with in-flight fetches.
+        self._keylocks: dict[str, list] = {}
+        self._keylocks_guard = threading.Lock()
+
         # Background flush thread
         self._flush_timer: threading.Timer | None = None
         self._shutdown = False
@@ -342,6 +350,38 @@ class PersistentTTLCache:
         with self._dirty_lock:
             self._deleted_keys.add(key)
             self._dirty_keys.discard(key)
+
+    @contextmanager
+    def lock_key(self, key: str) -> Iterator[None]:
+        """Serialize work for a single cache key across threads (single-flight).
+
+        Callers use the double-checked pattern: read the cache, and only on a
+        miss enter ``lock_key`` and re-read before fetching. This collapses a
+        burst of concurrent identical fetches (e.g. parallel stream matching all
+        wanting the same league/date scoreboard) into one upstream request — the
+        first thread fetches and populates the cache, the rest wait and read it.
+
+        Locks are refcounted and removed when idle so the map stays bounded.
+        """
+        with self._keylocks_guard:
+            entry = self._keylocks.get(key)
+            if entry is None:
+                entry = [threading.Lock(), 0]
+                self._keylocks[key] = entry
+            entry[1] += 1  # register as a waiter before releasing the guard
+            lock = entry[0]
+
+        lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+            with self._keylocks_guard:
+                entry = self._keylocks.get(key)
+                if entry is not None:
+                    entry[1] -= 1
+                    if entry[1] <= 0:
+                        del self._keylocks[key]
 
     def clear(self) -> None:
         """Clear all cached values."""

--- a/teamarr/utilities/cache.py
+++ b/teamarr/utilities/cache.py
@@ -362,6 +362,12 @@ class PersistentTTLCache:
         first thread fetches and populates the cache, the rest wait and read it.
 
         Locks are refcounted and removed when idle so the map stays bounded.
+
+        Non-reentrant: this is a plain ``threading.Lock``, so a caller holding
+        the lock for ``key`` must not re-enter ``lock_key`` for that same key
+        (it would self-deadlock). The double-checked fetch bodies today stay
+        flat — they read the cache and call the provider, never back into a
+        lock-wrapped ``get_events``/``get_event`` for the same key.
         """
         with self._keylocks_guard:
             entry = self._keylocks.get(key)
@@ -376,12 +382,13 @@ class PersistentTTLCache:
             yield
         finally:
             lock.release()
+            # Our own refcount kept this exact entry in the map for the whole
+            # critical section (no other thread can drop it while count > 0), so
+            # the captured local is still the live entry — decrement and evict.
             with self._keylocks_guard:
-                entry = self._keylocks.get(key)
-                if entry is not None:
-                    entry[1] -= 1
-                    if entry[1] <= 0:
-                        del self._keylocks[key]
+                entry[1] -= 1
+                if entry[1] <= 0:
+                    del self._keylocks[key]
 
     def clear(self) -> None:
         """Clear all cached values."""

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,6 +9,7 @@ Single-use fakes (FakeDispatcharrChannel, FakeTemplate, FakeMappingSource,
 ...) stay local to their test file.
 """
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -34,6 +35,13 @@ class FakeCache:
 
     def delete(self, key):
         self.data.pop(key, None)
+
+    @contextmanager
+    def lock_key(self, key):
+        """No-op single-flight lock — get_events/get_event enter this before a
+        provider fetch; the real PersistentTTLCache serializes concurrent
+        misses, but tests run single-threaded so a bare yield suffices."""
+        yield
 
 
 @dataclass

--- a/tests/test_cache_singleflight.py
+++ b/tests/test_cache_singleflight.py
@@ -1,0 +1,82 @@
+"""Single-flight dedup: concurrent identical fetches collapse to one request.
+
+Parallel stream matching fans out across threads that frequently want the same
+``(league, date)`` scoreboard. Without single-flight, every thread that races
+past the cache miss issues its own upstream fetch. SportsDataService.get_events
+now serializes the miss path per cache key so only the first thread fetches.
+"""
+
+import threading
+import time
+from datetime import date, timedelta
+
+from teamarr.services import sports_data
+from teamarr.services.sports_data import SportsDataService
+from teamarr.utilities.cache import PersistentTTLCache
+
+
+class _SlowProvider:
+    """Provider whose fetch is slow enough that concurrent callers pile up."""
+
+    def __init__(self):
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    @property
+    def name(self):
+        return "espn"
+
+    def supports_league(self, league):
+        return True
+
+    def get_events(self, league, target_date):
+        with self._lock:
+            self.calls += 1
+        time.sleep(0.1)  # simulate a network round-trip
+        return []  # empty slate is enough; we count fetches, not contents
+
+
+def _service(monkeypatch):
+    # Hermetic cache: stub SQLite load/flush so the shared cache starts empty
+    # and never touches the real service_cache DB.
+    monkeypatch.setattr(PersistentTTLCache, "_load_from_sqlite", lambda self: None)
+    monkeypatch.setattr(PersistentTTLCache, "flush", lambda self: 0)
+    monkeypatch.setattr(sports_data, "_shared_cache", None)
+    provider = _SlowProvider()
+    return provider, SportsDataService(providers=[provider])
+
+
+def _hammer(service, league, target, n):
+    barrier = threading.Barrier(n)
+
+    def worker():
+        barrier.wait()  # release all threads at once to maximize the race
+        service.get_events(league, target)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+def test_concurrent_same_key_fetches_once(monkeypatch):
+    provider, service = _service(monkeypatch)
+    target = date.today() + timedelta(days=3)
+
+    _hammer(service, "nba", target, n=20)
+
+    # 20 threads, one cache key -> exactly one upstream fetch.
+    assert provider.calls == 1
+
+
+def test_distinct_keys_not_serialized_away(monkeypatch):
+    """Guard: single-flight must not drop fetches for different keys."""
+    provider, service = _service(monkeypatch)
+    d1 = date.today() + timedelta(days=3)
+    d2 = date.today() + timedelta(days=4)
+
+    _hammer(service, "nba", d1, n=10)
+    _hammer(service, "nba", d2, n=10)
+
+    assert provider.calls == 2

--- a/tests/test_espn_team_schedule_dedup.py
+++ b/tests/test_espn_team_schedule_dedup.py
@@ -11,6 +11,7 @@ and shared across every team (and with event-group matching).
 from teamarr.providers.espn.provider import ESPNProvider
 from teamarr.services import sports_data
 from teamarr.services.sports_data import SportsDataService
+from teamarr.utilities.cache import PersistentTTLCache
 
 
 class _StubMapping:
@@ -48,7 +49,11 @@ class _CountingClient:
 
 
 def _build(monkeypatch, *, optimized):
-    # Isolated cache per service so the two configurations don't share hits.
+    # Isolated, hermetic cache per service: stub SQLite load/flush so the shared
+    # cache starts empty and never reads from or pollutes the real service_cache
+    # DB, then reset the process-global singleton so a fresh one is built.
+    monkeypatch.setattr(PersistentTTLCache, "_load_from_sqlite", lambda self: None)
+    monkeypatch.setattr(PersistentTTLCache, "flush", lambda self: 0)
     monkeypatch.setattr(sports_data, "_shared_cache", None)
     client = _CountingClient()
     provider = ESPNProvider(client=client, league_mapping_source=_StubMappingSource())

--- a/tests/test_espn_team_schedule_dedup.py
+++ b/tests/test_espn_team_schedule_dedup.py
@@ -1,0 +1,87 @@
+"""ESPN team-schedule scans share one scoreboard fetch per league/day.
+
+Regression guard for the call-volume bug class called out in
+``teamarr.utilities.call_metrics``: the future-day team scan used to fetch each
+day's full-league scoreboard once *per team*, so a league with N teams hit the
+scoreboard N x days_ahead times. SportsDataService now injects its cached,
+league-wide ``get_events`` into the provider so each day is fetched once per run
+and shared across every team (and with event-group matching).
+"""
+
+from teamarr.providers.espn.provider import ESPNProvider
+from teamarr.services import sports_data
+from teamarr.services.sports_data import SportsDataService
+
+
+class _StubMapping:
+    provider_league_id = "basketball/nba"
+    sport = "basketball"
+
+
+class _StubMappingSource:
+    def supports_league(self, league, provider):
+        return True
+
+    def get_mapping(self, league, provider):
+        return _StubMapping()
+
+    def get_mapping_by_league(self, league):
+        return _StubMapping()
+
+    def get_league_sport(self, league):
+        return "basketball"
+
+    def register_discovered_league(self, **kwargs):
+        pass
+
+
+class _CountingClient:
+    def __init__(self):
+        self.scoreboard_calls = 0
+
+    def get_scoreboard(self, league, date_str=None, sport_league=None):
+        self.scoreboard_calls += 1
+        return {"events": [], "leagues": [{"name": "NBA"}]}
+
+    def get_team_schedule(self, league, team_id, sport_league=None):
+        return {"events": []}
+
+
+def _build(monkeypatch, *, optimized):
+    # Isolated cache per service so the two configurations don't share hits.
+    monkeypatch.setattr(sports_data, "_shared_cache", None)
+    client = _CountingClient()
+    provider = ESPNProvider(client=client, league_mapping_source=_StubMappingSource())
+    service = SportsDataService(providers=[provider])
+    if not optimized:
+        provider.set_cached_events_fn(None)  # simulate pre-fix behavior
+    return client, service
+
+
+def test_scoreboard_fetched_once_per_day_across_teams(monkeypatch):
+    days_ahead = 14
+    n_teams = 6
+
+    client_opt, service_opt = _build(monkeypatch, optimized=True)
+    for i in range(n_teams):
+        service_opt.get_team_schedule(f"team{i}", "verify-on", days_ahead=days_ahead)
+
+    # Flat at days_ahead regardless of team count — the whole point.
+    assert client_opt.scoreboard_calls == days_ahead
+
+
+def test_optimization_cuts_redundant_fetches(monkeypatch):
+    days_ahead = 14
+    n_teams = 6
+
+    client_off, service_off = _build(monkeypatch, optimized=False)
+    for i in range(n_teams):
+        service_off.get_team_schedule(f"team{i}", "verify-off", days_ahead=days_ahead)
+
+    client_on, service_on = _build(monkeypatch, optimized=True)
+    for i in range(n_teams):
+        service_on.get_team_schedule(f"team{i}", "verify-on", days_ahead=days_ahead)
+
+    assert client_off.scoreboard_calls == n_teams * days_ahead
+    assert client_on.scoreboard_calls == days_ahead
+    assert client_on.scoreboard_calls < client_off.scoreboard_calls


### PR DESCRIPTION
## Summary

Generation was hitting ESPN's scoreboard endpoint far more than necessary — the same `(league, date)` scoreboard was being fetched once per team, once per racing thread, and once as a redundant pre-flight before matching even ran. This branch collapses all of that onto a single shared, deduplicated per-`(league, date)` events cache.

Three independent fixes, no behavior change to matching coverage or EPG output:

## 1. Share scoreboard fetches across team-schedule scans

Team-schedule generation scanned each future day's full-league scoreboard once **per team** (`days_ahead × N_teams` fetches), bypassing the cached, league-wide `get_events`. `SportsDataService` now injects `get_events` into the ESPN provider so the future-day scan reuses the shared per-`(league, date)` cache — each day's scoreboard is fetched once per run and shared across every team and event-group match.

- **Measured: 84 → 14 fetches (83% fewer)** for 6 teams × 14 days; flat at `days_ahead` regardless of team count.
- Falls back to direct per-day fetches when used standalone (no cache wired).

## 2. Single-flight dedup for concurrent identical fetches 

Parallel stream matching fans out across threads that frequently want the same `(league, date)` scoreboard. Without coordination, every thread racing past the cache miss issued its own upstream fetch, and the coalesce marker had a check-then-act race.

## 3. Drop the redundant pre-flight event fetch

`_fetch_events` did a full multi-day scoreboard sweep before matching, but its result was only used for an "are there any events?" early-exit guard — it was **never matched against**. The matcher fetches its own events (30-day window, past days cache-only), so the sweep was pure overhead, and its 7-day lookback existed solely to stop the guard from false-bailing mid-week for weekly sports (NFL).

<img width="159" height="230" alt="image" src="https://github.com/user-attachments/assets/bcbec467-8402-42de-9597-9e2fa1ef58f7" />

