### PR TITLE
feat(leagues): add FIBA World Cup, Australian NBL, Olympic basketball

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 
 ## Features
 
-- **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 136 pre-configured leagues plus dynamically discovered soccer leagues.
+- **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 139 pre-configured leagues plus dynamically discovered soccer leagues.
 - **240 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
 - **Flexible matching** - Aliases, fuzzy matching, and configurable stream ordering to handle inconsistent IPTV naming
 - **Channel groups & profiles** - Use existing Dispatcharr groups/profiles or create them dynamically using variables and wildcards

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,7 +13,7 @@ Developer documentation covering Teamarr's architecture, data providers, databas
 
 | Section | Contents |
 |---------|----------|
-| [Supported Leagues](supported-leagues) | All 134 pre-configured leagues and ~250 discovered soccer leagues, organized by sport |
+| [Supported Leagues](supported-leagues) | All 139 pre-configured leagues and ~250 discovered soccer leagues, organized by sport |
 | [Providers](providers/) | Data provider system — ESPN, Squiggle, MLB Stats, HockeyTech, TheSportsDB, Supabase — priority chain, API details, rate limiting |
 | [Architecture](architecture/) | API layer, consumer layer, Dispatcharr integration, detection keywords, database, template engine, migrations |
 | [Frontend](frontend/) | React + TypeScript + Vite architecture, component library, state management |

--- a/docs/reference/providers/espn.md
+++ b/docs/reference/providers/espn.md
@@ -8,7 +8,7 @@ docs_version: "2.3.1"
 
 # ESPN Provider
 
-ESPN is the primary data provider (priority 0), serving 89 pre-configured leagues plus ~250 dynamically discovered soccer leagues. The API is free, public, and requires no authentication.
+ESPN is the primary data provider (priority 0), serving 90 pre-configured leagues plus ~250 dynamically discovered soccer leagues. The API is free, public, and requires no authentication.
 
 ## API Details
 
@@ -56,7 +56,7 @@ baseball/mlb
 | Sport | Leagues | Notes |
 |-------|---------|-------|
 | Football | NFL, NCAAF, UFL | |
-| Basketball | NBA, WNBA, G League, NCAAM, NCAAW | |
+| Basketball | NBA, WNBA, G League, NCAAM, NCAAW, NBL (Australia) | |
 | Hockey | NHL, NCAA M/W, Olympics M/W | |
 | Baseball | MLB | MiLB handled by MLB Stats provider |
 | Soccer | 44 pre-configured, ~250 discovered | Dot notation: `eng.1`, `ger.2` |

--- a/docs/reference/providers/tsdb.md
+++ b/docs/reference/providers/tsdb.md
@@ -43,6 +43,7 @@ These leagues have high event volume or unreliable free-tier data and require a 
 - IPL, BBL, SA20 (cricket)
 - Svenska Cupen and other regional soccer leagues (Canadian Premier League, Swedish Superettan / Division 1, Icelandic, Venezuelan, Gambian, Aruban, Northern Irish)
 - IMSA and WEC (motor racing). WEC's 62 events/season exceeds the free `eventsseason.php` 15-event cap; IMSA fits it but is gated premium too, so all TSDB racing is premium (no silent truncation if a schedule grows).
+- FIBA Basketball World Cup (M/W) — gated premium since qualifiers run in parallel across multiple confederations, which can exceed the free tier's 5-events/day/league cap during busy qualifying windows.
 
 The `tsdb_tier` column in `schema.sql` classifies each league as `free` or `premium`.
 

--- a/docs/reference/supported-leagues.md
+++ b/docs/reference/supported-leagues.md
@@ -7,7 +7,7 @@ docs_version: "2.3.1"
 
 # Supported Sports & Leagues
 
-Teamarr supports **136 pre-configured leagues** across 15 sports, plus **~250 dynamically discovered soccer leagues** from ESPN. Pre-configured leagues have full support (team import + event matching). Discovered leagues support event matching only.
+Teamarr supports **139 pre-configured leagues** across 15 sports, plus **~250 dynamically discovered soccer leagues** from ESPN. Pre-configured leagues have full support (team import + event matching). Discovered leagues support event matching only.
 
 ## Support Levels
 
