### PR TITLE
fix(lifecycle): assign channel profiles when only one profile exists

### DIFF
--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -744,12 +744,8 @@ class ChannelLifecycleService:
                             )
                         )
 
-                        resolved_channel_profile_ids = (
-                            self._dynamic_resolver.resolve_channel_profiles(
-                                profile_ids=effective_profile_ids,
-                                event_sport=event_sport,
-                                event_league=event_league,
-                            )
+                        resolved_channel_profile_ids = self._resolve_profiles_for_event(
+                            effective_profile_ids, event_sport, event_league
                         )
 
                         # Create new channel
@@ -1090,6 +1086,27 @@ class ChannelLifecycleService:
 
         return result
 
+    def _resolve_profiles_for_event(
+        self,
+        profile_ids: list[int | str] | None,
+        event_sport: str | None,
+        event_league: str | None,
+    ) -> list[int] | None:
+        """Resolve configured channel profile IDs for channel creation.
+
+        None (not configured) must be preserved — _create_channel maps it to
+        the [0] all-profiles sentinel. Passing None through the dynamic
+        resolver would collapse it to [] (NO profiles), silently creating
+        channels without any profile (issue #267).
+        """
+        if profile_ids is None:
+            return None
+        return self._dynamic_resolver.resolve_channel_profiles(
+            profile_ids=profile_ids,
+            event_sport=event_sport,
+            event_league=event_league,
+        )
+
     def _create_channel(
         self,
         conn: Connection,
@@ -1099,7 +1116,7 @@ class ChannelLifecycleService:
         template: dict | None,
         matched_keyword: str | None,
         channel_group_id: int | None,
-        channel_profile_ids: list[int],
+        channel_profile_ids: list[int] | None,
         stream_profile_id: int | None = None,
         segment: str | None = None,
         segment_display: str = "",
@@ -1166,6 +1183,22 @@ class ChannelLifecycleService:
             event, template, matched_keyword, segment, feed_team=feed_team,
         )
 
+        # Dispatcharr profile semantics (as of commit 6b873be):
+        #   [] = NO profiles (explicit)
+        #   [0] = ALL profiles (sentinel)
+        #   [1, 2, ...] = specific profile IDs
+        #
+        # Logic:
+        #   None = not configured → default to [0] (all profiles, backwards compat)
+        #   [] = explicitly no profiles → send [] (no profiles)
+        #   [1, 2, ...] = specific profiles → send those
+        #
+        # Persisted to the local DB as-is so the profile drift sync compares
+        # against the same value that was pushed to Dispatcharr.
+        effective_profile_ids = (
+            channel_profile_ids if channel_profile_ids is not None else [0]
+        )
+
         # Create in Dispatcharr
         dispatcharr_channel_id = None
         dispatcharr_uuid = None
@@ -1182,19 +1215,6 @@ class ChannelLifecycleService:
                     if logo_result.success and logo_result.logo:
                         dispatcharr_logo_id = logo_result.logo.get("id")
 
-                # Create channel with channel_profile_ids
-                # Dispatcharr profile semantics (as of commit 6b873be):
-                #   [] = NO profiles (explicit)
-                #   [0] = ALL profiles (sentinel)
-                #   [1, 2, ...] = specific profile IDs
-                #
-                # Logic:
-                #   None = not configured → default to [0] (all profiles, backwards compat)
-                #   [] = explicitly no profiles → send [] (no profiles)
-                #   [1, 2, ...] = specific profiles → send those
-                effective_profile_ids = (
-                    channel_profile_ids if channel_profile_ids is not None else [0]
-                )
                 logger.debug(
                     f"Channel '{channel_name}' profile assignment: "
                     f"configured={channel_profile_ids}, effective={effective_profile_ids}"
@@ -1262,7 +1282,7 @@ class ChannelLifecycleService:
                 dispatcharr_uuid=dispatcharr_uuid,
                 dispatcharr_logo_id=dispatcharr_logo_id,
                 channel_group_id=channel_group_id,
-                channel_profile_ids=channel_profile_ids,
+                channel_profile_ids=effective_profile_ids,
                 primary_stream_id=stream_id,
                 exception_keyword=matched_keyword,
                 feed_team_id=feed_team_id,

--- a/tests/test_single_profile_assignment.py
+++ b/tests/test_single_profile_assignment.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #267 — single-profile assignment at channel create.
+
+When only one channel profile exists in Dispatcharr and the user checks it in
+Dispatcharr Output, the frontend collapses "all profiles selected" to null.
+The create path used to push that None through
+DynamicResolver.resolve_channel_profiles, which collapsed it to []
+(NO profiles), so channels were created without any profile assignment.
+
+None must survive to _create_channel, which maps it to the [0] all-profiles
+sentinel — and the same value must be persisted to the local DB so the
+profile drift sync doesn't immediately flag the new channel.
+"""
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+from teamarr.dispatcharr.types import OperationResult
+
+
+@dataclass
+class FakeEvent:
+    """Minimal event for testing."""
+
+    id: str = "123"
+    name: str = "Team A vs Team B"
+    short_name: str = "A vs B"
+    sport: str = "baseball"
+    league: str = "milb"
+    provider: str = "espn"
+    start_time: None = None
+    home_team: None = None
+    away_team: None = None
+    venue: None = None
+    broadcasts: list = field(default_factory=list)
+    status: None = None
+
+
+def _make_service(channel_manager=None):
+    from teamarr.consumers.lifecycle.service import ChannelLifecycleService
+
+    sports_service = MagicMock()
+    sports_service.get_sport_display_name.return_value = "Baseball"
+
+    return ChannelLifecycleService(
+        db_factory=MagicMock(),
+        sports_service=sports_service,
+        channel_manager=channel_manager,
+        logo_manager=MagicMock(),
+        epg_manager=MagicMock(),
+    )
+
+
+class TestResolveProfilesForEvent:
+    """None (not configured) must bypass the dynamic resolver entirely."""
+
+    def test_none_is_preserved_and_resolver_not_called(self):
+        service = _make_service()
+        service._dynamic_resolver = MagicMock()
+
+        result = service._resolve_profiles_for_event(None, "baseball", "milb")
+
+        assert result is None
+        service._dynamic_resolver.resolve_channel_profiles.assert_not_called()
+
+    def test_lists_are_delegated_to_resolver(self):
+        service = _make_service()
+        service._dynamic_resolver = MagicMock()
+        service._dynamic_resolver.resolve_channel_profiles.return_value = [2]
+
+        result = service._resolve_profiles_for_event([2], "baseball", "milb")
+
+        assert result == [2]
+        service._dynamic_resolver.resolve_channel_profiles.assert_called_once_with(
+            profile_ids=[2],
+            event_sport="baseball",
+            event_league="milb",
+        )
+
+    def test_empty_list_stays_empty(self):
+        """[] means explicitly no profiles — not the all-profiles fallback."""
+        service = _make_service()
+        service._dynamic_resolver = MagicMock()
+        service._dynamic_resolver.resolve_channel_profiles.return_value = []
+
+        assert service._resolve_profiles_for_event([], "baseball", "milb") == []
+
+
+class TestCreateChannelProfileSentinel:
+    """_create_channel maps None → [0] for Dispatcharr AND the local DB."""
+
+    def _run_create(self, channel_profile_ids):
+        cm = MagicMock()
+        cm.create_channel.return_value = OperationResult(
+            success=True, channel={"id": 100, "uuid": "uuid-100"}
+        )
+        service = _make_service(channel_manager=cm)
+
+        with (
+            patch.object(service, "_generate_channel_name", return_value="Test Channel"),
+            patch.object(service, "_get_next_channel_number", return_value="5001"),
+            patch.object(service, "_resolve_logo_url", return_value=None),
+            patch.object(
+                service._timing_manager, "calculate_delete_time", return_value=None
+            ),
+            patch("teamarr.database.channels.create_managed_channel", return_value=1)
+            as mock_create_db,
+            patch("teamarr.database.channels.add_stream_to_channel"),
+        ):
+            result = service._create_channel(
+                conn=MagicMock(),
+                event=FakeEvent(),
+                stream={"id": 456, "name": "Test Stream"},
+                group_config={"id": 1},
+                template=None,
+                matched_keyword=None,
+                channel_group_id=10,
+                channel_profile_ids=channel_profile_ids,
+            )
+
+        assert result.success
+        api_profiles = cm.create_channel.call_args.kwargs["channel_profile_ids"]
+        db_profiles = mock_create_db.call_args.kwargs["channel_profile_ids"]
+        return api_profiles, db_profiles
+
+    def test_none_becomes_all_profiles_sentinel(self):
+        """Issue #267: unconfigured (None) must create with [0], not []."""
+        api_profiles, db_profiles = self._run_create(None)
+        assert api_profiles == [0]
+        assert db_profiles == [0]
+
+    def test_empty_list_means_no_profiles(self):
+        api_profiles, db_profiles = self._run_create([])
+        assert api_profiles == []
+        assert db_profiles == []
+
+    def test_specific_profiles_pass_through(self):
+        api_profiles, db_profiles = self._run_create([2, 3])
+        assert api_profiles == [2, 3]
+        assert db_profiles == [2, 3]


### PR DESCRIPTION
Fixes #267 

With a single Dispatcharr profile, the frontend collapses 'all profiles selected' to null. The create path pushed that None through resolve_channel_profiles, which collapsed it to [] (NO profiles), so channels were created without any profile assignment. The None → [0] all-profiles fallback in _create_channel was unreachable.

Preserve None through a new _resolve_profiles_for_event helper so the [0] sentinel fallback fires, and persist the same effective value to the local DB so the profile drift sync doesn't flag brand-new channels.