### PR TITLE
fix(lint): ESLint behavioral React Compiler tier — 40 errors to 0 (#292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,12 @@ bd ready                              # Find available work
 bd show <id>                          # View issue details
 bd update <id> --status in_progress   # Claim work
 bd close <id>                         # Complete work
-bd sync                               # Sync beads data
+bd doctor                             # Check beads health (sync issues, hooks)
 ```
+
+Beads data syncs automatically: git hooks import/export `.beads/*.jsonl` on
+checkout/merge, and the JSONL rides in normal commits. (`bd sync` no longer
+exists in bd ≥1.1.)
 
 ## Development Workflow (issue-first — MANDATORY)
 

--- a/frontend/src/components/DispatcharrOutputSettings.tsx
+++ b/frontend/src/components/DispatcharrOutputSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { SaveButton as SaveButtonBase } from "@/components/ui/save-button"
@@ -66,34 +66,43 @@ export function DispatcharrOutputSettings() {
   const [dispatcharr, setDispatcharr] = useState<Partial<DispatcharrSettings>>({})
   const [selectedProfileIds, setSelectedProfileIds] = useState<(number | string)[]>([])
 
-  useEffect(() => {
-    if (settings) {
-      setDispatcharr({
-        enabled: settings.dispatcharr.enabled,
-        url: settings.dispatcharr.url,
-        username: settings.dispatcharr.username,
-        password: "", // Don't show masked password
-        epg_id: settings.dispatcharr.epg_id,
-        default_channel_profile_ids: settings.dispatcharr.default_channel_profile_ids,
-        default_stream_profile_id: settings.dispatcharr.default_stream_profile_id,
-        default_channel_group_id: settings.dispatcharr.default_channel_group_id,
-        default_channel_group_mode: settings.dispatcharr.default_channel_group_mode,
-        cleanup_unused_logos: settings.dispatcharr.cleanup_unused_logos,
-      })
-    }
-  }, [settings])
+  // Sync the form from the server blob during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every settings refetch,
+  // exactly like the previous effect, without the extra effect render pass.
+  const [syncedSettings, setSyncedSettings] = useState<typeof settings>(undefined)
+  if (settings && settings !== syncedSettings) {
+    setSyncedSettings(settings)
+    setDispatcharr({
+      enabled: settings.dispatcharr.enabled,
+      url: settings.dispatcharr.url,
+      username: settings.dispatcharr.username,
+      password: "", // Don't show masked password
+      epg_id: settings.dispatcharr.epg_id,
+      default_channel_profile_ids: settings.dispatcharr.default_channel_profile_ids,
+      default_stream_profile_id: settings.dispatcharr.default_stream_profile_id,
+      default_channel_group_id: settings.dispatcharr.default_channel_group_id,
+      default_channel_group_mode: settings.dispatcharr.default_channel_group_mode,
+      cleanup_unused_logos: settings.dispatcharr.cleanup_unused_logos,
+    })
+  }
 
   // Convert API profile IDs to display IDs when profiles are loaded
-  useEffect(() => {
-    if (channelProfilesQuery.data && settings) {
-      const allProfileIds = channelProfilesQuery.data.map((p) => p.id)
-      const displayIds = apiToProfileIds(
-        settings.dispatcharr.default_channel_profile_ids,
-        allProfileIds
-      )
-      setSelectedProfileIds(displayIds)
-    }
-  }, [channelProfilesQuery.data, settings])
+  const profilesData = channelProfilesQuery.data
+  const [syncedProfiles, setSyncedProfiles] = useState<{
+    profiles: typeof profilesData
+    settings: typeof settings
+  } | null>(null)
+  if (
+    profilesData &&
+    settings &&
+    (syncedProfiles?.profiles !== profilesData || syncedProfiles?.settings !== settings)
+  ) {
+    setSyncedProfiles({ profiles: profilesData, settings })
+    const allProfileIds = profilesData.map((p) => p.id)
+    setSelectedProfileIds(
+      apiToProfileIds(settings.dispatcharr.default_channel_profile_ids, allProfileIds)
+    )
+  }
 
   const handleSave = async () => {
     try {
@@ -126,7 +135,7 @@ export function DispatcharrOutputSettings() {
     }
   }
 
-  const SaveButton = () => (
+  const saveButton = (
     <SaveButtonBase onClick={handleSave} pending={updateDispatcharr.isPending} />
   )
 
@@ -150,7 +159,7 @@ export function DispatcharrOutputSettings() {
               Profile assignment is enforced on every EPG generation run.
             </p>
           </div>
-          <SaveButton />
+          {saveButton}
         </CardContent>
       </Card>
 
@@ -173,7 +182,7 @@ export function DispatcharrOutputSettings() {
               This default applies to all groups unless overridden.
             </p>
           </div>
-          <SaveButton />
+          {saveButton}
         </CardContent>
       </Card>
 
@@ -276,7 +285,7 @@ export function DispatcharrOutputSettings() {
             </div>
           )}
 
-          <SaveButton />
+          {saveButton}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/components/EpgOutput.tsx
+++ b/frontend/src/components/EpgOutput.tsx
@@ -38,11 +38,13 @@ export function EpgOutput() {
     beforeProgram: string
   } | null>(null)
 
+  const epgXml = epgContent?.content
+
   // Search functionality for XML preview
   const searchMatches = useMemo(() => {
-    if (!searchTerm || !epgContent?.content) return []
+    if (!searchTerm || !epgXml) return []
     const matches: number[] = []
-    const lines = epgContent.content.split("\n")
+    const lines = epgXml.split("\n")
     const searchLower = searchTerm.toLowerCase()
     lines.forEach((line, idx) => {
       if (line.toLowerCase().includes(searchLower)) {
@@ -50,7 +52,7 @@ export function EpgOutput() {
       }
     })
     return matches
-  }, [searchTerm, epgContent?.content])
+  }, [searchTerm, epgXml])
 
   const scrollToMatch = useCallback((matchIndex: number) => {
     if (!previewRef.current || searchMatches.length === 0) return
@@ -75,8 +77,8 @@ export function EpgOutput() {
 
   // Highlighted XML content
   const highlightedContent = useMemo(() => {
-    if (!epgContent?.content) return ""
-    const lines = epgContent.content.split("\n")
+    if (!epgXml) return ""
+    const lines = epgXml.split("\n")
 
     if (highlightedGap) {
       const result: string[] = []
@@ -140,7 +142,7 @@ export function EpgOutput() {
       }
       return `${lineNum}${escapeHtml(line)}`
     }).join("\n")
-  }, [epgContent?.content, showLineNumbers, searchTerm, currentMatch, searchMatches, highlightedGap])
+  }, [epgXml, showLineNumbers, searchTerm, currentMatch, searchMatches, highlightedGap])
 
   const hasIssues = (analysis?.unreplaced_variables?.length ?? 0) > 0 ||
                    (analysis?.coverage_gaps?.length ?? 0) > 0

--- a/frontend/src/components/EpgOutputSettings.tsx
+++ b/frontend/src/components/EpgOutputSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -39,9 +39,14 @@ export function EpgOutputSettings() {
 
   const [epg, setEPG] = useState<EPGSettings | null>(null)
 
-  useEffect(() => {
-    if (epgData) setEPG(epgData)
-  }, [epgData])
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedEpgData, setSyncedEpgData] = useState<typeof epgData>(undefined)
+  if (epgData && epgData !== syncedEpgData) {
+    setSyncedEpgData(epgData)
+    setEPG(epgData)
+  }
 
   const handleSaveOutput = async () => {
     try {
@@ -144,9 +149,15 @@ export function DefaultDurations() {
 
   const [durations, setDurations] = useState<DurationSettings | null>(null)
 
-  useEffect(() => {
-    if (durationsData) setDurations(durationsData)
-  }, [durationsData])
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedDurationsData, setSyncedDurationsData] =
+    useState<typeof durationsData>(undefined)
+  if (durationsData && durationsData !== syncedDurationsData) {
+    setSyncedDurationsData(durationsData)
+    setDurations(durationsData)
+  }
 
   const { data: sportsData } = useQuery({
     queryKey: ["sports"],

--- a/frontend/src/components/EventMatcherModal.tsx
+++ b/frontend/src/components/EventMatcherModal.tsx
@@ -86,14 +86,16 @@ export function EventMatcherModal({
     staleTime: 5 * 60 * 1000,
   })
 
+  const leagues = leaguesData?.leagues
+
   const sortedLeagues = useMemo(() => {
-    if (!leaguesData?.leagues) return []
-    return [...leaguesData.leagues].sort((a, b) => {
+    if (!leagues) return []
+    return [...leagues].sort((a, b) => {
       const sportCompare = (a.sport ?? "").localeCompare(b.sport ?? "")
       if (sportCompare !== 0) return sportCompare
       return (a.name ?? a.slug ?? "").localeCompare(b.name ?? b.slug ?? "")
     })
-  }, [leaguesData?.leagues])
+  }, [leagues])
 
   const leaguesBySport = useMemo(() => {
     const grouped: Record<string, CachedLeague[]> = {}

--- a/frontend/src/components/EventMatchingSettings.tsx
+++ b/frontend/src/components/EventMatchingSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -30,9 +30,15 @@ export function EpgMatchingSettings() {
   const dispatcharrStatus = useDispatcharrStatus()
 
   const [epg, setEPG] = useState<EPGSettings | null>(null)
-  useEffect(() => {
-    if (epgData) setEPG(epgData)
-  }, [epgData])
+
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedEpgData, setSyncedEpgData] = useState<typeof epgData>(undefined)
+  if (epgData && epgData !== syncedEpgData) {
+    setSyncedEpgData(epgData)
+    setEPG(epgData)
+  }
 
   const channelGroupsQuery = useChannelGroups(
     true,
@@ -179,9 +185,15 @@ export function EventLookaheadSetting() {
   const updateEPG = useUpdateEPGSettings()
 
   const [epg, setEPG] = useState<EPGSettings | null>(null)
-  useEffect(() => {
-    if (epgData) setEPG(epgData)
-  }, [epgData])
+
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedEpgData, setSyncedEpgData] = useState<typeof epgData>(undefined)
+  if (epgData && epgData !== syncedEpgData) {
+    setSyncedEpgData(epgData)
+    setEPG(epgData)
+  }
 
   return (
     <Card>

--- a/frontend/src/components/FeedSeparationCard.tsx
+++ b/frontend/src/components/FeedSeparationCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { ToggleCard } from "@/components/ui/toggle-card"
@@ -29,11 +29,15 @@ export function FeedSeparationCard() {
     label_style: "team_name",
   })
 
-  useEffect(() => {
-    if (feedSeparationData) {
-      setFeedSeparation(feedSeparationData)
-    }
-  }, [feedSeparationData])
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedFeedSeparationData, setSyncedFeedSeparationData] =
+    useState<typeof feedSeparationData>(undefined)
+  if (feedSeparationData && feedSeparationData !== syncedFeedSeparationData) {
+    setSyncedFeedSeparationData(feedSeparationData)
+    setFeedSeparation(feedSeparationData)
+  }
 
   return (
     <ToggleCard

--- a/frontend/src/components/GlobalDefaults.tsx
+++ b/frontend/src/components/GlobalDefaults.tsx
@@ -11,7 +11,7 @@
  * Explicit Save buttons — league changes trigger EPG regeneration.
  */
 
-import { useState, useEffect, useMemo, useCallback } from "react"
+import { useState, useMemo, useCallback } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { Loader2 } from "lucide-react"
@@ -28,6 +28,29 @@ import { useTeamFilterSettings, useUpdateTeamFilterSettings } from "@/hooks/useS
 import { getLeagues } from "@/api/teams"
 import type { SoccerFollowedTeam } from "@/api/types"
 import type { TeamFilterSettings } from "@/api/settings"
+
+/**
+ * Split subscribed league slugs into soccer vs non-soccer. Module-level so the
+ * render-time seeding block below stays simple enough for the React Compiler
+ * (a .find() lambda combined with a method call inside that block defeats its
+ * memoization analysis).
+ */
+function splitSubscribedLeagues(
+  slugs: string[],
+  allLeagues: { slug: string; sport?: string | null }[],
+): { soccer: string[]; nonSoccer: string[] } {
+  const soccer: string[] = []
+  const nonSoccer: string[] = []
+  for (const slug of slugs) {
+    const league = allLeagues.find((l) => l.slug === slug)
+    if (league?.sport?.toLowerCase() === "soccer") {
+      soccer.push(slug)
+    } else {
+      nonSoccer.push(slug)
+    }
+  }
+  return { soccer, nonSoccer }
+}
 
 export function GlobalDefaults({
   activeTile,
@@ -65,35 +88,38 @@ export function GlobalDefaults({
     bypass_filter_for_playoffs: false,
   })
 
-  // Sync local state from server subscription
-  useEffect(() => {
-    if (!subscription) return
+  // Sync local state from the server subscription during render (React's
+  // "adjusting state when a prop changes" pattern) — re-seeds whenever the
+  // subscription or the league list refetches, exactly like the previous
+  // effect, without the extra effect render pass.
+  const [syncedSubscription, setSyncedSubscription] = useState<{
+    subscription: typeof subscription
+    leaguesData: typeof leaguesData
+  } | null>(null)
+  if (
+    subscription &&
+    (syncedSubscription?.subscription !== subscription ||
+      syncedSubscription?.leaguesData !== leaguesData)
+  ) {
+    setSyncedSubscription({ subscription, leaguesData })
 
     // Split leagues into soccer vs non-soccer
-    const soccer: string[] = []
-    const nonSoccer: string[] = []
-    for (const slug of subscription.leagues) {
-      const league = allLeagues.find((l) => l.slug === slug)
-      if (league?.sport?.toLowerCase() === "soccer") {
-        soccer.push(slug)
-      } else {
-        nonSoccer.push(slug)
-      }
-    }
+    const { soccer, nonSoccer } = splitSubscribedLeagues(subscription.leagues, allLeagues)
 
     setNonSoccerLeagues(nonSoccer)
     setSoccerLeagues(soccer)
     setSoccerMode(subscription.soccer_mode as SoccerMode)
     setFollowedTeams(subscription.soccer_followed_teams || [])
     setHasLocalChanges(false)
-  }, [subscription, allLeagues])
+  }
 
-  // Sync team filter state when data loads
-  useEffect(() => {
-    if (teamFilterData) {
-      setTeamFilter(teamFilterData)
-    }
-  }, [teamFilterData])
+  // Sync team filter state from server data during render (same pattern) —
+  // re-seeds on every refetch, exactly like the previous effect.
+  const [syncedTeamFilterData, setSyncedTeamFilterData] = useState<typeof teamFilterData>(undefined)
+  if (teamFilterData && teamFilterData !== syncedTeamFilterData) {
+    setSyncedTeamFilterData(teamFilterData)
+    setTeamFilter(teamFilterData)
+  }
 
   // Combined leagues for team picker
   const allSubscribedLeagues = useMemo(

--- a/frontend/src/components/RunHistoryTable.tsx
+++ b/frontend/src/components/RunHistoryTable.tsx
@@ -158,37 +158,41 @@ export function RunHistoryTable({ runs, onFixStream }: RunHistoryTableProps) {
     staleTime: 5 * 60 * 1000,
   })
 
+  const leagues = leaguesData?.leagues
+  const matchedStreams = matchedData?.streams
+  const failedFailures = failedData?.failures
+
   // League display lookup
   const getLeagueDisplay = useMemo(() => {
     const map = new Map<string, string>()
-    if (leaguesData?.leagues) {
-      for (const league of leaguesData.leagues) {
+    if (leagues) {
+      for (const league of leagues) {
         map.set(league.slug, getLeagueDisplayName(league, true))
       }
     }
     return (code: string | null) => (code ? (map.get(code) ?? code) : "-")
-  }, [leaguesData?.leagues])
+  }, [leagues])
 
   // Group dropdowns
   const matchedGroups = useMemo(() => {
-    if (!matchedData?.streams) return []
+    if (!matchedStreams) return []
     const groups = new Set<string>()
-    for (const s of matchedData.streams) if (s.group_name) groups.add(s.group_name)
+    for (const s of matchedStreams) if (s.group_name) groups.add(s.group_name)
     return Array.from(groups).sort()
-  }, [matchedData?.streams])
+  }, [matchedStreams])
 
   const failedGroups = useMemo(() => {
-    if (!failedData?.failures) return []
+    if (!failedFailures) return []
     const groups = new Set<string>()
-    for (const f of failedData.failures) if (f.group_name) groups.add(f.group_name)
+    for (const f of failedFailures) if (f.group_name) groups.add(f.group_name)
     return Array.from(groups).sort()
-  }, [failedData?.failures])
+  }, [failedFailures])
 
   // Filtered data
   const filteredMatchedStreams = useMemo(() => {
-    if (!matchedData?.streams) return []
+    if (!matchedStreams) return []
     const q = matchedFilter.toLowerCase()
-    return matchedData.streams.filter((s) => {
+    return matchedStreams.filter((s) => {
       if (matchedGroupFilter !== "all" && s.group_name !== matchedGroupFilter) return false
       if (!q) return true
       return (
@@ -199,12 +203,12 @@ export function RunHistoryTable({ runs, onFixStream }: RunHistoryTableProps) {
         s.league?.toLowerCase().includes(q)
       )
     })
-  }, [matchedData?.streams, matchedFilter, matchedGroupFilter])
+  }, [matchedStreams, matchedFilter, matchedGroupFilter])
 
   const filteredFailedMatches = useMemo(() => {
-    if (!failedData?.failures) return []
+    if (!failedFailures) return []
     const q = failedFilter.toLowerCase()
-    return failedData.failures.filter((f) => {
+    return failedFailures.filter((f) => {
       if (failedGroupFilter !== "all" && f.group_name !== failedGroupFilter) return false
       if (!q) return true
       return (
@@ -215,7 +219,7 @@ export function RunHistoryTable({ runs, onFixStream }: RunHistoryTableProps) {
         f.reason.toLowerCase().includes(q)
       )
     })
-  }, [failedData?.failures, failedFilter, failedGroupFilter])
+  }, [failedFailures, failedFilter, failedGroupFilter])
 
   const closeMatchedModal = () => {
     setMatchedModalRunId(null)

--- a/frontend/src/components/ScheduledChannelResetCard.tsx
+++ b/frontend/src/components/ScheduledChannelResetCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { SaveButton } from "@/components/ui/save-button"
@@ -35,12 +35,16 @@ export function ScheduledChannelResetCard() {
   const [enabled, setEnabled] = useState(false)
   const [cron, setCron] = useState("")
 
-  useEffect(() => {
-    if (schedulerData) {
-      setEnabled(schedulerData.channel_reset_enabled)
-      setCron(schedulerData.channel_reset_cron ?? "")
-    }
-  }, [schedulerData])
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedSchedulerData, setSyncedSchedulerData] =
+    useState<typeof schedulerData>(undefined)
+  if (schedulerData && schedulerData !== syncedSchedulerData) {
+    setSyncedSchedulerData(schedulerData)
+    setEnabled(schedulerData.channel_reset_enabled)
+    setCron(schedulerData.channel_reset_cron ?? "")
+  }
 
   const handleSave = async () => {
     try {

--- a/frontend/src/components/SortPriorityManager.tsx
+++ b/frontend/src/components/SortPriorityManager.tsx
@@ -120,11 +120,6 @@ export function SortPriorityManager({ showWhenSortBy = "sport_league_time", curr
   const reorderMutation = useReorderSortPriorities()
   const autoPopulateMutation = useAutoPopulateSortPriorities()
 
-  // Don't render if sort_by doesn't match
-  if (currentSortBy !== showWhenSortBy) {
-    return null
-  }
-
   // Transform priorities to HierarchicalItem format
   // First, build a map of sport codes to display names from sport-level entries
   const sportDisplayNames = useMemo(() => {
@@ -153,6 +148,11 @@ export function SortPriorityManager({ showWhenSortBy = "sport_league_time", curr
       },
     }))
   }, [priorities, sportDisplayNames])
+
+  // Don't render if sort_by doesn't match (after hooks — rules of hooks)
+  if (currentSortBy !== showWhenSortBy) {
+    return null
+  }
 
   const handleReorder = async (newOrder: Array<{ group: string; child: string | null; priority: number }>) => {
     const reorderData: SortPriorityReorderItem[] = newOrder.map(item => ({

--- a/frontend/src/components/StatusStrip.tsx
+++ b/frontend/src/components/StatusStrip.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { CheckCircle, XCircle, AlertTriangle, Clock, Tv, Target, Copy, Check, Loader2 } from "lucide-react"
 import { useDispatcharrStatus } from "@/hooks/useSettings"
@@ -9,6 +9,10 @@ import { getTeamXmltvUrl } from "@/api/epg"
 import type { ProcessingRun } from "@/api/epg"
 
 const DAY_MS = 24 * 60 * 60 * 1000
+
+// While a run is active the strip's values are mid-recompute — this spinner
+// renders in their place until the run finishes and the fresh numbers land.
+const Spinner = () => <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
 
 function formatDuration(ms: number | null | undefined): string | null {
   if (!ms) return null
@@ -33,9 +37,13 @@ export function StatusStrip({ lastRun }: { lastRun?: ProcessingRun }) {
   const { isGenerating } = useGenerationProgress()
   const [copied, setCopied] = useState(false)
 
-  // While a run is active these three values are mid-recompute — show a spinner
-  // in their place until the run finishes and the fresh numbers land.
-  const Spinner = () => <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+  // Clock for the staleness chip: state instead of Date.now()-in-render
+  // (render purity), refreshed each minute so the color also updates live.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [])
 
   const epgUrl = `${window.location.origin}${getTeamXmltvUrl()}`
 
@@ -81,7 +89,7 @@ export function StatusStrip({ lastRun }: { lastRun?: ProcessingRun }) {
 
   // --- Last generated chip ---
   const finishedAt = lastRun?.completed_at ?? lastRun?.started_at ?? null
-  const ageMs = finishedAt ? Date.now() - new Date(finishedAt).getTime() : null
+  const ageMs = finishedAt ? now - new Date(finishedAt).getTime() : null
   const failed = lastRun ? lastRun.status === "failed" || lastRun.status === "cancelled" : false
 
   // Color: red if never/failed or >3 days; amber 1–3 days; green <1 day.

--- a/frontend/src/components/TeamEpgSettingsCard.tsx
+++ b/frontend/src/components/TeamEpgSettingsCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -31,12 +31,20 @@ export function TeamEpgSettingsCard() {
   const [epg, setEPG] = useState<EPGSettings | null>(null)
   const [display, setDisplay] = useState<DisplaySettings | null>(null)
 
-  useEffect(() => {
-    if (epgData) setEPG(epgData)
-  }, [epgData])
-  useEffect(() => {
-    if (displayData) setDisplay(displayData)
-  }, [displayData])
+  // Sync the forms from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effects, without the extra effect render pass.
+  const [syncedEpgData, setSyncedEpgData] = useState<typeof epgData>(undefined)
+  if (epgData && epgData !== syncedEpgData) {
+    setSyncedEpgData(epgData)
+    setEPG(epgData)
+  }
+  const [syncedDisplayData, setSyncedDisplayData] =
+    useState<typeof displayData>(undefined)
+  if (displayData && displayData !== syncedDisplayData) {
+    setSyncedDisplayData(displayData)
+    setDisplay(displayData)
+  }
 
   const handleSave = async () => {
     try {

--- a/frontend/src/components/TemplateAssignmentModal/index.tsx
+++ b/frontend/src/components/TemplateAssignmentModal/index.tsx
@@ -76,16 +76,19 @@ export function TemplateAssignmentManager({
   const { data: templates } = useTemplates()
   const eventTemplates = templates?.filter((t) => t.template_type === "event") || []
 
-  // Fetch sports for dropdown
+  // Fetch sports for dropdown. useMemo (not `|| {}`): a fresh fallback object
+  // would destabilize every downstream hook dependency (exhaustive-deps).
   const { data: sportsData } = useSports()
-  const sportsMap = sportsData?.sports || {}
+  const sports = sportsData?.sports
+  const sportsMap = useMemo(() => sports ?? {}, [sports])
 
   // Fetch leagues for display
   const { data: leaguesData } = useQuery({
     queryKey: ["leagues"],
     queryFn: () => getLeagues(),
   })
-  const allLeagues = leaguesData?.leagues || []
+  const leaguesList = leaguesData?.leagues
+  const allLeagues = useMemo(() => leaguesList ?? [], [leaguesList])
 
   // Get unique sports from subscribed leagues (sorted)
   const subscribedSports = useMemo(() =>

--- a/frontend/src/components/TestPatternsModal/index.tsx
+++ b/frontend/src/components/TestPatternsModal/index.tsx
@@ -9,7 +9,7 @@
  * 5. Syncs patterns bidirectionally with the form (reads on open, writes on Apply)
  */
 
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   Dialog,
@@ -116,12 +116,20 @@ export function TestPatternsModal({
     streamName: string
   } | null>(null)
 
-  // Sync form → modal when opening
-  useEffect(() => {
+  // Sync form → modal when opening. Seeded during render (React's "adjusting
+  // state when a prop changes" pattern) — fires on exactly the same trigger as
+  // the previous effect: any change to `open` or `initialPatterns`, seeding
+  // only while the modal is open, without the extra effect render pass.
+  const [syncedSeedProps, setSyncedSeedProps] = useState<{
+    open: boolean
+    initialPatterns: Partial<PatternState> | undefined
+  }>({ open: false, initialPatterns: undefined })
+  if (open !== syncedSeedProps.open || initialPatterns !== syncedSeedProps.initialPatterns) {
+    setSyncedSeedProps({ open, initialPatterns })
     if (open && initialPatterns) {
       setPatterns({ ...EMPTY_PATTERNS, ...initialPatterns })
     }
-  }, [open, initialPatterns])
+  }
 
   // Fetch raw streams
   const {

--- a/frontend/src/components/VariablePicker.tsx
+++ b/frontend/src/components/VariablePicker.tsx
@@ -26,12 +26,14 @@ export function VariablePicker({
     staleTime: Infinity, // Variables don't change during session
   })
 
+  const categories = data?.categories
+
   const filteredCategories = useMemo(() => {
-    if (!data?.categories) return []
-    if (!search.trim()) return data.categories
+    if (!categories) return []
+    if (!search.trim()) return categories
 
     const searchLower = search.toLowerCase()
-    return data.categories
+    return categories
       .map((cat) => ({
         ...cat,
         variables: cat.variables.filter(
@@ -41,7 +43,7 @@ export function VariablePicker({
         ),
       }))
       .filter((cat) => cat.variables.length > 0)
-  }, [data?.categories, search])
+  }, [categories, search])
 
   const handleSelect = (variable: Variable, suffix?: string) => {
     const varName = suffix && suffix !== "base" ? `${variable.name}${suffix}` : variable.name

--- a/frontend/src/components/XmltvMetadataCard.tsx
+++ b/frontend/src/components/XmltvMetadataCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -19,9 +19,15 @@ export function XmltvMetadataCard() {
 
   const [display, setDisplay] = useState<DisplaySettings | null>(null)
 
-  useEffect(() => {
-    if (displayData) setDisplay(displayData)
-  }, [displayData])
+  // Sync the form from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedDisplayData, setSyncedDisplayData] =
+    useState<typeof displayData>(undefined)
+  if (displayData && displayData !== syncedDisplayData) {
+    setSyncedDisplayData(displayData)
+    setDisplay(displayData)
+  }
 
   const handleSave = async () => {
     if (!display) return

--- a/frontend/src/hooks/useRowSelection.ts
+++ b/frontend/src/hooks/useRowSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 /**
  * Multi-select state for table rows keyed by numeric id, with optional
@@ -16,7 +16,11 @@ import { useCallback, useRef, useState } from "react"
 export function useRowSelection<Row extends { id: number }>(rows: Row[]) {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const rowsRef = useRef(rows)
-  rowsRef.current = rows
+  // Latest-ref pattern, updated post-commit: toggle/toggleAll only read it
+  // from event handlers, which always fire after the effect has run.
+  useEffect(() => {
+    rowsRef.current = rows
+  }, [rows])
   // Range anchor. A ref, not state: it never needs to trigger a render.
   const lastClickedIndexRef = useRef<number | null>(null)
 

--- a/frontend/src/lib/pattern-generator.ts
+++ b/frontend/src/lib/pattern-generator.ts
@@ -158,7 +158,7 @@ export function generatePattern(
     }
     // For date-related fields, also anchor on date separators (/, ., -)
     if (!anchorBefore && (field === "month" || field === "day" || field === "date")) {
-      const dateSepMatch = before.match(/[/.\-]\s*$/)
+      const dateSepMatch = before.match(/[/.-]\s*$/)
       if (dateSepMatch) {
         anchorBefore = escapeRegex(dateSepMatch[0])
       }
@@ -177,7 +177,7 @@ export function generatePattern(
     }
     // For date-related fields, also anchor on date separators
     if (!anchorAfter && (field === "month" || field === "day" || field === "date")) {
-      const dateSepMatch = after.match(/^\s*[/.\-]/)
+      const dateSepMatch = after.match(/^\s*[/.-]/)
       if (dateSepMatch) {
         anchorAfter = escapeRegex(dateSepMatch[0])
       }

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -87,7 +87,10 @@ export function EventGroupForm() {
     queryKey: ["leagues"],
     queryFn: () => getLeagues(),
   })
-  const allLeagues = leaguesData?.leagues || []
+  // useMemo (not `|| []`): a fresh fallback array would destabilize every
+  // downstream hook dependency (react-hooks/exhaustive-deps).
+  const leaguesList = leaguesData?.leagues
+  const allLeagues = useMemo(() => leaguesList ?? [], [leaguesList])
 
   const matchGlobal = useCallback(async () => {
     setMatchingGlobal(true)

--- a/frontend/src/pages/TemplateForm.tsx
+++ b/frontend/src/pages/TemplateForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react"
+import { useState, useRef, useMemo } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 import { ArrowLeft, User, Tv, ArrowRight } from "lucide-react"
@@ -80,10 +80,10 @@ export function TemplateForm() {
 
   // Keep the preview league valid against the fetched list. Prefer a subscribed
   // league (nba if subscribed, else the first subscribed), then nba, then the
-  // first available league.
-  useEffect(() => {
-    if (previewLeagues.length === 0) return
-    if (previewLeagues.some((l) => l.slug === previewLeague)) return
+  // first available league. Adjusted during render (React's "adjusting state
+  // when a prop changes" pattern) — the guard is self-correcting: once the
+  // league is in the list the branch no longer fires.
+  if (previewLeagues.length > 0 && !previewLeagues.some((l) => l.slug === previewLeague)) {
     const subscribed = new Set(subscribedSlugs)
     const fallback =
       (subscribed.has("nba") ? previewLeagues.find((l) => l.slug === "nba") : undefined) ??
@@ -91,7 +91,7 @@ export function TemplateForm() {
       previewLeagues.find((l) => l.slug === "nba") ??
       previewLeagues[0]
     setPreviewLeague(fallback.slug)
-  }, [previewLeagues, subscribedSlugs, previewLeague])
+  }
 
   // Fetch sample data for preview (league-specific, optionally live)
   const { data: samplesData } = useQuery({
@@ -105,14 +105,17 @@ export function TemplateForm() {
   const resolveTemplate = createResolver(sampleData)
   const isLivePreview = samplesData?.live ?? false
 
-  // Build validation set from variables data
+  // Build validation set from variables data. The optional chain is hoisted
+  // out of the memo so the manual dependency matches what the React Compiler
+  // infers (preserve-manual-memoization).
+  const variableCategories = variablesData?.categories
   const validationData = useMemo(() => {
-    if (!variablesData?.categories) {
+    if (!variableCategories) {
       return { validNames: new Set<string>(), baseNames: new Set<string>() }
     }
-    const { validNames, baseNames } = buildValidVariableSet(variablesData.categories)
+    const { validNames, baseNames } = buildValidVariableSet(variableCategories)
     return { validNames, baseNames }
-  }, [variablesData?.categories])
+  }, [variableCategories])
 
   // Helper to merge filler content with defaults, ensuring no null values
   const mergeFillerContent = (content: FillerContent | null, defaults: FillerContent): FillerContent => {
@@ -125,39 +128,41 @@ export function TemplateForm() {
     }
   }
 
-  // Populate form when template loads
-  useEffect(() => {
-    if (template) {
-      setFormData({
-        name: template.name,
-        template_type: template.template_type,
-        sport: template.sport,
-        league: template.league,
-        title_format: template.title_format || "",
-        subtitle_template: template.subtitle_template,
-        description_template: template.description_template,
-        program_art_url: template.program_art_url,
-        game_duration_mode: template.game_duration_mode || "sport",
-        game_duration_override: template.game_duration_override,
-        xmltv_flags: template.xmltv_flags || { new: true, live: false, date: false },
-        xmltv_video: template.xmltv_video || { enabled: false, quality: "HDTV" },
-        xmltv_categories: template.xmltv_categories || ["Sports"],
-        xmltv_filler_categories: template.xmltv_filler_categories || [],
-        pregame_enabled: template.pregame_enabled ?? true,
-        pregame_fallback: mergeFillerContent(template.pregame_fallback, DEFAULT_PREGAME),
-        postgame_enabled: template.postgame_enabled ?? true,
-        postgame_fallback: mergeFillerContent(template.postgame_fallback, DEFAULT_POSTGAME),
-        postgame_conditional: template.postgame_conditional || { enabled: true, title_final: null, title_not_final: null, subtitle_final: null, subtitle_not_final: null, description_final: null, description_not_final: null },
-        idle_enabled: template.idle_enabled ?? true,
-        idle_content: mergeFillerContent(template.idle_content, DEFAULT_IDLE),
-        idle_conditional: template.idle_conditional || { enabled: true, title_final: null, title_not_final: null, subtitle_final: null, subtitle_not_final: null, description_final: null, description_not_final: null },
-        idle_offseason: template.idle_offseason || { title_enabled: false, title: null, subtitle_enabled: false, subtitle: null, description_enabled: false, description: null },
-        conditional_descriptions: template.conditional_descriptions || [],
-        event_channel_name: template.event_channel_name,
-        event_channel_logo_url: template.event_channel_logo_url,
-      })
-    }
-  }, [template])
+  // Populate form from the server template during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedTemplate, setSyncedTemplate] = useState<typeof template>(undefined)
+  if (template && template !== syncedTemplate) {
+    setSyncedTemplate(template)
+    setFormData({
+      name: template.name,
+      template_type: template.template_type,
+      sport: template.sport,
+      league: template.league,
+      title_format: template.title_format || "",
+      subtitle_template: template.subtitle_template,
+      description_template: template.description_template,
+      program_art_url: template.program_art_url,
+      game_duration_mode: template.game_duration_mode || "sport",
+      game_duration_override: template.game_duration_override,
+      xmltv_flags: template.xmltv_flags || { new: true, live: false, date: false },
+      xmltv_video: template.xmltv_video || { enabled: false, quality: "HDTV" },
+      xmltv_categories: template.xmltv_categories || ["Sports"],
+      xmltv_filler_categories: template.xmltv_filler_categories || [],
+      pregame_enabled: template.pregame_enabled ?? true,
+      pregame_fallback: mergeFillerContent(template.pregame_fallback, DEFAULT_PREGAME),
+      postgame_enabled: template.postgame_enabled ?? true,
+      postgame_fallback: mergeFillerContent(template.postgame_fallback, DEFAULT_POSTGAME),
+      postgame_conditional: template.postgame_conditional || { enabled: true, title_final: null, title_not_final: null, subtitle_final: null, subtitle_not_final: null, description_final: null, description_not_final: null },
+      idle_enabled: template.idle_enabled ?? true,
+      idle_content: mergeFillerContent(template.idle_content, DEFAULT_IDLE),
+      idle_conditional: template.idle_conditional || { enabled: true, title_final: null, title_not_final: null, subtitle_final: null, subtitle_not_final: null, description_final: null, description_not_final: null },
+      idle_offseason: template.idle_offseason || { title_enabled: false, title: null, subtitle_enabled: false, subtitle: null, description_enabled: false, description: null },
+      conditional_descriptions: template.conditional_descriptions || [],
+      event_channel_name: template.event_channel_name,
+      event_channel_logo_url: template.event_channel_logo_url,
+    })
+  }
 
   const createMutation = useMutation({
     mutationFn: createTemplate,

--- a/frontend/src/pages/channels/ChannelConsolidation.tsx
+++ b/frontend/src/pages/channels/ChannelConsolidation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -37,9 +37,15 @@ export function ChannelConsolidation() {
     force_channel_relayout_pending: false,
   })
 
-  useEffect(() => {
-    if (channelNumberingData) setChannelNumbering(channelNumberingData)
-  }, [channelNumberingData])
+  // Sync local state from the server data during render (React's "adjusting
+  // state when a prop changes" pattern) — re-seeds on every refetch, exactly
+  // like the previous effect, without the extra effect render pass.
+  const [syncedChannelNumberingData, setSyncedChannelNumberingData] =
+    useState<typeof channelNumberingData>(undefined)
+  if (channelNumberingData && channelNumberingData !== syncedChannelNumberingData) {
+    setSyncedChannelNumberingData(channelNumberingData)
+    setChannelNumbering(channelNumberingData)
+  }
 
   return (
     <div className="space-y-3">

--- a/frontend/src/pages/channels/ChannelLifecycle.tsx
+++ b/frontend/src/pages/channels/ChannelLifecycle.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { SaveButton } from "@/components/ui/save-button"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -21,13 +21,14 @@ export function ChannelLifecycle() {
 
   const [lifecycle, setLifecycle] = useState<LifecycleSettings | null>(null)
 
-  const initRef = useRef(false)
-  useEffect(() => {
-    if (settings && !initRef.current) {
-      initRef.current = true
-      setLifecycle(settings.lifecycle)
-    }
-  }, [settings])
+  // Seed local state from the server blob during render (React's "adjusting
+  // state when a prop changes" pattern). The previous effect seeded ONCE
+  // (initRef guard) — `lifecycle === null` preserves that: it is only null
+  // before the first seed, and every later setLifecycle spreads a non-null
+  // object, so refetches never re-seed.
+  if (settings && lifecycle === null) {
+    setLifecycle(settings.lifecycle)
+  }
 
   return (
     <Card>

--- a/frontend/src/pages/template-form/TemplateField.tsx
+++ b/frontend/src/pages/template-form/TemplateField.tsx
@@ -83,7 +83,9 @@ export function TemplateField({
   onChange,
   placeholder,
   helpText,
-  fieldRefs,
+  // Aliased to a *Ref name so the React Compiler recognizes it as a ref and
+  // allows the ref-callback mutation below (its ref detection is name-based).
+  fieldRefs: fieldRefsRef,
   setLastFocusedField,
   multiline = false,
   resolveTemplate = defaultResolver,
@@ -122,7 +124,7 @@ export function TemplateField({
         <Textarea
           id={id}
           ref={(el) => {
-            if (fieldRefs) fieldRefs.current[id] = el
+            if (fieldRefsRef) fieldRefsRef.current[id] = el
           }}
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -134,7 +136,7 @@ export function TemplateField({
         <Input
           id={id}
           ref={(el) => {
-            if (fieldRefs) fieldRefs.current[id] = el
+            if (fieldRefsRef) fieldRefsRef.current[id] = el
           }}
           value={value}
           onChange={(e) => onChange(e.target.value)}

--- a/frontend/src/pages/template-form/tabs/BasicTab.tsx
+++ b/frontend/src/pages/template-form/tabs/BasicTab.tsx
@@ -3,7 +3,9 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { TabProps } from "../types"
 
-export function BasicTab({ formData, setFormData, fieldRefs, setLastFocusedField }: TabProps) {
+// fieldRefs aliased to a *Ref name so the React Compiler recognizes it as a
+// ref and allows the ref-callback mutation (its ref detection is name-based).
+export function BasicTab({ formData, setFormData, fieldRefs: fieldRefsRef, setLastFocusedField }: TabProps) {
   return (
     <div className="space-y-6">
       {/* Template Name */}
@@ -17,7 +19,7 @@ export function BasicTab({ formData, setFormData, fieldRefs, setLastFocusedField
             <Input
               id="name"
               ref={(el) => {
-                if (fieldRefs) fieldRefs.current["name"] = el
+                if (fieldRefsRef) fieldRefsRef.current["name"] = el
               }}
               value={formData.name}
               onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}


### PR DESCRIPTION
## Summary
Completes the ESLint burndown under #292: the ESLint (advisory) CI check should go **green on dev for the first time** when this merges (matching Pyright, green since #294).

Fix patterns by rule:
- **set-state-in-effect (18)** — every data-seeding effect converted to React's render-time "adjusting state when a prop changes" pattern (`const [synced, setSynced] = useState(...)` + compare-and-set during render). Behavior-identical minus one effect render pass; re-seeds on refetch exactly as before. Reference implementation: `DispatcharrOutputSettings.tsx`.
- **preserve-manual-memoization (10)** — root cause everywhere was an optional-chained value (`obj?.prop`) in a deps array; bound to a plain const above the memo. No memo deleted.
- **static-components (3+2)** — render-created components inlined as JSX variables or hoisted to module scope (2 extra were masked in StatusStrip behind its purity error — compiler errors hide siblings in the same file).
- **rules-of-hooks (2)** — early return moved below hooks (SortPriorityManager).
- **immutability (3)** — the compiler's ref detection is name-based (`*Ref` suffix); the `fieldRefs` prop (plural) defeated it. Destructure-alias `fieldRefs: fieldRefsRef` fixes it with no signature change.
- **refs (1)** — `useRowSelection`'s render-time latest-ref write moved to a post-commit effect (handlers only read it from events, after commit).
- **purity (1)** — StatusStrip's `Date.now()` in render replaced with minute-interval state; the staleness chip now also updates live.
- Also: 2 `no-useless-escape` stragglers missed by #295's rule-summary grep, 6 `exhaustive-deps` warnings (fresh `|| []` fallbacks), and CLAUDE.md's stale `bd sync` reference.

Remaining (acceptable): 2 warnings — react-window "incompatible library" (compiler skips those two components; unfixable without replacing the lib). Warnings don't fail the advisory job.

## Test plan
- [x] `npx eslint src` — **0 errors** (was 40), 2 pre-existing library warnings
- [x] `npm run build` — clean
- [x] `ruff check` + `pytest` — 1379 passed (no backend changes)
- [x] Playwright over the touched surfaces on the live dev instance: Dashboard (StatusStrip clock/age chip, run history, managed channels), Templates list + **template editor** (form seeds from server, variable picker, live preview 147/194), Channel Lifecycle + Consolidation, Dispatcharr Output (profile checkboxes/custom group mode seed correctly), Matching page (buffer values seed) — zero console errors everywhere