### PR TITLE
fix(types): guard get_group() Optional returns — Pyright 532→388 (#292)

### DIFF
--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -770,6 +770,11 @@ def create_group(request: GroupCreate):
         )
 
         group = get_group(conn, group_id)
+        if group is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Group {group_id} could not be loaded after creation",
+            )
 
     logger.info("[CREATED] Event group id=%d name=%s", group_id, request.name)
 
@@ -1376,6 +1381,11 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
             delete_group_xmltv(conn, group_id)
 
         group = get_group(conn, group_id)
+        if group is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Group {group_id} could not be loaded after update",
+            )
         channel_count = get_group_channel_count(conn, group_id)
 
     logger.info("[UPDATED] Event group id=%d", group_id)


### PR DESCRIPTION
Bead \`teamarrv2-9y67.1\` (epic \`9y67\`, #292). **Tranche 1** of the advisory-Pyright burndown.

## What
`groups.py` held **144 of 532** Pyright errors (27%) — all `reportOptionalMemberAccess`. Root cause: two response-builder handlers (create + update) re-fetch through `get_group() → EventEPGGroup | None` and then read ~70 fields each without a None-guard. The other 11 `get_group` sites in the file already guard.

Added a guard after each of the two un-guarded re-fetches:
```python
group = get_group(conn, group_id)
if group is None:
    raise HTTPException(status_code=500, detail=f"Group {group_id} could not be loaded after …")
```
**Behavior-preserving**: if `group` were ever `None`, the field access already raised `AttributeError` → HTTP 500; this just makes it a clean 500 and narrows the type for Pyright.

## Result
- Pyright: **532 → 388** (`groups.py` 144 → 0)
- Tests **1379 pass**, ruff clean

## Not in this PR (tracked on the bead for later tranches)
- lifecycle creator/syncer/cleanup (103) — behavior-sensitive, careful pass
- keywords/presets (36) — also need a `Keyword`/`Preset` `id: int | None` model-level fix, not just guards
- odds.py (20, template-var-safe), matching/subscription/sports_data/team_epg/matcher

Advisory check, so non-blocking — this shrinks the red incrementally.