### PR TITLE
fix(dispatcharr): stop unbounded list_streams calls in event group processor

### DIFF
--- a/teamarr/consumers/event_group_processor.py
+++ b/teamarr/consumers/event_group_processor.py
@@ -1268,8 +1268,15 @@ class EventGroupProcessor:
             if group.m3u_group_id:
                 streams = m3u_manager.list_streams(group_id=group.m3u_group_id)
             else:
-                # Fetch all streams if no group filter
-                streams = m3u_manager.list_streams()
+                # No M3U group configured — never fall back to listing Dispatcharr's
+                # entire stream catalog (tens of thousands of streams on large
+                # instances; the paginated fetch can tip over Dispatcharr's workers).
+                logger.warning(
+                    "[EVENT_EPG] Group '%s' has no m3u_group_id configured - "
+                    "skipping stream fetch",
+                    group.name,
+                )
+                return []
 
             # Convert to dicts for matcher (sorted by name for consistent order)
             stream_dicts = [
@@ -1348,11 +1355,13 @@ class EventGroupProcessor:
         except Exception as e:
             logger.warning("[CHANNEL_SOURCE] Failed to load managed/group ids: %s", e)
 
-        # Stream detail (name, account) keyed by id — listed once.
+        # Stream detail (name, account) keyed by id — fetched by-ids for just the
+        # curated streams instead of listing Dispatcharr's entire catalog.
         try:
-            detail_by_id = {s.id: s for s in client.m3u.list_streams()}
+            curated_ids = sorted(stream_channel_map.keys())
+            detail_by_id = {s.id: s for s in client.m3u.get_streams_by_ids(curated_ids)}
         except Exception as e:
-            logger.warning("[CHANNEL_SOURCE] Failed to list streams: %s", e)
+            logger.warning("[CHANNEL_SOURCE] Failed to fetch stream details: %s", e)
             detail_by_id = {}
 
         candidates: list[dict] = []

--- a/teamarr/dispatcharr/managers/m3u.py
+++ b/teamarr/dispatcharr/managers/m3u.py
@@ -311,6 +311,39 @@ class M3UManager:
 
         return streams
 
+    def get_streams_by_ids(self, stream_ids: list[int]) -> list[DispatcharrStream]:
+        """Fetch stream details for specific stream IDs.
+
+        Uses POST /api/channels/streams/by-ids/ in chunks of 1000 (matching
+        page_size, so each chunk fits one page). Far cheaper than list_streams()
+        when the caller already knows which streams it needs. Non-existent IDs
+        are silently omitted by Dispatcharr.
+
+        Args:
+            stream_ids: Dispatcharr stream IDs to fetch
+
+        Returns:
+            List of DispatcharrStream objects (empty on API failure)
+        """
+        streams: list[DispatcharrStream] = []
+        for i in range(0, len(stream_ids), 1000):
+            chunk = stream_ids[i : i + 1000]
+            response = self._client.post(
+                "/api/channels/streams/by-ids/?page_size=1000",
+                {"ids": chunk},
+            )
+            if response is None or response.status_code != 200:
+                status = response.status_code if response else "No response"
+                logger.error("[M3U] Failed to fetch %d streams by ids: %s", len(chunk), status)
+                return []
+            data = response.json()
+            results = data.get("results", data) if isinstance(data, dict) else data
+            for raw in results:
+                if "name" in raw:
+                    raw["name"] = _fix_double_encoded_utf8(raw["name"])
+                streams.append(DispatcharrStream.from_api(raw))
+        return streams
+
     def get_group_with_streams(
         self,
         group_id: int,

--- a/tests/test_channel_source.py
+++ b/tests/test_channel_source.py
@@ -41,7 +41,9 @@ def _make_processor(stream_channel_map, epg_data_list, streams, managed, epg_gro
             get_stream_channel_map=lambda: stream_channel_map,
             get_epg_data_list=lambda: epg_data_list,
         ),
-        m3u=SimpleNamespace(list_streams=lambda: streams),
+        m3u=SimpleNamespace(
+            get_streams_by_ids=lambda ids: [s for s in streams if s.id in set(ids)]
+        ),
     )
 
     proc = object.__new__(EventGroupProcessor)

--- a/tests/test_m3u_streams_by_ids.py
+++ b/tests/test_m3u_streams_by_ids.py
@@ -1,0 +1,93 @@
+"""Tests for M3UManager.get_streams_by_ids and the no-group stream-fetch guard.
+
+get_streams_by_ids fetches stream details via POST /api/channels/streams/by-ids/
+in chunks of 1000 so the caller never pulls Dispatcharr's entire stream catalog.
+EventGroupProcessor._fetch_streams must refuse (not list everything) when a
+group has no m3u_group_id — the unbounded fallback could tip over Dispatcharr's
+workers on large instances (35k+ streams).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from teamarr.consumers.event_group_processor import EventGroupProcessor
+from teamarr.dispatcharr.managers.m3u import M3UManager
+
+
+@pytest.fixture
+def manager():
+    return M3UManager(MagicMock())
+
+
+def _resp(status_code, payload=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    return r
+
+
+def test_empty_ids_makes_no_requests(manager):
+    assert manager.get_streams_by_ids([]) == []
+    manager._client.post.assert_not_called()
+
+
+def test_single_chunk_maps_streams(manager):
+    payload = {
+        "results": [
+            {"id": 1, "name": "ESPN HD", "channel_group_id": 42, "m3u_account": 7},
+            {"id": 2, "name": "FS1", "is_stale": True},
+        ]
+    }
+    manager._client.post = MagicMock(return_value=_resp(200, payload))
+
+    streams = manager.get_streams_by_ids([1, 2])
+
+    assert [s.id for s in streams] == [1, 2]
+    assert streams[0].channel_group_id == 42
+    assert streams[0].m3u_account_id == 7
+    assert streams[1].is_stale is True
+    endpoint, body = manager._client.post.call_args[0]
+    assert "streams/by-ids/" in endpoint
+    assert body == {"ids": [1, 2]}
+
+
+def test_ids_are_chunked_at_1000(manager):
+    ids = list(range(2500))
+    manager._client.post = MagicMock(return_value=_resp(200, {"results": []}))
+
+    manager.get_streams_by_ids(ids)
+
+    assert manager._client.post.call_count == 3
+    chunks = [call.args[1]["ids"] for call in manager._client.post.call_args_list]
+    assert [len(c) for c in chunks] == [1000, 1000, 500]
+    assert [i for chunk in chunks for i in chunk] == ids
+
+
+def test_api_failure_returns_empty(manager):
+    manager._client.post = MagicMock(return_value=_resp(500))
+    assert manager.get_streams_by_ids([1]) == []
+
+    manager._client.post = MagicMock(return_value=None)
+    assert manager.get_streams_by_ids([1]) == []
+
+
+def test_double_encoded_names_are_fixed(manager):
+    payload = {"results": [{"id": 1, "name": "EspaÃ±a TV"}]}
+    manager._client.post = MagicMock(return_value=_resp(200, payload))
+
+    streams = manager.get_streams_by_ids([1])
+
+    assert streams[0].name == "España TV"
+
+
+def test_fetch_streams_without_group_skips_instead_of_listing_all():
+    proc = object.__new__(EventGroupProcessor)
+    m3u = MagicMock()
+    proc._dispatcharr_client = SimpleNamespace(m3u=m3u)
+
+    group = SimpleNamespace(name="No Group", m3u_group_id=None, is_channel_source=False)
+
+    assert proc._fetch_streams(group) == []
+    m3u.list_streams.assert_not_called()


### PR DESCRIPTION
Two call sites fetched Dispatcharr's entire stream catalog (35k+ streams = ~36 sequential page-1000 requests), colliding with Dispatcharr's own M3U refresh and crashing its uwsgi workers:

- _fetch_channel_source_streams: swap full list_streams() for a new M3UManager.get_streams_by_ids (POST /api/channels/streams/by-ids/, chunked at 1000) scoped to just the curated stream IDs
- _fetch_streams: warn and skip instead of listing all streams when a group has no m3u_group_id