### PR TITLE
feat: add SHL (Swedish Hockey League) via TSDB (#276)

### DIFF
--- a/docs/guide/settings/general.md
+++ b/docs/guide/settings/general.md
@@ -65,7 +65,7 @@ Optional premium API key for TheSportsDB. The card header shows your current tie
 | **Free** | 30 req/min | Limited (a few events per league per day) | Free |
 | **Premium** | 100 req/min | Full event coverage | ~$9/mo |
 
-Some TSDB leagues (CFL, Unrivaled, boxing, Norwegian hockey) work fine on the free tier. Premium leagues — AFL, cricket (IPL, BBL, SA20), and Svenska Cupen — need a premium key for full event coverage. The league picker shows a crown icon on premium leagues.
+Some TSDB leagues (CFL, Unrivaled, boxing, Norwegian hockey) work fine on the free tier. Premium leagues — AFL, SHL (Swedish Hockey League), cricket (IPL, BBL, SA20), and Svenska Cupen — need a premium key for full event coverage. The league picker shows a crown icon on premium leagues.
 
 Use the **Validate** button to test your key before saving. Get a key at [thesportsdb.com/pricing](https://www.thesportsdb.com/pricing).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 
 ## Features
 
-- **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 140 pre-configured leagues plus dynamically discovered soccer leagues.
+- **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 141 pre-configured leagues plus dynamically discovered soccer leagues.
 - **240 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
 - **Flexible matching** - Aliases, fuzzy matching, and configurable stream ordering to handle inconsistent IPTV naming
 - **Channel groups & profiles** - Use existing Dispatcharr groups/profiles or create them dynamically using variables and wildcards

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,7 +13,7 @@ Developer documentation covering Teamarr's architecture, data providers, databas
 
 | Section | Contents |
 |---------|----------|
-| [Supported Leagues](supported-leagues) | All 140 pre-configured leagues and ~250 discovered soccer leagues, organized by sport |
+| [Supported Leagues](supported-leagues) | All 141 pre-configured leagues and ~250 discovered soccer leagues, organized by sport |
 | [Providers](providers/) | Data provider system — ESPN, Squiggle, MLB Stats, HockeyTech, TheSportsDB, Supabase — priority chain, API details, rate limiting |
 | [Architecture](architecture/) | API layer, consumer layer, Dispatcharr integration, detection keywords, database, template engine, migrations |
 | [Frontend](frontend/) | React + TypeScript + Vite architecture, component library, state management |

--- a/docs/reference/providers/tsdb.md
+++ b/docs/reference/providers/tsdb.md
@@ -40,6 +40,7 @@ These leagues have low enough event volume to work within free tier limits:
 These leagues have high event volume or unreliable free-tier data and require a premium key for full coverage:
 
 - AFL (Australian football)
+- SHL (Swedish Hockey League) — a full ~52-round, 14-team season far exceeds the free tier's 15-events/call cap
 - IPL, BBL, SA20 (cricket)
 - Svenska Cupen and other regional soccer leagues (Canadian Premier League, Swedish Superettan / Division 1, Icelandic, Venezuelan, Gambian, Aruban, Northern Irish)
 - IMSA and WEC (motor racing). WEC's 62 events/season exceeds the free `eventsseason.php` 15-event cap; IMSA fits it but is gated premium too, so all TSDB racing is premium (no silent truncation if a schedule grows).
@@ -61,6 +62,7 @@ Get a key at [thesportsdb.com/pricing](https://www.thesportsdb.com/pricing).
 | Unrivaled | `unrivaled` | 5622 | Basketball | Free |
 | Norwegian Fjordkraft-ligaen | `norwegian-hockey` | 4926 | Hockey | Free |
 | Boxing | `boxing` | 4445 | Boxing | Free |
+| Swedish Hockey League | `shl` | 4419 | Hockey | Premium |
 | Australian Football League | `afl` | 4456 | Australian Football | Premium |
 | Indian Premier League | `ipl` | 4460 | Cricket | Premium |
 | Big Bash League | `bbl` | 4461 | Cricket | Premium |

--- a/docs/reference/supported-leagues.md
+++ b/docs/reference/supported-leagues.md
@@ -7,7 +7,7 @@ docs_version: "2.3.1"
 
 # Supported Sports & Leagues
 
-Teamarr supports **140 pre-configured leagues** across 15 sports, plus **~250 dynamically discovered soccer leagues** from ESPN. Pre-configured leagues have full support (team import + event matching). Discovered leagues support event matching only.
+Teamarr supports **141 pre-configured leagues** across 15 sports, plus **~250 dynamically discovered soccer leagues** from ESPN. Pre-configured leagues have full support (team import + event matching). Discovered leagues support event matching only.
 
 ## Support Levels
 
@@ -121,6 +121,7 @@ TSDB leagues are classified by tier. Most work on the free tier. Leagues marked 
 | League | ID | Provider |
 |--------|-----|----------|
 | Norwegian Fjordkraft-ligaen | `norwegian-hockey` | TSDB |
+| Swedish Hockey League | `shl` | TSDB |
 
 ---
 

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1004,6 +1004,7 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
 
     -- Hockey - European Leagues (TSDB)
     ('norwegian-hockey', 'tsdb', '4926', 'Norwegian Fjordkraft-ligaen', 'Norwegian Fjordkraft-ligaen', 'hockey', 'https://r2.thesportsdb.com/images/media/league/badge/lpfdvc1697194460.png', NULL, 1, NULL, 'norwegian-hockey', 'team_vs_team', NULL, NULL, NULL, 'free', 1),
+    ('shl', 'tsdb', '4419', 'Swedish Hockey League', 'Swedish Hockey League', 'hockey', 'https://r2.thesportsdb.com/images/media/league/badge/95fnqb1547547893.png', NULL, 1, 'SHL', 'shl', 'team_vs_team', NULL, NULL, NULL, 'premium', 1),
 
     -- Australian Football (TSDB)
     ('afl', 'squiggle', 'afl', NULL, 'Australian Football League', 'australian-football', 'https://r2.thesportsdb.com/images/media/league/badge/wvx4721525519372.png', NULL, 1, 'AFL', 'afl', 'team_vs_team', 'AFL', NULL, NULL, NULL, 1),


### PR DESCRIPTION
Closes the implementation for #276.

## Summary
Adds **Swedish Hockey League (SHL)** as a premium-tier TSDB league (TheSportsDB id `4419`), mirroring the existing Norwegian hockey row. No new provider code — the generic TSDB provider keys off `provider_league_id`.

## Why premium tier
SHL is a full ~52-round, 14-team season, which exceeds the free tier's 15-events/call cap. Per policy it's gated `tsdb_tier='premium'` and auto-skipped in cache refresh when no premium key is configured.

## Changes
- `schema.sql`: `INSERT OR REPLACE INTO leagues` row for `shl` (provider `tsdb`, sport `hockey`, alias `SHL`, `team_vs_team`, premium). Applied on restart via schema reconciliation.
- Docs (per new-league table): supported-leagues hockey section + count 140→141, tsdb.md league table + premium list, index count claims (docs/index.md, docs/reference/index.md), settings general premium-league list.

## Testing
- `ruff check` clean
- `pytest tests/` — 1393 passed
- `npm run build` — clean
- Verified `schema.sql` loads and the SHL row materializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)