### PR TITLE
fix(dispatcharr): eliminate N+1 in m3u account groups endpoint

### DIFF
--- a/teamarr/api/routes/dispatcharr.py
+++ b/teamarr/api/routes/dispatcharr.py
@@ -56,26 +56,20 @@ def list_m3u_groups(account_id: int) -> list[dict]:
     if not conn:
         raise HTTPException(status_code=503, detail="Dispatcharr not configured or unavailable")
 
-    # Get all groups first
-    all_groups = conn.m3u.list_groups()
+    # The account detail endpoint carries per-group stream counts, so this is
+    # two requests total instead of one stream listing per group (issue #265)
+    names_by_id = {g.id: g.name for g in conn.m3u.list_groups()}
+    counts = conn.m3u.get_account_group_counts(account_id)
 
-    # Get streams filtered by account to find groups with streams from this account
-    # Note: This is an approximation - Dispatcharr may not directly support
-    # filtering groups by account, so we list streams per group
-    result = []
-    for group in all_groups:
-        # Count streams for this group from this account
-        streams = conn.m3u.list_streams(group_name=group.name, account_id=account_id, limit=1000)
-        if streams:  # Only include groups that have streams from this account
-            result.append(
-                {
-                    "id": group.id,
-                    "name": group.name,
-                    "stream_count": len(streams),
-                }
-            )
-
-    return result
+    return [
+        {
+            "id": group_id,
+            "name": names_by_id[group_id],
+            "stream_count": count,
+        }
+        for group_id, count in counts.items()
+        if count > 0 and group_id in names_by_id
+    ]
 
 
 def _natural_sort_key(name: str) -> list:

--- a/teamarr/dispatcharr/managers/m3u.py
+++ b/teamarr/dispatcharr/managers/m3u.py
@@ -169,6 +169,32 @@ class M3UManager:
             error=f"Failed to create group: {response.status_code}",
         )
 
+    def get_account_group_counts(self, account_id: int) -> dict[int, int]:
+        """Get per-group stream counts for a single M3U account.
+
+        Uses the account detail endpoint, whose ``channel_groups`` array holds
+        one relationship entry per group with Dispatcharr's tracked
+        ``stream_count`` — one request instead of listing streams per group.
+
+        Args:
+            account_id: M3U account ID
+
+        Returns:
+            Mapping of channel group ID -> stream count for this account
+        """
+        response = self._client.get(f"/api/m3u/accounts/{account_id}/")
+        if response is None or response.status_code != 200:
+            status = response.status_code if response else "No response"
+            logger.error("[M3U] Failed to fetch account %d detail: %s", account_id, status)
+            return {}
+
+        counts: dict[int, int] = {}
+        for rel in response.json().get("channel_groups") or []:
+            group_id = rel.get("channel_group")
+            if group_id is not None:
+                counts[group_id] = rel.get("stream_count") or 0
+        return counts
+
     def get_group_name(self, group_id: int) -> str | None:
         """Get exact group name by ID (needed for stream filtering).
 
@@ -218,18 +244,19 @@ class M3UManager:
                 )
                 return []
 
-        # Build query params
-        params = ["page=1", "page_size=1000"]
+        # Build query params — don't request more per page than the caller wants
+        page_size = min(limit, 1000) if limit else 1000
+        params = ["page=1", f"page_size={page_size}"]
         if group_name:
             params.append(f"channel_group_name={urllib.parse.quote(group_name)}")
         if account_id is not None:
             params.append(f"m3u_account={account_id}")
 
-        # Fetch all pages
+        # Fetch pages until exhausted or limit reached
         raw_streams: list[dict] = []
         url: str | None = f"/api/channels/streams/?{'&'.join(params)}"
 
-        while url:
+        while url and (limit is None or len(raw_streams) < limit):
             response = self._client.get(url)
             if response is None or response.status_code != 200:
                 status = response.status_code if response else "No response"


### PR DESCRIPTION
Fixes #265

- list_m3u_groups now reads per-group stream counts from the account detail endpoint (2 requests total) instead of listing streams for every channel group in Dispatcharr
- list_streams caps page_size at limit and stops paginating once the limit is reached