### PR TITLE
chore(lint): ignoreRestSiblings for no-unused-vars (#292)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,10 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Rest-destructure omission (`const { drop, ...keep } = obj`) is the
+      // idiomatic way to exclude fields; don't flag the dropped names.
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
+    },
   },
 ])

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -176,7 +176,6 @@ export function Templates() {
       const fullTemplate = await getTemplate(template.id)
 
       // Export without ID/timestamps (for portability)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- discarded via rest destructure
       const { id, created_at, updated_at, team_count, global_assignments, ...exportData } = fullTemplate
       const blob = new Blob([JSON.stringify([exportData], null, 2)], { type: "application/json" })
       const url = URL.createObjectURL(blob)


### PR DESCRIPTION
## Summary
- Configures `@typescript-eslint/no-unused-vars` with `ignoreRestSiblings: true` — the canonical fix for rest-destructure field omission (`const { drop, ...keep } = obj`) — replacing the inline `eslint-disable` added in #295
- Follow-up to the mechanical tier (#295) under #292

## Test plan
- [x] `npx eslint src` — exactly 40 errors remain (the staged behavioral tier), no new or hidden findings
- [x] `cd frontend && npm run build` — clean