### PR TITLE
Harden stream date parsing

### DIFF
--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -199,18 +199,28 @@ def apply_city_translations(text: str) -> str:
 
 # Date patterns to extract and mask
 _MONTHS = r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec"
+# Abbrev or full month name, \b-anchored. Avoids the old `(Jan|...)[a-z]*`
+# which let "Mar" swallow "Marauders" -> mis-read as "Mar 30".
+_MONTH_NAMES = (
+    r"Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?"
+)
 DATE_PATTERNS = [
     # ISO format: 2026-01-09 (YYYY-MM-DD) - must be before MM/DD/YYYY pattern
     (r"\b(\d{4})[/\-](\d{1,2})[/\-](\d{1,2})\b", "DATE_MASK_ISO"),
     # 12/31/25, 12/31/2025 (MM/DD/YY or MM/DD/YYYY)
     (r"\b(\d{1,2})[/\-](\d{1,2})[/\-](\d{2,4})\b", "DATE_MASK"),
+    # 30 @ Jun - reversed day-@-month tail (some MiLB feeds). Masking removes the
+    # stray "@" so it can't beat " at " as the matchup separator. Month NAME
+    # required so real matchups ("LAL @ BOS") are untouched.
+    (rf"\b(\d{{1,2}})(?:st|nd|rd|th)?\s*@\s*(?:{_MONTH_NAMES})\b", "DATE_MASK"),
     # 1/17, 12/31 (MM/DD without year) - infer year based on proximity to today
     # Must come after MM/DD/YYYY to avoid partial matches
     (r"\b(\d{1,2})[/\-](\d{1,2})\b", "DATE_MASK_NO_YEAR"),
     # 31 Dec, 31 December - check this BEFORE "Dec 31" to prefer "14 Jan" over "Jan 11"
-    (rf"\b(\d{{1,2}})(?:st|nd|rd|th)?\s+({_MONTHS})[a-z]*\b", "DATE_MASK"),
+    (rf"\b(\d{{1,2}})(?:st|nd|rd|th)?\s+(?:{_MONTH_NAMES})\b", "DATE_MASK"),
     # Dec 31, December 31 - use negative lookahead (?!:) to avoid matching "Jan 11:45pm"
-    (rf"\b({_MONTHS})[a-z]*\s+(\d{{1,2}})(?:st|nd|rd|th)?(?!:)\b", "DATE_MASK"),
+    (rf"\b(?:{_MONTH_NAMES})\s+(\d{{1,2}})(?:st|nd|rd|th)?(?!:)\b", "DATE_MASK"),
 ]
 
 # Time patterns to extract and mask (with optional TZ suffix)

--- a/tests/test_day_at_month_date.py
+++ b/tests/test_day_at_month_date.py
@@ -1,0 +1,76 @@
+"""Regression tests for the "DD @ Mon" datetime tail and month-abbreviation greed.
+
+Some MiLB/provider feeds name streams like:
+
+    "MiLB 08: MiLB A 05: Daytona Tortugas at Bradenton Marauders 30 @ Jun 06:30 PM ET"
+
+i.e. the day comes BEFORE the month and "@" is used as the date/time separator.
+Two bugs used to break these streams:
+
+1. The greedy month pattern `(Jan|...|Dec)[a-z]*` let "Mar" swallow "Marauders",
+   so "Marauders 30" parsed as March 30 instead of the real June 30 date.
+2. The leftover "@" in "30 @ Jun" was picked as the matchup separator (it
+   outranks " at " in GAME_SEPARATORS), splitting the teams completely wrong.
+
+Both are fixed in the normalizer by masking "DD @ Mon" as a date (which also
+removes the stray "@") and tightening the month names to bounded abbreviations.
+"""
+
+from datetime import date
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.normalizer import normalize_stream
+
+
+class TestDayAtMonthDate:
+    """The reversed 'DD @ Mon' datetime tail extracts correctly."""
+
+    def test_month_named_team_not_eaten_by_date(self):
+        # "Marauders" must not be read as "Mar" + day 30.
+        norm = normalize_stream(
+            "Daytona Tortugas at Bradenton Marauders 30 @ Jun 06:30 PM ET"
+        )
+        assert norm.extracted_date == date(date.today().year, 6, 30)
+
+    def test_full_milb_stream_classifies_correctly(self):
+        c = classify_stream(
+            "MiLB 08: MiLB A 05: Daytona Tortugas at Bradenton Marauders 30 @ Jun 06:30 PM ET"
+        )
+        assert c.category.value == "team_vs_team"
+        # The real " at " matchup separator wins now that the stray "@" is masked.
+        assert c.team1 and c.team1.endswith("Daytona Tortugas")
+        assert c.team2 == "Bradenton Marauders"
+        assert c.normalized.extracted_date == date(date.today().year, 6, 30)
+
+    def test_non_month_team_unaffected(self):
+        c = classify_stream(
+            "MiLB 17: MiLB AA 04: Erie SeaWolves at Akron RubberDucks 30 @ Jun 06:35 PM ET"
+        )
+        assert c.team2 == "Akron RubberDucks"
+        assert c.normalized.extracted_date == date(date.today().year, 6, 30)
+
+
+class TestNoRegressions:
+    """Existing date / separator behaviour must be preserved."""
+
+    def test_real_at_matchup_separator_still_works(self):
+        # "@" as a genuine matchup separator (no month after it) is untouched.
+        c = classify_stream("NBA | Lakers @ Celtics")
+        assert c.team1 == "Lakers"
+        assert c.team2 == "Celtics"
+
+    def test_day_month_date_still_parses(self):
+        # Year is inferred by proximity; assert the month/day were extracted.
+        norm = normalize_stream("Arsenal vs Chelsea 14 Jan 3:00 PM ET")
+        assert norm.extracted_date is not None
+        assert (norm.extracted_date.month, norm.extracted_date.day) == (1, 14)
+
+    def test_month_day_date_still_parses(self):
+        norm = normalize_stream("Yankees vs Red Sox Dec 31")
+        assert norm.extracted_date is not None
+        assert (norm.extracted_date.month, norm.extracted_date.day) == (12, 31)
+
+    def test_full_month_name_still_parses(self):
+        norm = normalize_stream("Game on June 30 tonight")
+        assert norm.extracted_date is not None
+        assert (norm.extracted_date.month, norm.extracted_date.day) == (6, 30)


### PR DESCRIPTION
Month abbreviations swallowed adjacent words. The date patterns used (Jan|...|Dec)[a-z]*, so a 3-letter month could greedily absorb any longer word starting with the same letters — e.g. "Marauders 30" was read as March 30. 
Any team/word beginning with a month prefix was at risk (Marauders, Mariners, Marlins, Mayhem, Augusta).

Add a \d{1,2} @ <month-name> pattern that extracts the date and masks out the stray @, so the genuine " at " matchup separator wins. It only fires when an actual month name follows @, so real match-ups like LAL @ BOS are untouched.