### PR TITLE
fix(types): Pyright burndown 388→0 — backend now type-clean (#292)

### DIFF
--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -9,7 +9,7 @@ Provides REST API for:
 
 import logging
 from datetime import date, datetime, timezone
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -396,7 +396,7 @@ def get_managed_channel_streams(channel_id: int):
                 matched_event=channel_event,
                 matched_league=channel.league,
                 cache_match_method=(d := match_details.get(
-                    (s.source_group_id, s.dispatcharr_stream_id), {}
+                    cast("tuple[int, int]", (s.source_group_id, s.dispatcharr_stream_id)), {}
                 )).get("match_method"),
                 cache_created_at=(
                     _safe_isoformat(d.get("created_at"))

--- a/teamarr/api/routes/dispatcharr.py
+++ b/teamarr/api/routes/dispatcharr.py
@@ -150,6 +150,7 @@ def create_channel_group(name: str) -> dict:
         raise HTTPException(status_code=400, detail=result.error)
 
     logger.info("[CREATED] Channel group in Dispatcharr name=%s", name)
+    assert result.data is not None  # success guaranteed non-None data above
     return result.data
 
 
@@ -194,6 +195,7 @@ def create_channel_profile(name: str) -> dict:
         raise HTTPException(status_code=400, detail=result.error)
 
     logger.info("[CREATED] Channel profile in Dispatcharr name=%s", name)
+    assert result.data is not None  # success guaranteed non-None data above
     return result.data
 
 

--- a/teamarr/api/routes/keywords.py
+++ b/teamarr/api/routes/keywords.py
@@ -100,8 +100,10 @@ def list_keywords(
     with get_db() as conn:
         keywords = get_all_keywords(conn, include_disabled=include_disabled)
 
-    return ExceptionKeywordListResponse(
-        keywords=[
+    responses = []
+    for kw in keywords:
+        assert kw.id is not None  # persisted rows always have an id
+        responses.append(
             ExceptionKeywordResponse(
                 id=kw.id,
                 label=kw.label,
@@ -111,8 +113,10 @@ def list_keywords(
                 enabled=kw.enabled,
                 created_at=kw.created_at.isoformat() if kw.created_at else None,
             )
-            for kw in keywords
-        ],
+        )
+
+    return ExceptionKeywordListResponse(
+        keywords=responses,
         total=len(keywords),
     )
 
@@ -130,6 +134,7 @@ def get_keyword(keyword_id: int):
             detail=f"Keyword {keyword_id} not found",
         )
 
+    assert keyword.id is not None  # persisted rows always have an id
     return ExceptionKeywordResponse(
         id=keyword.id,
         label=keyword.label,
@@ -163,6 +168,13 @@ def create_keyword(request: ExceptionKeywordCreate):
             detail=f"Label '{request.label}' already exists",
         ) from e
 
+    if keyword is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Keyword could not be retrieved after creation",
+        )
+
+    assert keyword.id is not None  # persisted rows always have an id
     return ExceptionKeywordResponse(
         id=keyword.id,
         label=keyword.label,
@@ -204,6 +216,13 @@ def update_keyword(keyword_id: int, request: ExceptionKeywordUpdate):
             detail=f"Label '{request.label}' already exists",
         ) from e
 
+    if keyword is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Keyword could not be retrieved after update",
+        )
+
+    assert keyword.id is not None  # persisted rows always have an id
     return ExceptionKeywordResponse(
         id=keyword.id,
         label=keyword.label,

--- a/teamarr/api/routes/leagues.py
+++ b/teamarr/api/routes/leagues.py
@@ -11,6 +11,7 @@ reject any non-TSDB provider; edits and deletes only ever touch user-added
 """
 
 import logging
+from typing import NoReturn
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
@@ -85,7 +86,7 @@ class CustomLeagueTestFetch(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _raise_http(exc: Exception) -> None:
+def _raise_http(exc: Exception) -> NoReturn:
     """Translate a custom-league service exception into an HTTPException."""
     if isinstance(exc, CustomLeagueGateError):
         raise HTTPException(status_code=403, detail=str(exc)) from exc

--- a/teamarr/api/routes/presets.py
+++ b/teamarr/api/routes/presets.py
@@ -80,8 +80,10 @@ def list_presets():
     with get_db() as conn:
         presets = get_all_presets(conn)
 
-    return ConditionPresetListResponse(
-        presets=[
+    responses = []
+    for p in presets:
+        assert p.id is not None  # persisted rows always have an id
+        responses.append(
             ConditionPresetResponse(
                 id=p.id,
                 name=p.name,
@@ -89,8 +91,10 @@ def list_presets():
                 conditions=p.conditions,
                 created_at=p.created_at.isoformat() if p.created_at else None,
             )
-            for p in presets
-        ],
+        )
+
+    return ConditionPresetListResponse(
+        presets=responses,
         total=len(presets),
     )
 
@@ -108,6 +112,7 @@ def get_preset(preset_id: int):
             detail=f"Preset {preset_id} not found",
         )
 
+    assert preset.id is not None  # persisted rows always have an id
     return ConditionPresetResponse(
         id=preset.id,
         name=preset.name,
@@ -138,6 +143,13 @@ def create_preset(request: ConditionPresetCreate):
         )
         preset = db_get_preset(conn, preset_id)
 
+    if preset is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Preset could not be retrieved after creation",
+        )
+
+    assert preset.id is not None  # persisted rows always have an id
     return ConditionPresetResponse(
         id=preset.id,
         name=preset.name,
@@ -178,6 +190,13 @@ def update_preset(preset_id: int, request: ConditionPresetUpdate):
         )
         preset = db_get_preset(conn, preset_id)
 
+    if preset is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Preset could not be retrieved after update",
+        )
+
+    assert preset.id is not None  # persisted rows always have an id
     return ConditionPresetResponse(
         id=preset.id,
         name=preset.name,

--- a/teamarr/api/routes/settings/dispatcharr.py
+++ b/teamarr/api/routes/settings/dispatcharr.py
@@ -126,7 +126,7 @@ def get_dispatcharr_status() -> dict:
         # Actually test the connection to verify it works
         result = factory.test_connection()
 
-        response = {
+        response: dict[str, object] = {
             "configured": True,
             "connected": result.success,
         }

--- a/teamarr/api/routes/stats.py
+++ b/teamarr/api/routes/stats.py
@@ -9,13 +9,20 @@ Provides centralized access to all processing statistics:
 
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from typing import cast
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Query
 
 from teamarr.database import get_db
 from teamarr.database.settings import get_all_settings
-from teamarr.database.stats import get_current_stats, get_live_xmltv_content, get_recent_runs
+from teamarr.database.stats import (
+    RunStatus,
+    RunType,
+    get_current_stats,
+    get_live_xmltv_content,
+    get_recent_runs,
+)
 
 router = APIRouter()
 
@@ -246,9 +253,9 @@ def get_runs(
         runs = get_recent_runs(
             conn,
             limit=limit,
-            run_type=run_type,
+            run_type=cast("RunType | None", run_type),
             group_id=group_id,
-            status=status,
+            status=cast("RunStatus | None", status),
         )
         return {
             "runs": [run.to_dict() for run in runs],

--- a/teamarr/api/routes/subscription.py
+++ b/teamarr/api/routes/subscription.py
@@ -4,7 +4,7 @@ Global sports/league subscription and template assignment management.
 """
 
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from teamarr.database import get_db
 from teamarr.database.subscription import (
@@ -72,8 +72,8 @@ class TemplateAssignmentUpdate(BaseModel):
     """Update subscription template assignment."""
 
     template_id: int | None = None
-    sports: list[str] | None = ...
-    leagues: list[str] | None = ...
+    sports: list[str] | None = Field(...)
+    leagues: list[str] | None = Field(...)
 
 
 class TemplateAssignmentListResponse(BaseModel):
@@ -205,6 +205,12 @@ def create_subscription_template(request: TemplateAssignmentCreate):
         )
         template = get_subscription_template(conn, assignment_id)
 
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Template assignment could not be retrieved after creation",
+        )
+
     return TemplateAssignmentResponse(
         id=template.id,
         template_id=template.template_id,
@@ -241,6 +247,12 @@ def update_subscription_template_endpoint(
 
         update_subscription_template(conn, assignment_id, **kwargs)
         template = get_subscription_template(conn, assignment_id)
+
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Template assignment could not be retrieved after update",
+        )
 
     return TemplateAssignmentResponse(
         id=template.id,

--- a/teamarr/consumers/event_epg.py
+++ b/teamarr/consumers/event_epg.py
@@ -15,6 +15,7 @@ Data flow:
 import logging
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from typing import overload
 
 from teamarr.core import Event, Programme
 from teamarr.database.templates import EventTemplateConfig
@@ -65,6 +66,14 @@ def is_event_postponed(event: Event) -> bool:
     if not event.status:
         return False
     return event.status.state.lower() == "postponed"
+
+
+@overload
+def prepend_postponed_label(text: str, event: Event, enabled: bool) -> str: ...
+
+
+@overload
+def prepend_postponed_label(text: None, event: Event, enabled: bool) -> None: ...
 
 
 def prepend_postponed_label(text: str | None, event: Event, enabled: bool) -> str | None:

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -7,6 +7,7 @@ resolution and UFC/racing segment expansion of the matched-stream list.
 import logging
 from collections.abc import Callable
 from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any
 
 from teamarr.consumers.matching import BatchMatchResult, StreamCategory, StreamMatcher
 from teamarr.database.groups import EventEPGGroup
@@ -23,6 +24,16 @@ class StreamMatching:
     ``_db_factory``, ``_dispatcharr_client``, ``_service``,
     ``_shared_events`` and ``_generation`` attributes.
     """
+
+    if TYPE_CHECKING:
+        # Provided by the EventGroupProcessor coordinator / sibling mixins.
+        # Declared for type-checkers only — no runtime effect.
+        _db_factory: Any
+        _dispatcharr_client: Any
+        _service: Any
+        _shared_events: Any
+        _get_all_known_leagues: Any
+        _load_sport_durations: Any
 
     def _match_streams(
         self,
@@ -273,7 +284,7 @@ class StreamMatching:
         except Exception as e:
             logger.debug("[XTREAM-EPG] group=%s account fetch failed: %s", group.id, e)
             return
-        if not is_xtream_account(account):
+        if account is None or not is_xtream_account(account):
             return
 
         already = set(index.tvg_ids())
@@ -281,8 +292,13 @@ class StreamMatching:
         if not wanted:
             return
 
+        url = xmltv_url(account)
+        if url is None:
+            # Unreachable in practice — account already passed is_xtream_account,
+            # which is xmltv_url's own precondition. Guard keeps the type sound.
+            return
         programs = fetch_xtream_programs(
-            xmltv_url(account),
+            url,
             cache_key=f"acct{account_id}",
             wanted_tvg_ids=wanted,
             window_start=window_start,

--- a/teamarr/consumers/event_group_processor/preview.py
+++ b/teamarr/consumers/event_group_processor/preview.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import date
+from typing import TYPE_CHECKING, Any
 
 from teamarr.database.groups import get_group
 from teamarr.utilities.sorting import natural_sort_key
@@ -16,6 +17,15 @@ class PreviewBuilder:
 
     Mixin for EventGroupProcessor.
     """
+
+    if TYPE_CHECKING:
+        # Provided by the EventGroupProcessor coordinator / sibling mixins.
+        # Declared for type-checkers only — no runtime effect.
+        _db_factory: Any
+        _dispatcharr_client: Any
+        _filter_streams: Any
+        _get_subscription_leagues: Any
+        _match_streams: Any
 
     def preview_group(
         self,

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -191,7 +191,7 @@ class EventGroupProcessor(
         has_override = (
             group is not None and group.subscription_leagues is not None
         )
-        cache_key = group.id if has_override else 0
+        cache_key = group.id if group is not None and has_override else 0
 
         if cache_key not in self._subscription_leagues_cache:
             self._subscription_leagues_cache[cache_key] = (
@@ -602,6 +602,8 @@ class EventGroupProcessor(
 
         # Create stats run for tracking
         stats_run = create_run(conn, run_type="event_group", group_id=group.id)
+        # create_run always returns a ProcessingRun with its DB id populated.
+        assert stats_run.id is not None
 
         try:
             # Clear any previously stored XMLTV for this group so that if
@@ -742,17 +744,17 @@ class EventGroupProcessor(
 
             # Build event lookup BEFORE team filtering (for cleanup of existing channels)
             # Use segment-aware event_id to match channel.event_id storage
-            def _effective_event_id(m):
+            def _effective_event_id(m) -> str | None:
                 event = m.get("event")
                 if not event or not hasattr(event, "id"):
                     return None
                 segment = m.get("segment")
                 return f"{event.id}-{segment}" if segment else event.id
 
-            all_matched_events = {
-                _effective_event_id(m): m.get("event")
+            all_matched_events: dict[str, Event] = {
+                eid: ev
                 for m in matched_streams
-                if _effective_event_id(m)
+                if (eid := _effective_event_id(m)) and (ev := m.get("event"))
             }
 
             # Apply team include/exclude filtering
@@ -763,7 +765,7 @@ class EventGroupProcessor(
 
             # Build set of event IDs that passed the filter (segment-aware)
             passed_event_ids = {
-                _effective_event_id(m) for m in matched_streams if _effective_event_id(m)
+                eid for m in matched_streams if (eid := _effective_event_id(m))
             }
 
             # Cleanup existing channels that no longer pass team filter
@@ -776,7 +778,7 @@ class EventGroupProcessor(
                 logger.info("[EVENT_EPG] Cleaned up %d channels due to team filter", cleanup_count)
 
             # Build stream dict for cleanup (fingerprint-based content change detection)
-            current_streams = {s.get("id"): s for s in streams if s.get("id")}
+            current_streams = {sid: s for s in streams if (sid := s.get("id"))}
 
             if matched_streams:
                 if status_callback:
@@ -926,7 +928,9 @@ class EventGroupProcessor(
 
         # Load template from database if configured
         # Resolve template from global subscription
-        template_config = None
+        # Typed Any: _load_event_template yields an EventTemplateConfig, which the
+        # lifecycle creator accepts even though its param is annotated ``dict | None``.
+        template_config: Any = None
         template_id = get_subscription_template_for_event(conn, "", "")
         if template_id:
             template_config = self._load_event_template(conn, template_id)

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -4,6 +4,7 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, timedelta
+from typing import TYPE_CHECKING, Any
 
 from teamarr.core import Event
 from teamarr.database.groups import EventEPGGroup
@@ -22,6 +23,14 @@ class StreamFetcher:
     Mixin for EventGroupProcessor — relies on the coordinator's
     ``_db_factory``, ``_dispatcharr_client`` and ``_service`` attributes.
     """
+
+    if TYPE_CHECKING:
+        # Provided by the EventGroupProcessor coordinator / sibling mixins.
+        # Declared for type-checkers only — no runtime effect.
+        _db_factory: Any
+        _dispatcharr_client: Any
+        _service: Any
+        _active_epg_source_ids: Any
 
     def _fetch_streams(self, group: EventEPGGroup) -> list[dict]:
         """Fetch M3U streams from Dispatcharr for the group.

--- a/teamarr/consumers/event_group_processor/team_filter.py
+++ b/teamarr/consumers/event_group_processor/team_filter.py
@@ -2,6 +2,7 @@
 
 import logging
 from sqlite3 import Connection
+from typing import TYPE_CHECKING, Any
 
 from teamarr.consumers.channel_lifecycle import create_lifecycle_service
 from teamarr.core import SEASON_POSTSEASON, Event
@@ -16,6 +17,13 @@ class TeamFiltering:
     Mixin for EventGroupProcessor — relies on the coordinator's
     ``_db_factory``, ``_dispatcharr_client`` and ``_service`` attributes.
     """
+
+    if TYPE_CHECKING:
+        # Provided by the EventGroupProcessor coordinator / sibling mixins.
+        # Declared for type-checkers only — no runtime effect.
+        _db_factory: Any
+        _dispatcharr_client: Any
+        _service: Any
 
     def _filter_by_teams(
         self,
@@ -48,6 +56,9 @@ class TeamFiltering:
             return matched_streams, 0
 
         filter_list = include_teams if include_teams else exclude_teams
+        # The empty-filter guard above guarantees one of the two lists is truthy,
+        # so filter_list is always a non-None list here.
+        assert filter_list is not None
         filtered = []
         filtered_count = 0
         playoff_bypass_count = 0

--- a/teamarr/consumers/event_group_processor/xmltv.py
+++ b/teamarr/consumers/event_group_processor/xmltv.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import asdict
 from datetime import datetime, timedelta
 from sqlite3 import Connection
+from typing import TYPE_CHECKING, Any
 
 from teamarr.config import get_user_timezone
 from teamarr.consumers.event_epg import EventEPGOptions
@@ -30,6 +31,13 @@ class XmltvRenderer:
     Mixin for EventGroupProcessor — relies on the coordinator's
     ``_service``, ``_epg_generator`` and ``_art_base_url`` attributes.
     """
+
+    if TYPE_CHECKING:
+        # Provided by the EventGroupProcessor coordinator / sibling mixins.
+        # Declared for type-checkers only — no runtime effect.
+        _service: Any
+        _epg_generator: Any
+        _art_base_url: Any
 
     def _load_event_template(self, conn: Connection, template_id: int):
         """Load and convert template for event-based EPG.
@@ -259,7 +267,7 @@ class XmltvRenderer:
     def _generate_filler_for_streams(
         self,
         matched_streams: list[dict],
-        filler_config: EventFillerConfig,
+        filler_config: EventFillerConfig | None,
         sport_durations: dict[str, float],
         lookback_hours: int = 6,
         prepend_postponed_label: bool = True,

--- a/teamarr/consumers/lifecycle/_host.py
+++ b/teamarr/consumers/lifecycle/_host.py
@@ -1,0 +1,57 @@
+"""Type-only host surface for the lifecycle mixins.
+
+``ChannelLifecycleService`` (service.py) is composed from four mixins —
+``ChannelCreator``, ``ChannelNaming``, ``ChannelSyncer`` and ``ChannelCleanup``.
+Each mixin freely calls ``self._<x>`` for attributes and methods that the
+*composed host* actually defines (on ``ChannelLifecycleService`` or on a
+sibling mixin). In isolation Pyright cannot see those cross-mixin members and
+reports ``reportAttributeAccessIssue``.
+
+``_LifecycleHost`` declares that borrowed surface for the type checker only.
+It is **runtime-empty**: every member lives under ``if TYPE_CHECKING`` so the
+class body is empty at import time. Each mixin inherits it, which lets Pyright
+resolve the borrowed ``self._x`` access; at runtime the real definitions on the
+most-derived ``ChannelLifecycleService`` win in MRO.
+
+Do NOT add ``_LifecycleHost`` to ``ChannelLifecycleService``'s bases — the mixins
+already carry it, and the host provides the concrete implementations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+class _LifecycleHost:
+    """Runtime-empty declaration of the host surface borrowed by the mixins."""
+
+    if TYPE_CHECKING:
+        # --- data attributes (real types where clear, else Any) ---
+        _db_factory: Any
+        _sports_service: Any
+        _channel_manager: Any
+        _logo_manager: Any
+        _epg_manager: Any
+        _timing_manager: Any
+        _dynamic_resolver: Any
+        _dispatcharr_lock: Any
+        _resolver: Any
+        _context_builder: Any
+        _external_occupied: set[int] | None
+        _league_configs: Any
+        _timezone: str
+        _exception_keywords: list | None
+        _pending_profile_changes: dict[int, dict[str, set[int]]]
+        _dispatcharr_failure_count: int
+        _stream_drift_fix_count: int
+
+        # --- borrowed methods (permissive signatures) ---
+        def _safe_update_channel(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _sync_channel_settings(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _resolve_logo_url(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _generate_channel_name(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _collect_profile_change(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _apply_pending_profile_changes(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _resolve_event_template(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _parse_profile_ids(self, *args: Any, **kwargs: Any) -> Any: ...
+        def _check_exception_keyword(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/teamarr/consumers/lifecycle/cleanup.py
+++ b/teamarr/consumers/lifecycle/cleanup.py
@@ -11,12 +11,13 @@ from teamarr.utilities.sports import get_sport_duration
 from teamarr.utilities.time_blocks import crosses_midnight
 from teamarr.utilities.tz import to_user_tz
 
+from ._host import _LifecycleHost
 from .types import StreamProcessResult
 
 logger = logging.getLogger(__name__)
 
 
-class ChannelCleanup:
+class ChannelCleanup(_LifecycleHost):
     """Deletes expired/stale channels and detaches dead streams.
 
     Mixin for ChannelLifecycleService — relies on the coordinator's managers,
@@ -483,10 +484,11 @@ class ChannelCleanup:
                             stream_id = getattr(s, "dispatcharr_stream_id", None)
                             if stream_id:
                                 remove_stream_from_channel(conn, channel.id, stream_id)
-                                self._remove_stream_from_dispatcharr_channel(
-                                    channel.dispatcharr_channel_id,
-                                    stream_id,
-                                )
+                                if channel.dispatcharr_channel_id:
+                                    self._remove_stream_from_dispatcharr_channel(
+                                        channel.dispatcharr_channel_id,
+                                        stream_id,
+                                    )
                                 log_channel_history(
                                     conn=conn,
                                     managed_channel_id=channel.id,
@@ -501,10 +503,11 @@ class ChannelCleanup:
                             reason = changed.get("reason", "content_changed")
                             if stream_id:
                                 remove_stream_from_channel(conn, channel.id, stream_id)
-                                self._remove_stream_from_dispatcharr_channel(
-                                    channel.dispatcharr_channel_id,
-                                    stream_id,
-                                )
+                                if channel.dispatcharr_channel_id:
+                                    self._remove_stream_from_dispatcharr_channel(
+                                        channel.dispatcharr_channel_id,
+                                        stream_id,
+                                    )
                                 if reason == "event_rotated":
                                     notes = f"Stream {stream_id} rotated to different event"
                                 else:

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from teamarr.core import Event
 
+from ._host import _LifecycleHost
 from .timing import compute_stream_window, is_stream_in_window
 from .types import (
     ChannelCreationResult,
@@ -23,7 +24,7 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-class ChannelCreator:
+class ChannelCreator(_LifecycleHost):
     """Creates channels from matched streams and handles duplicate modes.
 
     Mixin for ChannelLifecycleService — relies on the coordinator's managers,
@@ -354,7 +355,9 @@ class ChannelCreator:
                                 }
                             )
 
-                            # Log history
+                            # Log history — a successful create always yields a
+                            # local managed-channel id (invariant of _create_channel).
+                            assert channel_result.channel_id is not None
                             log_channel_history(
                                 conn=conn,
                                 managed_channel_id=channel_result.channel_id,
@@ -377,7 +380,7 @@ class ChannelCreator:
 
                     except Exception as stream_err:
                         event_id = matched.get("event")
-                        if hasattr(event_id, "id"):
+                        if event_id is not None and hasattr(event_id, "id"):
                             event_id = event_id.id
                         stream_name = matched.get("stream", {}).get("name", "Unknown")
                         logger.error(
@@ -461,6 +464,8 @@ class ChannelCreator:
         result = StreamProcessResult()
         stream_name = stream.get("name", "")
         stream_id = stream.get("id")
+        # A matched Dispatcharr stream always carries an integer id.
+        assert stream_id is not None
         disp_channel = None  # Dispatcharr's view of this channel (for phantom detection)
 
         # Verify channel exists in Dispatcharr.
@@ -727,6 +732,8 @@ class ChannelCreator:
         event_provider = getattr(event, "provider", "espn")
         stream_name = stream.get("name", "")
         stream_id = stream.get("id")
+        # A matched Dispatcharr stream always carries an integer id.
+        assert stream_id is not None
         group_id = group_config.get("id")
 
         # For segments, use segment-aware event_id for DB storage

--- a/teamarr/consumers/lifecycle/naming.py
+++ b/teamarr/consumers/lifecycle/naming.py
@@ -12,6 +12,8 @@ from teamarr.consumers.event_epg import POSTPONED_LABEL, is_event_postponed
 from teamarr.core import Event
 from teamarr.utilities.art_url import apply_art_base_url
 
+from ._host import _LifecycleHost
+
 logger = logging.getLogger(__name__)
 
 # Template variables that, when present in a channel-name template, mean the
@@ -30,7 +32,7 @@ FEED_TEMPLATE_VARS = frozenset({
 })
 
 
-class ChannelNaming:
+class ChannelNaming(_LifecycleHost):
     """Resolves channel names, logo URLs and template strings.
 
     Mixin for ChannelLifecycleService — relies on the coordinator's

--- a/teamarr/consumers/lifecycle/syncer.py
+++ b/teamarr/consumers/lifecycle/syncer.py
@@ -13,12 +13,13 @@ from typing import Any
 
 from teamarr.core import Event
 
+from ._host import _LifecycleHost
 from .types import StreamProcessResult, generate_event_tvg_id
 
 logger = logging.getLogger(__name__)
 
 
-class ChannelSyncer:
+class ChannelSyncer(_LifecycleHost):
     """Syncs existing channels' settings and EPG links to Dispatcharr.
 
     Mixin for ChannelLifecycleService — relies on the coordinator's managers,
@@ -183,7 +184,7 @@ class ChannelSyncer:
 
             # 5. Check tvg_id (regenerate with keyword + feed_team_id to migrate
             # old-format tvg_ids; feed_team_id keeps feed-separated channels distinct)
-            event_id = getattr(event, "id", None)
+            event_id = event.id
             event_provider = getattr(event, "provider", "espn")
             stored_feed_team_id_for_tvg = getattr(existing, "feed_team_id", None)
             expected_tvg_id = generate_event_tvg_id(

--- a/teamarr/consumers/lifecycle/types.py
+++ b/teamarr/consumers/lifecycle/types.py
@@ -47,7 +47,7 @@ class ChannelCreationResult:
     success: bool
     channel_id: int | None = None
     dispatcharr_channel_id: int | None = None
-    channel_number: str | None = None
+    channel_number: int | None = None
     tvg_id: str | None = None
     error: str | None = None
 

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from datetime import date, time
 from enum import Enum
 from re import Pattern
+from typing import cast
 
 from teamarr.consumers.matching.normalizer import NormalizedStream, normalize_stream
 from teamarr.services.detection_keywords import DetectionKeywordService
@@ -998,7 +999,7 @@ def detect_sport_hint(text: str) -> str | None:
     if not text:
         return None
 
-    return DetectionKeywordService.detect_sport(text)
+    return cast("str | None", DetectionKeywordService.detect_sport(text))
 
 
 # =============================================================================

--- a/teamarr/consumers/matching/epg_resolver.py
+++ b/teamarr/consumers/matching/epg_resolver.py
@@ -138,7 +138,8 @@ def resolve_program_tvg_ids(
             continue
 
         # 1. Channel (curated mapping — most trusted).
-        ch = stream_channel_map.get(s.get("id"))
+        sid = s.get("id")
+        ch = stream_channel_map.get(sid) if sid is not None else None
         if ch:
             eid = ch.get("effective_epg_data_id") or ch.get("epg_data_id")
             ed = epgdata_by_id.get(eid)

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -701,13 +701,13 @@ class StreamMatcher:
         # gate), we keep only the one whose start is nearest the event — the live
         # broadcast — giving a deterministic, correctly-anchored window (bead
         # t5e). Different events on the same channel keep distinct keys.
-        best_by_event: dict[str, tuple[float, MatchedStreamResult]] = {}
+        best_by_event: dict[str | None, tuple[float, MatchedStreamResult]] = {}
         league_event_type = self._get_dominant_event_type()
 
         # Full sorted timeline for this tvg_id. A linear channel legitimately
         # matches many programs/day; each matched program's broadcast slot drives
         # its own attach/detach window in the lifecycle layer.
-        programs = self._epg_index.programs_for(tvg_id)
+        programs = self._epg_index.programs_for(tvg_id) if self._epg_index is not None else []
         attempted = 0
         skipped_non_event = 0
         for program in programs:
@@ -872,7 +872,7 @@ class StreamMatcher:
           name found nothing (a static-named single-event stream).
         """
         epg_matched = [r for r in epg_results if r.matched]
-        if self._epg_index.is_linear(tvg_id):
+        if self._epg_index is not None and self._epg_index.is_linear(tvg_id):
             return epg_matched if epg_matched else name_results
         name_matched = any(r.matched for r in name_results)
         if not name_matched and epg_matched:
@@ -1187,7 +1187,7 @@ class StreamMatcher:
 
         # Return the most common type
         if type_counts:
-            return max(type_counts, key=type_counts.get)
+            return max(type_counts, key=lambda k: type_counts[k])
         return None
 
     def _load_league_event_types(self) -> None:
@@ -1219,7 +1219,7 @@ class StreamMatcher:
                 sport_counts[sport] = sport_counts.get(sport, 0) + 1
 
         if sport_counts:
-            return max(sport_counts, key=sport_counts.get)
+            return max(sport_counts, key=lambda k: sport_counts[k])
         return None
 
     def purge_stale(self) -> int:

--- a/teamarr/consumers/matching/racing_matcher.py
+++ b/teamarr/consumers/matching/racing_matcher.py
@@ -225,7 +225,7 @@ class RacingMatcher:
         stream_norm = normalize_text(ctx.stream_name)
         best_score = 0
         best_event: Event | None = None
-        country_scores: dict[str, int] = {}
+        country_scores: dict[str, float] = {}
 
         for event in events:
             for candidate in (event.name, event.short_name, event.circuit_name):

--- a/teamarr/consumers/matching/result.py
+++ b/teamarr/consumers/matching/result.py
@@ -237,7 +237,7 @@ class MatchOutcome:
     @classmethod
     def failed(
         cls,
-        reason: FailedReason,
+        reason: FailedReason | None,
         *,
         stream_name: str | None = None,
         stream_id: int | None = None,
@@ -399,7 +399,7 @@ class MatchOutcome:
 # DISPLAY TEXT - Human-readable descriptions
 # =============================================================================
 
-FILTERED_DISPLAY: dict[FilteredReason, str] = {
+FILTERED_DISPLAY: dict[FilteredReason | None, str] = {
     FilteredReason.NOT_EVENT: "Not an event stream",
     FilteredReason.INCLUDE_REGEX: "Didn't match include regex",
     FilteredReason.EXCLUDE_REGEX: "Matched exclude regex",
@@ -408,7 +408,7 @@ FILTERED_DISPLAY: dict[FilteredReason, str] = {
     FilteredReason.SPORT_NOT_SUPPORTED: "Sport not supported",
 }
 
-FAILED_DISPLAY: dict[FailedReason, str] = {
+FAILED_DISPLAY: dict[FailedReason | None, str] = {
     FailedReason.TEAMS_NOT_PARSED: "Could not parse team names",
     FailedReason.TEAM1_NOT_FOUND: "First team not found",
     FailedReason.TEAM2_NOT_FOUND: "Second team not found",
@@ -423,7 +423,7 @@ FAILED_DISPLAY: dict[FailedReason, str] = {
     FailedReason.DATE_MISMATCH: "Stream date doesn't match event",
 }
 
-METHOD_DISPLAY: dict[MatchMethod, str] = {
+METHOD_DISPLAY: dict[MatchMethod | None, str] = {
     MatchMethod.CACHE: "Cache hit",
     MatchMethod.USER_CORRECTED: "User corrected",
     MatchMethod.ALIAS: "Alias match",
@@ -433,7 +433,7 @@ METHOD_DISPLAY: dict[MatchMethod, str] = {
     MatchMethod.DIRECT: "Direct assignment",
 }
 
-EXCLUDED_DISPLAY: dict[ExcludedReason, str] = {
+EXCLUDED_DISPLAY: dict[ExcludedReason | None, str] = {
     ExcludedReason.LEAGUE_NOT_INCLUDED: "League not in group",
     ExcludedReason.EVENT_FINAL: "Event is final",
     ExcludedReason.EVENT_PAST: "Event already ended",

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -1565,7 +1565,7 @@ class TeamMatcher:
         events: list[Event],
         stream_time: time,
         user_tz: ZoneInfo,
-    ) -> Event:
+    ) -> Event | None:
         """Pick event closest to stream time for doubleheaders."""
         if len(events) <= 1:
             return events[0] if events else None
@@ -1604,6 +1604,8 @@ class TeamMatcher:
             start_time = cached_data.get("start_time")
             if isinstance(start_time, str):
                 start_time = datetime.fromisoformat(start_time)
+            if not isinstance(start_time, datetime):
+                return None  # missing/invalid start_time -> treat as cache miss
 
             # Reconstruct teams (use `or {}` to handle explicit None values)
             home_data = cached_data.get("home_team") or {}
@@ -1728,7 +1730,7 @@ class TeamMatcher:
                 id=cached_data.get("id", ""),
                 provider=cached_data.get("provider", ""),
                 name=cached_data.get("name", ""),
-                short_name=cached_data.get("short_name"),
+                short_name=cached_data.get("short_name", ""),
                 start_time=start_time,
                 home_team=home_team,
                 away_team=away_team,

--- a/teamarr/consumers/racing_segments.py
+++ b/teamarr/consumers/racing_segments.py
@@ -182,6 +182,9 @@ def expand_racing_segments(
             result.append(match)
             continue
 
+        # is_racing_event returned True, so event is a non-None racing Event.
+        assert event is not None
+
         expanded_streams += 1
         sessions = sorted(event.sessions, key=lambda s: s.start_time)
 

--- a/teamarr/consumers/stream_match_cache.py
+++ b/teamarr/consumers/stream_match_cache.py
@@ -346,8 +346,8 @@ class StreamMatchCache:
         group_id: int,
         stream_id: int,
         stream_name: str,
-        event_id: str,
-        league: str,
+        event_id: str | None,
+        league: str | None,
         cached_data: dict[str, Any],
     ) -> bool:
         """Set a user-corrected match (pinned, never auto-purged).

--- a/teamarr/consumers/team_epg.py
+++ b/teamarr/consumers/team_epg.py
@@ -386,6 +386,9 @@ class TeamEPGGenerator:
         options: TeamEPGOptions,
     ) -> Programme | None:
         """Convert an Event to a Programme with template resolution."""
+        # Caller (generate) returns early when options.template is None, so a
+        # template is guaranteed present here.
+        assert options.template is not None
         start = event.start_time - timedelta(minutes=options.pregame_minutes)
         # V1 Parity: Use template custom duration if set
         template_dict = (

--- a/teamarr/consumers/ufc_segments.py
+++ b/teamarr/consumers/ufc_segments.py
@@ -556,6 +556,9 @@ def expand_ufc_segments(
             result.append(match)
             continue
 
+        # is_ufc_event returned True, so event is a non-None UFC Event.
+        assert event is not None
+
         # Check for excluded streams (weigh-ins, etc.)
         if should_exclude_stream(stream):
             logger.debug(
@@ -617,6 +620,8 @@ def expand_ufc_segments(
         # Get the event from any stream (they all have the same event)
         first_match = next(iter(next(iter(segments.values()))))
         event = first_match.get("event")
+        # Every match grouped into ufc_by_segment carries its UFC Event.
+        assert event is not None
 
         # Create entry for each discovered segment
         for segment in SEGMENT_ORDER:

--- a/teamarr/core/interfaces.py
+++ b/teamarr/core/interfaces.py
@@ -62,6 +62,10 @@ class LeagueMappingSource(Protocol):
         """
         ...
 
+    def get_league_sport(self, league_code: str) -> str | None:
+        """Get canonical sport code for a league (any provider)."""
+        ...
+
     def register_discovered_league(
         self,
         league_code: str,

--- a/teamarr/database/aliases.py
+++ b/teamarr/database/aliases.py
@@ -140,8 +140,10 @@ def create_alias(
     )
     conn.commit()
 
+    new_id = cursor.lastrowid
+    assert new_id is not None  # just-inserted row always has a rowid
     return TeamAlias(
-        id=cursor.lastrowid,
+        id=new_id,
         alias=normalized_alias,
         league=league.lower(),
         provider=provider,

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -712,6 +712,7 @@ def _reassign_sticky(
     for ch in sorted_channels:
         if is_anchor(ch):
             num = _channel_num_as_int(ch["channel_number"])
+            assert num is not None  # is_anchor guarantees a valid int
             used.add(num)
             locked_teamarr.add(num)
 
@@ -727,7 +728,9 @@ def _reassign_sticky(
     for gi in range(ng - 1, -1, -1):
         next_anchor_after[gi] = upcoming
         anchor_nums = [
-            _channel_num_as_int(ch["channel_number"]) for ch in groups[gi] if is_anchor(ch)
+            n
+            for ch in groups[gi]
+            if is_anchor(ch) and (n := _channel_num_as_int(ch["channel_number"])) is not None
         ]
         if anchor_nums:
             upcoming = min(anchor_nums)
@@ -796,12 +799,17 @@ def _reassign_sticky(
 
         if not unplaced:
             # Fully anchored event — fixed; advance the neighbourhood low-water mark.
-            anchor_nums = [_channel_num_as_int(ch["channel_number"]) for ch in anchors]
+            anchor_nums = [
+                n
+                for ch in anchors
+                if (n := _channel_num_as_int(ch["channel_number"])) is not None
+            ]
             if anchor_nums:
                 lo = max(lo, max(anchor_nums))
             continue
 
-        hi = next_anchor_after[gi] if next_anchor_after[gi] is not None else (effective_end + 1)
+        na = next_anchor_after[gi]
+        hi = na if na is not None else (effective_end + 1)
 
         if anchors:
             # Mixed event: a feed was added to an already-locked game (feeds are
@@ -809,7 +817,14 @@ def _reassign_sticky(
             # extends the event's run *contiguously* into the gap reserved right
             # after its existing feeds — so all feeds of one game stay together
             # instead of being scattered a full gap (or out to the frontier) away.
-            lo = max(lo, max(_channel_num_as_int(c["channel_number"]) for c in anchors))
+            lo = max(
+                lo,
+                max(
+                    n
+                    for c in anchors
+                    if (n := _channel_num_as_int(c["channel_number"])) is not None
+                ),
+            )
             stopped = False
             for ch in unplaced:
                 target = first_free_run(lo + 1, hi, 1)

--- a/teamarr/database/channels/crud.py
+++ b/teamarr/database/channels/crud.py
@@ -120,6 +120,7 @@ def create_managed_channel(
         values,
     )
     channel_id = cursor.lastrowid
+    assert channel_id is not None  # just-inserted row always has a rowid
     logger.info(
         "[CREATED] Managed channel id=%d name=%s event=%s", channel_id, channel_name, event_id
     )

--- a/teamarr/database/channels/history.py
+++ b/teamarr/database/channels/history.py
@@ -43,7 +43,9 @@ def log_channel_history(
     logger.debug(
         "[HISTORY] channel_id=%d type=%s source=%s", managed_channel_id, change_type, change_source
     )
-    return cursor.lastrowid
+    new_id = cursor.lastrowid
+    assert new_id is not None  # just-inserted row always has a rowid
+    return new_id
 
 
 def get_channel_history(

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -38,7 +38,7 @@ def add_stream_to_channel(
         ID of created stream record
     """
     columns = ["managed_channel_id", "dispatcharr_stream_id", "priority"]
-    values = [managed_channel_id, dispatcharr_stream_id, priority]
+    values: list = [managed_channel_id, dispatcharr_stream_id, priority]
 
     if stream_name:
         columns.append("stream_name")
@@ -70,6 +70,7 @@ def add_stream_to_channel(
         values,
     )
     stream_id = cursor.lastrowid
+    assert stream_id is not None  # just-inserted row always has a rowid
     logger.debug(
         "[ATTACHED] Stream %d to channel %d priority=%d",
         dispatcharr_stream_id,

--- a/teamarr/database/condition_presets.py
+++ b/teamarr/database/condition_presets.py
@@ -127,6 +127,7 @@ def create_preset(
     )
     conn.commit()
     preset_id = cursor.lastrowid
+    assert preset_id is not None  # just-inserted row always has a rowid
     logger.info("[CREATED] Condition preset id=%d name=%s", preset_id, name)
     return preset_id
 

--- a/teamarr/database/exception_keywords.py
+++ b/teamarr/database/exception_keywords.py
@@ -153,6 +153,7 @@ def create_keyword(
     )
     conn.commit()
     keyword_id = cursor.lastrowid
+    assert keyword_id is not None  # just-inserted row always has a rowid
     logger.info("[CREATED] Exception keyword id=%d label=%s", keyword_id, label)
     return keyword_id
 

--- a/teamarr/database/groups.py
+++ b/teamarr/database/groups.py
@@ -645,6 +645,7 @@ def create_group(
         ),
     )
     group_id = cursor.lastrowid
+    assert group_id is not None  # just-inserted row always has a rowid
     logger.info("[CREATED] Event group id=%d name=%s", group_id, name)
     return group_id
 

--- a/teamarr/database/migrations/versioned.py
+++ b/teamarr/database/migrations/versioned.py
@@ -1283,7 +1283,7 @@ def _migrate_v75_extract_art_base_url(conn: sqlite3.Connection) -> None:
     if not art_columns and not json_columns:
         return
 
-    def origin_of(url: str) -> str | None:
+    def origin_of(url: object) -> str | None:
         if not url or not isinstance(url, str):
             return None
         parts = urlsplit(url)

--- a/teamarr/database/provider_cache.py
+++ b/teamarr/database/provider_cache.py
@@ -141,7 +141,7 @@ def dict_to_event(data: dict) -> Event:
         season_year=data.get("season_year"),
         season_type=data.get("season_type"),
         # UFC-specific fields
-        segment_times=segment_times,
+        segment_times=segment_times or {},
         main_card_start=main_card_start,
         # Racing-specific fields
         circuit_name=data.get("circuit_name"),

--- a/teamarr/database/stats.py
+++ b/teamarr/database/stats.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 # TYPES
 # =============================================================================
 
-RunType = Literal["event_group", "team_epg", "batch", "reconciliation", "scheduler"]
+RunType = Literal[
+    "event_group", "team_epg", "batch", "reconciliation", "scheduler", "full_epg"
+]
 RunStatus = Literal["running", "completed", "failed", "partial", "cancelled"]
 
 
@@ -33,7 +35,7 @@ class ProcessingRun:
     group_id: int | None = None
     team_id: int | None = None
 
-    started_at: datetime = field(default_factory=datetime.now)
+    started_at: datetime | None = field(default_factory=datetime.now)
     completed_at: datetime | None = None
     duration_ms: int | None = None
     status: RunStatus = "running"
@@ -182,6 +184,7 @@ def create_run(
         team_id=team_id,
         started_at=datetime.now(),
     )
+    assert run.started_at is not None  # just set above
 
     cursor = conn.execute(
         """

--- a/teamarr/database/subscription.py
+++ b/teamarr/database/subscription.py
@@ -8,6 +8,7 @@ import json
 import logging
 from dataclasses import dataclass, field
 from sqlite3 import Connection
+from types import EllipsisType
 
 logger = logging.getLogger(__name__)
 
@@ -158,9 +159,9 @@ def get_subscribed_league_codes(conn: Connection) -> set[str]:
 
 def update_subscription(
     conn: Connection,
-    leagues: list[str] | None = ...,
-    soccer_mode: str | None = ...,
-    soccer_followed_teams: list[dict] | None = ...,
+    leagues: list[str] | None | EllipsisType = ...,
+    soccer_mode: str | None | EllipsisType = ...,
+    soccer_followed_teams: list[dict] | None | EllipsisType = ...,
 ) -> SportsSubscription:
     """Update the global sports subscription.
 
@@ -273,15 +274,17 @@ def add_subscription_template(
         sports,
         leagues,
     )
-    return cursor.lastrowid
+    new_id = cursor.lastrowid
+    assert new_id is not None  # just-inserted row always has a rowid
+    return new_id
 
 
 def update_subscription_template(
     conn: Connection,
     assignment_id: int,
     template_id: int | None = None,
-    sports: list[str] | None = ...,
-    leagues: list[str] | None = ...,
+    sports: list[str] | None | EllipsisType = ...,
+    leagues: list[str] | None | EllipsisType = ...,
 ) -> bool:
     """Update a subscription template assignment.
 
@@ -477,7 +480,9 @@ def upsert_league_config(
         ),
     )
     logger.info("[LEAGUE_CONFIG] Upserted config for %s", league_code)
-    return get_league_config(conn, league_code)
+    config = get_league_config(conn, league_code)
+    assert config is not None  # just upserted, row must exist
+    return config
 
 
 def delete_league_config(conn: Connection, league_code: str) -> bool:

--- a/teamarr/database/teams.py
+++ b/teamarr/database/teams.py
@@ -140,8 +140,11 @@ def create_team(
         ),
     )
     team_id = cursor.lastrowid
+    assert team_id is not None  # just-inserted row always has a rowid
     logger.info("[CREATED] Team id=%d name=%s", team_id, team_name)
-    return get_team(conn, team_id)
+    team = get_team(conn, team_id)
+    assert team is not None  # just inserted, row must exist
+    return team
 
 
 def update_team(conn: Connection, team_id: int, updates: dict) -> dict | None:

--- a/teamarr/database/templates.py
+++ b/teamarr/database/templates.py
@@ -452,6 +452,7 @@ def create_template(
     cursor = conn.execute(f"INSERT INTO templates ({column_str}) VALUES ({placeholders})", values)
     conn.commit()
     template_id = cursor.lastrowid
+    assert template_id is not None  # just-inserted row always has a rowid
     logger.info("[CREATED] Template id=%d name=%s type=%s", template_id, name, template_type)
     return template_id
 

--- a/teamarr/dispatcharr/factory.py
+++ b/teamarr/dispatcharr/factory.py
@@ -339,7 +339,7 @@ class ConnectionTestResult:
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        result = {"success": self.success}
+        result: dict[str, Any] = {"success": self.success}
         if self.url:
             result["url"] = self.url
         if self.username:

--- a/teamarr/dispatcharr/managers/channels.py
+++ b/teamarr/dispatcharr/managers/channels.py
@@ -718,7 +718,7 @@ class ChannelManager:
             Dict mapping tvg_id to EPGData dict
         """
         epg_data_list = self.get_epg_data_list(epg_source_id)
-        return {e.get("tvg_id"): e for e in epg_data_list if e.get("tvg_id")}
+        return {tvg_id: e for e in epg_data_list if (tvg_id := e.get("tvg_id"))}
 
     def find_epg_data_by_tvg_id(
         self,

--- a/teamarr/providers/__init__.py
+++ b/teamarr/providers/__init__.py
@@ -15,6 +15,8 @@ ProviderRegistry.initialize() must be called during app startup
 to inject the LeagueMappingSource into providers.
 """
 
+from collections.abc import Callable
+
 from teamarr.database import get_db
 from teamarr.database.team_cache import get_team_name_by_id
 from teamarr.providers.espn import ESPNClient, ESPNProvider
@@ -59,7 +61,7 @@ def _get_tsdb_api_key() -> str | None:
     return None
 
 
-def _create_tsdb_team_name_resolver() -> callable:
+def _create_tsdb_team_name_resolver() -> Callable[[str, str], str | None]:
     """Create a team name resolver callback for TSDB provider.
 
     This callback accesses the database, keeping DB access at the factory

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -813,7 +813,10 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
         slug = (season_data.get("slug") or "").lower()
         if slug in self._SEASON_SLUG_MAP:
             return self._SEASON_SLUG_MAP[slug]
-        return self._SEASON_TYPE_NUM_MAP.get(season_data.get("type"))
+        season_type_num = season_data.get("type")
+        if not isinstance(season_type_num, int):
+            return None
+        return self._SEASON_TYPE_NUM_MAP.get(season_type_num)
 
     def _parse_odds(self, odds_list: list) -> dict | None:
         """Parse ESPN odds data into structured dict.

--- a/teamarr/providers/espn/tennis.py
+++ b/teamarr/providers/espn/tennis.py
@@ -13,6 +13,7 @@ players by surname only: "Wimbledon: Zheng vs Norrie @ Jun 29 12:30 PM").
 
 import logging
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 from teamarr.core import Event, EventStatus, Team, Venue
 
@@ -54,6 +55,10 @@ class TennisParserMixin:
     Requires:
         - self.name: Provider name ('espn')
     """
+
+    if TYPE_CHECKING:
+        # Provided by the host provider class (ESPNProvider).
+        name: str
 
     def _parse_tennis_matches(
         self, data: dict, league: str, sport: str, target_date: date

--- a/teamarr/providers/espn/tournament.py
+++ b/teamarr/providers/espn/tournament.py
@@ -6,8 +6,12 @@ traditional home/away matchups.
 
 import logging
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 from teamarr.core import Event, EventStatus, RacingResult, RacingSession, Team, Venue
+
+if TYPE_CHECKING:
+    from teamarr.providers.espn.client import ESPNClient
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +59,15 @@ class TournamentParserMixin:
         - self._client: ESPNClient instance
         - self.name: Provider name ('espn')
     """
+
+    if TYPE_CHECKING:
+        # Provided by the host provider class (ESPNProvider).
+        _client: "ESPNClient"
+        name: str
+
+        def _parse_tennis_matches(
+            self, data: dict, league: str, sport: str, target_date: date
+        ) -> list[Event]: ...
 
     def _get_tournament_events(
         self,

--- a/teamarr/providers/espn/ufc.py
+++ b/teamarr/providers/espn/ufc.py
@@ -5,6 +5,7 @@ No API calls, no date filtering - that's the provider's responsibility.
 """
 
 import logging
+from typing import TYPE_CHECKING, Any
 
 from teamarr.core import Bout, Event, EventStatus, Team
 
@@ -20,6 +21,14 @@ class UFCParserMixin:
         - self.name: Provider name ('espn')
         - self._parse_datetime(date_str): Parse datetime from string
     """
+
+    if TYPE_CHECKING:
+        # Provided by the host provider class (ESPNProvider).
+        from datetime import datetime
+
+        name: str
+
+        def _parse_datetime(self, date_str: str) -> "datetime | None": ...
 
     def _parse_ufc_events(self, data: dict) -> list[Event]:
         """Parse UFC scoreboard response into Event objects.
@@ -77,7 +86,7 @@ class UFCParserMixin:
             sorted_times = sorted(bout_times)
 
             # Build segment_times dict based on number of distinct times
-            segment_times: dict[str, any] = {}
+            segment_times: dict[str, Any] = {}
             time_to_segment: dict[str, str] = {}  # Map raw time strings to segment names
 
             if len(sorted_times) == 3:

--- a/teamarr/providers/registry.py
+++ b/teamarr/providers/registry.py
@@ -48,6 +48,7 @@ class ProviderConfig:
                 self._instance = self.factory()
             else:
                 self._instance = self.provider_class(**self.config)
+        assert self._instance is not None  # both branches above set it
         return self._instance
 
     def reset_instance(self) -> None:
@@ -244,7 +245,8 @@ class ProviderRegistry:
 
         # Check if provider exposes an is_premium property
         if hasattr(provider, "is_premium"):
-            return provider.is_premium
+            # Duck-typed: not all SportsProvider subclasses declare is_premium.
+            return provider.is_premium  # type: ignore[attr-defined]
 
         # Assume full capability if provider doesn't track premium status
         return True

--- a/teamarr/services/cache_service.py
+++ b/teamarr/services/cache_service.py
@@ -31,7 +31,7 @@ class LeagueInfo:
 
     slug: str
     provider: str
-    name: str
+    name: str | None
     sport: str
     team_count: int = 0
     logo_url: str | None = None

--- a/teamarr/services/channel_service.py
+++ b/teamarr/services/channel_service.py
@@ -4,6 +4,7 @@ This module provides a clean API for channel management operations.
 """
 
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from datetime import datetime
 from sqlite3 import Connection
@@ -16,8 +17,8 @@ from teamarr.services.sports_data import SportsDataService
 class DeletionResult:
     """Result of channel deletion processing."""
 
-    deleted: list[int] = field(default_factory=list)
-    errors: list[str] = field(default_factory=list)
+    deleted: list[dict] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -53,8 +54,8 @@ class ReconciliationResult:
     completed_at: datetime | None = None
     summary: ReconciliationSummary = field(default_factory=ReconciliationSummary)
     issues_found: list[ReconciliationIssue] = field(default_factory=list)
-    issues_fixed: int = 0
-    issues_skipped: int = 0
+    issues_fixed: list[dict] = field(default_factory=list)
+    issues_skipped: list[dict] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
 
@@ -66,7 +67,7 @@ class ChannelService:
 
     def __init__(
         self,
-        db_factory: Callable[[], Connection],
+        db_factory: Callable[[], AbstractContextManager[Connection]],
         sports_service: SportsDataService,
         dispatcharr_client: Any | None = None,
     ):
@@ -167,7 +168,7 @@ class ChannelService:
 
 
 def create_channel_service(
-    db_factory: Callable[[], Connection],
+    db_factory: Callable[[], AbstractContextManager[Connection]],
     sports_service: SportsDataService,
     dispatcharr_client: Any | None = None,
 ) -> ChannelService:

--- a/teamarr/services/custom_leagues.py
+++ b/teamarr/services/custom_leagues.py
@@ -338,7 +338,9 @@ def create_custom_league(
         tsdb_tier=tier,
     )
     _auto_subscribe(conn, code)
-    return get_league_row(conn, code)
+    row = get_league_row(conn, code)
+    assert row is not None  # row just created above
+    return row
 
 
 def _auto_subscribe(conn: sqlite3.Connection, league_code: str) -> None:
@@ -448,7 +450,9 @@ def update_custom_league(
         event_type=resolved_event_type,
         tsdb_tier=tier,
     )
-    return get_league_row(conn, code)
+    row = get_league_row(conn, code)
+    assert row is not None  # row just upserted above
+    return row
 
 
 def delete_custom_league(conn: sqlite3.Connection, league_code: str) -> None:

--- a/teamarr/services/league_mappings.py
+++ b/teamarr/services/league_mappings.py
@@ -8,7 +8,8 @@ This is critical for thread-safety during parallel team processing.
 """
 
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from sqlite3 import Connection
 
 from teamarr.core import LeagueMapping
@@ -37,7 +38,7 @@ class LeagueMappingService:
 
     def __init__(
         self,
-        db_getter: Callable[[], Generator[Connection, None, None]],
+        db_getter: Callable[[], AbstractContextManager[Connection]],
     ):
         self._db_getter = db_getter
         # Cache all mappings at initialization for thread-safety
@@ -502,7 +503,7 @@ _league_mapping_service: LeagueMappingService | None = None
 
 
 def init_league_mapping_service(
-    db_getter: Callable[[], Generator[Connection, None, None]],
+    db_getter: Callable[[], AbstractContextManager[Connection]],
 ) -> LeagueMappingService:
     """Initialize the global league mapping service.
 

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -15,6 +15,7 @@ import threading
 import time
 from dataclasses import replace
 from datetime import UTC, date, datetime, timedelta
+from typing import Any, cast, overload
 
 from teamarr.core import Event, SportsProvider, Team, TeamStats
 from teamarr.database import get_db
@@ -118,6 +119,10 @@ def _backfill_team_from_cache(team: Team | None, league: str) -> Team | None:
     )
 
 
+@overload
+def _enrich_event_teams(event: Event) -> Event: ...
+@overload
+def _enrich_event_teams(event: None) -> None: ...
 def _enrich_event_teams(event: Event | None) -> Event | None:
     """Backfill home_team and away_team from team_cache where fields are empty."""
     if event is None:
@@ -305,7 +310,7 @@ class SportsDataService:
             chosen = provider
             bulk = getattr(provider, "get_sample_candidates", None)
             if callable(bulk):
-                candidates = bulk(league)
+                candidates = cast("list[Event]", bulk(league))
             else:
                 # Recent days first (their finals), then a couple upcoming.
                 for d in (
@@ -330,7 +335,7 @@ class SportsDataService:
         # Bowl). A finished game populates every postgame variable.
         deep = getattr(chosen, "get_recent_final", None) if chosen else None
         if callable(deep):
-            ev = deep(league)
+            ev = cast("Event | None", deep(league))
             if ev and ev.home_team and ev.away_team:
                 return _enrich_event_teams(ev)
 
@@ -627,7 +632,7 @@ class SportsDataService:
 
             # Check for TSDB-specific stats
             if hasattr(provider, "_client"):
-                client = provider._client
+                client: Any = getattr(provider, "_client", None)
                 if hasattr(client, "rate_limit_stats"):
                     provider_stats["has_rate_limit"] = True
                     provider_stats["rate_limit"] = client.rate_limit_stats().to_dict()
@@ -645,7 +650,7 @@ class SportsDataService:
         """
         for provider in self._providers:
             if hasattr(provider, "_client"):
-                client = provider._client
+                client: Any = getattr(provider, "_client", None)
                 if hasattr(client, "reset_rate_limit_stats"):
                     client.reset_rate_limit_stats()
 

--- a/teamarr/services/stream_filter.py
+++ b/teamarr/services/stream_filter.py
@@ -14,6 +14,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from re import Pattern
+from typing import Any, cast
 
 from teamarr.services.detection_keywords import DetectionKeywordService
 
@@ -144,7 +145,9 @@ BUILTIN_EVENT_PATTERNS = [
 ]
 
 # Compiled regex for event stream detection
-_BUILTIN_EVENT_REGEX: Pattern | None = None
+# Typed Any: compiled by REGEX_MODULE (third-party `regex` lib or stdlib `re`),
+# whose pattern types differ and aren't mutually assignable.
+_BUILTIN_EVENT_REGEX: Any = None
 
 
 def get_builtin_event_pattern() -> Pattern:
@@ -237,7 +240,7 @@ def compile_pattern(pattern: str | None, ignore_case: bool = True) -> Pattern | 
     flags = REGEX_MODULE.IGNORECASE if ignore_case else 0
 
     try:
-        return REGEX_MODULE.compile(pattern.strip(), flags)
+        return cast("Pattern | None", REGEX_MODULE.compile(pattern.strip(), flags))
     except Exception as e:
         logger.debug("[FILTER] Failed to compile regex pattern '%s': %s", pattern, e)
         return None

--- a/teamarr/services/team_import.py
+++ b/teamarr/services/team_import.py
@@ -208,6 +208,7 @@ def bulk_import_teams(conn: Connection, teams: list[ImportTeam]) -> ImportResult
                 )
                 used_ids.add(channel_id)
                 new_id = cursor.lastrowid
+                assert new_id is not None  # INSERT always yields a rowid
                 existing_full[full_key] = (new_id, all_leagues)
                 existing_sport[sport_key] = [(new_id, team.league, all_leagues)]
                 imported += 1
@@ -242,6 +243,7 @@ def bulk_import_teams(conn: Connection, teams: list[ImportTeam]) -> ImportResult
                 )
                 used_ids.add(channel_id)
                 new_id = cursor.lastrowid
+                assert new_id is not None  # INSERT always yields a rowid
                 existing_full[full_key] = (new_id, [team.league])
                 if sport_key not in existing_sport:
                     existing_sport[sport_key] = []

--- a/teamarr/templates/conditions.py
+++ b/teamarr/templates/conditions.py
@@ -34,6 +34,7 @@ import random
 from dataclasses import dataclass
 from typing import Any
 
+from teamarr.core import SEASON_POSTSEASON, SEASON_PRESEASON
 from teamarr.templates.context import GameContext, TemplateContext
 
 logger = logging.getLogger(__name__)
@@ -181,14 +182,14 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if this is a playoff game."""
         event = game_ctx.event
-        return event.is_playoff if event else False
+        return bool(event and event.season_type == SEASON_POSTSEASON)
 
     def _eval_is_preseason(
         self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
     ) -> bool:
         """Check if this is a preseason game."""
         event = game_ctx.event
-        return event.is_preseason if event else False
+        return bool(event and event.season_type == SEASON_PRESEASON)
 
     # =========================================================================
     # Conference conditions (college)
@@ -223,9 +224,7 @@ class ConditionEvaluator:
 
         national_networks = {"abc", "cbs", "nbc", "fox", "espn", "espn2", "tnt", "tbs"}
         for broadcast in event.broadcasts:
-            network = broadcast.get("network", "").lower()
-            market = broadcast.get("market", "").lower()
-            if market == "national" or network in national_networks:
+            if broadcast.lower() in national_networks:
                 return True
         return False
 

--- a/teamarr/templates/variables/odds.py
+++ b/teamarr/templates/variables/odds.py
@@ -25,9 +25,10 @@ def _has_odds(game_ctx: GameContext | None) -> bool:
     description="Odds provider name (e.g., 'ESPN BET')",
 )
 def extract_odds_provider(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx):
-        return game_ctx.odds.provider
-    return ""
+    odds = game_ctx.odds if game_ctx else None
+    if odds is None:
+        return ""
+    return odds.provider
 
 
 @register_variable(
@@ -37,8 +38,9 @@ def extract_odds_provider(ctx: TemplateContext, game_ctx: GameContext | None) ->
     description="Point spread (absolute value, e.g., '7')",
 )
 def extract_odds_spread(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx) and game_ctx.odds.spread:
-        spread = game_ctx.odds.spread
+    odds = game_ctx.odds if game_ctx else None
+    if odds is not None and odds.spread:
+        spread = odds.spread
         # Format as integer if whole number
         if spread == int(spread):
             return str(int(spread))
@@ -53,8 +55,9 @@ def extract_odds_spread(ctx: TemplateContext, game_ctx: GameContext | None) -> s
     description="Over/under total (e.g., '47.5')",
 )
 def extract_odds_over_under(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx) and game_ctx.odds.over_under:
-        ou = game_ctx.odds.over_under
+    odds = game_ctx.odds if game_ctx else None
+    if odds is not None and odds.over_under:
+        ou = odds.over_under
         if ou == int(ou):
             return str(int(ou))
         return str(ou)
@@ -68,9 +71,10 @@ def extract_odds_over_under(ctx: TemplateContext, game_ctx: GameContext | None) 
     description="Full odds description string",
 )
 def extract_odds_details(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx):
-        return game_ctx.odds.details
-    return ""
+    odds = game_ctx.odds if game_ctx else None
+    if odds is None:
+        return ""
+    return odds.details
 
 
 @register_variable(
@@ -81,8 +85,9 @@ def extract_odds_details(ctx: TemplateContext, game_ctx: GameContext | None) -> 
     scope=TemplateScope.TEAM_ONLY,
 )
 def extract_odds_moneyline(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx) and game_ctx.odds.team_moneyline:
-        ml = game_ctx.odds.team_moneyline
+    odds = game_ctx.odds if game_ctx else None
+    if odds is not None and odds.team_moneyline:
+        ml = odds.team_moneyline
         if ml > 0:
             return f"+{ml}"
         return str(ml)
@@ -97,8 +102,9 @@ def extract_odds_moneyline(ctx: TemplateContext, game_ctx: GameContext | None) -
     scope=TemplateScope.TEAM_ONLY,
 )
 def extract_odds_opponent_moneyline(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    if _has_odds(game_ctx) and game_ctx.odds.opponent_moneyline:
-        ml = game_ctx.odds.opponent_moneyline
+    odds = game_ctx.odds if game_ctx else None
+    if odds is not None and odds.opponent_moneyline:
+        ml = odds.opponent_moneyline
         if ml > 0:
             return f"+{ml}"
         return str(ml)

--- a/teamarr/utilities/xmltv.py
+++ b/teamarr/utilities/xmltv.py
@@ -157,7 +157,8 @@ def merge_xmltv_content(
         root.set("generator-info-url", generator_url)
 
     seen_channels: set[str] = set()
-    seen_programmes: set[tuple[str, str, str]] = set()  # (channel, start, stop)
+    # (channel, start, stop)
+    seen_programmes: set[tuple[str | None, str | None, str | None]] = set()
     all_programmes: list[Element] = []
 
     for content in xmltv_contents:


### PR DESCRIPTION
Bead \`teamarrv2-9y67.1\` (epic \`9y67\`, #292). Finishes the Pyright burndown started in #293 (groups.py −144). **`pyright teamarr/` is now 0** (was 532 total).

## Result
- **Pyright: 388 → 0** across ~64 files
- Tests **1379 pass**, ruff clean
- Only **2 `# type: ignore`** in the entire burndown (registry.py duck-typed `is_premium`)
- The CI `Pyright (advisory)` check (`uv run pyright teamarr/`) will go green — and per its own comment can now be promoted to a blocking gate

## All fixes behavior-preserving. Patterns used
- **None-guards / early-return** on Optional access (matching hot path mirrors existing skip/continue behavior)
- **`@overload`** for `_enrich_event_teams` (Event→Event, None→None)
- **`_LifecycleHost`** type-only base declaring the host surface the 4 lifecycle mixins borrow (runtime-empty; MRO-safe)
- **`assert x is not None`** for genuine invariants: `cursor.lastrowid` after insert, re-fetch of a just-created row
- **Annotation corrections**: `create_channel_service` `db_factory` → context-manager factory; display-dict keys → `| None`; `MatchOutcome.failed(reason)` → Optional; `country_scores` → float; `RunType` += `full_epg`; `LeagueMappingSource` Protocol += `get_league_sport`
- **`cast`** for genuinely-dynamic results (`getattr` provider hooks, `regex`-vs-`re` pattern types)
- **`EllipsisType`** sentinel widening for `update_*` params

## How it was done
Fanned out across subagents by subsystem (database, providers, lifecycle, routes, templates, matching), each with a strict behavior-preserving, edit-only contract self-verifying `pyright`→0 on its files. Three batches died on transient 529s mid-work; I hand-finished the 52 they left and ran full central verification (pyright 0 + pytest + ruff).

## Reviewer notes (flagged, verified by the suite)
- `stats.py` was edited by two batches concurrently — changes coexist, tests pass
- `cleanup.py` stream-removal guards: `None` id was already a no-op; guard mirrors line 694
- `team_matcher._reconstruct_event`: missing/invalid `start_time` now returns `None` (cache miss) — consistent with its existing stale-row handling
- `_disambiguate_by_time` is dead (zero callers); return widened to `Event | None`

Next: ESLint burndown (bead \`9y67.2\`, 67 React Compiler findings) as a separate PR.