@@ -63,6 +63,9 @@ TSDB leagues are classified by tier. Most work on the free tier. Leagues marked 
 | Women's National Basketball Association | `wnba` | ESPN |
 | NCAA Men's Basketball | `ncaam` | ESPN |
 | NCAA Women's Basketball | `ncaaw` | ESPN |
+| National Basketball League (Australia) | `nbl` | ESPN |
+| FIBA Basketball World Cup | `fiba` | TSDB |
+| FIBA Women's Basketball World Cup | `fiba-women` | TSDB |
 | Unrivaled | `unrivaled` | TSDB |
 
 ---

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -962,8 +962,13 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     ('wnba', 'espn', 'basketball/wnba', NULL, 'Women''s National Basketball Association', 'basketball', 'https://a.espncdn.com/i/teamlogos/leagues/500/wnba.png', NULL, 1, 'WNBA', 'wnba', 'team_vs_team', 'WNBA Basketball', NULL, NULL, NULL, 1),
     ('mens-college-basketball', 'espn', 'basketball/mens-college-basketball', NULL, 'NCAA Men''s Basketball', 'basketball', 'https://www.ncaa.com/modules/custom/casablanca_core/img/sportbanners/basketball.png', NULL, 1, 'NCAAM', 'ncaam', 'team_vs_team', 'College Basketball', NULL, NULL, NULL, 1),
     ('womens-college-basketball', 'espn', 'basketball/womens-college-basketball', NULL, 'NCAA Women''s Basketball', 'basketball', 'https://www.ncaa.com/modules/custom/casablanca_core/img/sportbanners/basketball.png', NULL, 1, 'NCAAW', 'ncaaw', 'team_vs_team', 'Women''s College Basketball', NULL, NULL, NULL, 1),
+    ('nbl', 'espn', 'basketball/nbl', NULL, 'National Basketball League (Australia)', 'basketball', 'https://a.espncdn.com/i/teamlogos/leagues/500/nbl.png', 'https://a.espncdn.com/i/teamlogos/leagues/500-dark/nbl.png', 1, 'NBL', 'nbl', 'team_vs_team', NULL, NULL, NULL, NULL, 1),
 
     -- Basketball (TSDB) - Leagues not on ESPN
+    -- FIBA World Cups: ESPN's basketball/fiba only tracks the World Cup final
+    -- event itself (dead between tournaments); TSDB tracks qualifiers year-round.
+    ('fiba', 'tsdb', '4549', 'FIBA Basketball World Cup', 'FIBA Basketball World Cup', 'basketball', 'https://r2.thesportsdb.com/images/media/league/badge/x45gjq1764423537.png', NULL, 1, 'FIBA', 'fiba', 'team_vs_team', NULL, NULL, NULL, 'premium', 1),
+    ('fiba-women', 'tsdb', '4891', 'FIBA Womens World Cup', 'FIBA Women''s Basketball World Cup', 'basketball', 'https://r2.thesportsdb.com/images/media/league/badge/tlkdaq1726930250.png', NULL, 1, 'FIBA W', 'fibaw', 'team_vs_team', NULL, NULL, NULL, 'premium', 1),
     ('unrivaled', 'tsdb', '5622', 'Unrivaled Basketball', 'Unrivaled', 'basketball', 'https://r2.thesportsdb.com/images/media/league/badge/71mier1746291561.png', NULL, 1, NULL, 'unrivaled', 'team_vs_team', 'Unrivaled Basketball', NULL, NULL, 'free', 1),
 
     -- Hockey (ESPN)


### PR DESCRIPTION
- Add Australian NBL via ESPN (basketball/nbl) — verified against live 2026-27 schedule data (real fixtures, e.g. Cairns Taipans @ Perth Wildcats)
- Add FIBA Basketball World Cup (M/W) via TSDB, premium tier — ESPN's basketball/fiba endpoint only tracks the tournament final and returns nothing between World Cups; TSDB tracks year-round qualifiers instead (confirmed live games today). Gated premium since parallel confederation qualifiers can exceed the free tier's 5-events/day/league cap.

Closes: #271 