### PR TITLE
fix(matching): attach identically named streams from multiple M3U accounts

### DIFF
--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -1879,13 +1879,18 @@ class EventGroupProcessor:
             match_result: Result from matcher
             stream_timezone: Group-configured timezone for stream time interpretation
         """
-        # Build name -> stream lookup
-        stream_lookup = {s["name"]: s for s in streams}
+        # Look up by stream ID first: identically named streams (same provider,
+        # multiple M3U logins) collapse in a name-keyed dict, silently dropping
+        # all but one stream per name (#264). Name lookup is only a fallback.
+        stream_by_id = {s["id"]: s for s in streams if s.get("id") is not None}
+        stream_by_name = {s["name"]: s for s in streams}
 
         matched = []
         for result in match_result.results:
             if result.matched and result.included and result.event:
-                stream = stream_lookup.get(result.stream_name)
+                stream = stream_by_id.get(result.stream_id) or stream_by_name.get(
+                    result.stream_name
+                )
                 if stream:
                     matched.append(
                         {
@@ -2462,14 +2467,18 @@ class EventGroupProcessor:
 
         Stores both matched streams and failed/unmatched streams for analysis.
         """
-        # Build name -> stream lookup for stream IDs
-        stream_lookup = {s["name"]: s for s in streams}
+        # ID-first lookup: identically named streams collapse in a name-keyed
+        # dict (#264), which would misattribute details to one stream ID.
+        stream_by_id = {s["id"]: s for s in streams if s.get("id") is not None}
+        stream_by_name = {s["name"]: s for s in streams}
 
         matched_list: list[MatchedStream] = []
         failed_list: list[FailedMatch] = []
 
         for result in match_result.results:
-            stream = stream_lookup.get(result.stream_name, {})
+            stream = stream_by_id.get(result.stream_id) or stream_by_name.get(
+                result.stream_name, {}
+            )
             stream_id = stream.get("id")
 
             if result.matched and result.included and result.event:

--- a/tests/test_duplicate_stream_names.py
+++ b/tests/test_duplicate_stream_names.py
@@ -1,0 +1,69 @@
+"""Identically named streams must each survive matched-stream list building.
+
+Regression for GitHub issue #264: users with multiple M3U accounts from the
+same provider get identically NAMED streams with distinct stream IDs. The
+matched-stream list builder keyed its stream lookup by name, collapsing all
+duplicates onto one stream dict — so only one account's stream was ever
+attached to the consolidated channel. Lookup must be ID-first.
+"""
+
+from types import SimpleNamespace
+
+from teamarr.consumers.event_group_processor import EventGroupProcessor
+from teamarr.consumers.matching.matcher import BatchMatchResult, MatchedStreamResult
+
+
+def _make_processor():
+    proc = object.__new__(EventGroupProcessor)
+    # Segment expansion needs DB-backed sport durations — pass entries through.
+    proc._expand_ufc_segments = lambda matched, tz=None: matched
+    proc._expand_racing_segments = lambda matched: matched
+    return proc
+
+
+def _result(stream_id: int, stream_name: str, event) -> MatchedStreamResult:
+    return MatchedStreamResult(
+        stream_name=stream_name,
+        stream_id=stream_id,
+        matched=True,
+        included=True,
+        event=event,
+    )
+
+
+def test_identically_named_streams_each_produce_matched_entry():
+    event = SimpleNamespace(id="401234", name="Yankees vs Red Sox")
+    # Same provider via two M3U logins: same name, different stream IDs.
+    streams = [
+        {"id": 101, "name": "MLB: Yankees vs Red Sox", "m3u_account_id": 1},
+        {"id": 202, "name": "MLB: Yankees vs Red Sox", "m3u_account_id": 2},
+    ]
+    match_result = BatchMatchResult(
+        results=[
+            _result(101, "MLB: Yankees vs Red Sox", event),
+            _result(202, "MLB: Yankees vs Red Sox", event),
+        ]
+    )
+
+    proc = _make_processor()
+    matched = proc._build_matched_stream_list(streams, match_result)
+
+    attached_ids = {m["stream"]["id"] for m in matched}
+    assert attached_ids == {101, 202}
+    # Each entry carries its own account's stream dict, not a shared one.
+    accounts = {m["stream"]["m3u_account_id"] for m in matched}
+    assert accounts == {1, 2}
+
+
+def test_name_fallback_still_works_without_stream_id():
+    event = SimpleNamespace(id="401234", name="Yankees vs Red Sox")
+    streams = [{"name": "MLB: Yankees vs Red Sox"}]  # no id key
+    match_result = BatchMatchResult(
+        results=[_result(0, "MLB: Yankees vs Red Sox", event)]
+    )
+
+    proc = _make_processor()
+    matched = proc._build_matched_stream_list(streams, match_result)
+
+    assert len(matched) == 1
+    assert matched[0]["stream"]["name"] == "MLB: Yankees vs Red Sox"


### PR DESCRIPTION
 Fixes #264

Matched-stream list and match-detail lookups were keyed by stream name, collapsing identically named streams (same provider, multiple logins) onto one stream dict — only one account's stream ever reached the channel. Key by stream ID first, name as fallback.