### PR TITLE
Align issue templates with the type:/status: label scheme + richer bug/league fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,38 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: dispatcharr_version
+    attributes:
+      label: Dispatcharr version
+      description: "Dispatcharr version Teamarr is connected to (e.g., 0.24.0). Several features are gated on the Dispatcharr version."
+      placeholder: "e.g., 0.24.0"
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: "Only if the bug is in the UI. Include the version if you can."
+      placeholder: "e.g., Firefox 128, Chrome 126, Safari 17"
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Teamarr is this about?
+      options:
+        - Not sure
+        - Generation / EPG output
+        - Matching
+        - Sources
+        - Dispatcharr sync
+        - Templates
+        - Settings
+        - Frontend / UI
+        - Other
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["type: bug", "status: needs-triage"]
 body:
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,7 +1,7 @@
 name: Enhancement
 description: Improve an existing feature
 title: "[Enhancement]: "
-labels: ["enhancement"]
+labels: ["type: enhancement", "status: needs-triage"]
 body:
   - type: textarea
     id: current

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -27,6 +27,22 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Teamarr is this about?
+      options:
+        - Not sure
+        - Generation / EPG output
+        - Matching
+        - Sources
+        - Dispatcharr sync
+        - Templates
+        - Settings
+        - Frontend / UI
+        - Other
+
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature
 title: "[Feature]: "
-labels: ["feature-request"]
+labels: ["type: feature", "status: needs-triage"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,6 +25,22 @@ body:
       label: Alternatives considered
       placeholder: Other approaches you've thought about
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Teamarr is this about?
+      options:
+        - Not sure
+        - Generation / EPG output
+        - Matching
+        - Sources
+        - Dispatcharr sync
+        - Templates
+        - Settings
+        - Frontend / UI
+        - Other
+
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/league_request.yml
+++ b/.github/ISSUE_TEMPLATE/league_request.yml
@@ -1,7 +1,7 @@
 name: "League/Sport Request"
 description: "Request support for a new league or sport"
 title: "[League Request]: "
-labels: ["new-league"]
+labels: ["type: league", "status: needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/league_request.yml
+++ b/.github/ISSUE_TEMPLATE/league_request.yml
@@ -1,7 +1,7 @@
 name: "League/Sport Request"
 description: "Request support for a new league or sport"
 title: "[League Request]: "
-labels: ["type: league", "status: needs-triage"]
+labels: ["type: league", "status: needs-triage", "research"]
 body:
   - type: markdown
     attributes:
@@ -63,9 +63,14 @@ body:
     id: data_sources
     attributes:
       label: Data Sources
-      description: Links to where schedule/score data can be found (ESPN, official site, etc.)
+      description: >
+        Links to where schedule/score data can be found. ESPN is where most leagues get
+        implemented, so an ESPN API URL for this league is the most useful thing you can provide
+        (find your sport/league at site.api.espn.com — see the placeholder). Official sites help too.
       placeholder: |
-        - ESPN: https://www.espn.com/...
+        - ESPN API: https://site.api.espn.com/apis/site/v2/sports/<sport>/<league>/scoreboard
+        - ESPN web: https://www.espn.com/...
+        - TheSportsDB (TSDB): https://www.thesportsdb.com/league/...
         - Official site: https://...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,47 @@
+name: Task / Chore
+description: Internal engineering work — refactor, chore, tech-debt, or docs (maintainers)
+title: "[Task]: "
+labels: ["status: needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For internal work that isn't a user-facing bug or feature. Under the issue-first
+        workflow, this becomes the tracking issue for a bead + branch. Add the matching
+        `type:` label (`refactor`, `chore`, or `docs`) after filing.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of work
+      options:
+        - Refactor (restructure without changing behavior)
+        - Chore (build, deps, CI, tooling, cleanup)
+        - Docs (documentation only)
+        - Tech debt / cleanup
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs to happen?
+      placeholder: Describe the work and why it's worth doing now.
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Affected area
+      description: Which subsystem(s)? e.g. templates, epg-matching, sync, settings, frontend, ci/release
+      placeholder: "e.g. epg-matching"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done?
+      placeholder: |
+        - [ ]
+        - [ ]


### PR DESCRIPTION
Updates the GitHub issue templates so their default labels match the repo's namespaced label scheme (type: * / status: *), adds a maintainer Task / Chore template, and collects a few more high-signal fields on the bug and league-request forms.
