### PR TITLE
fix(tennis): feed fan-out guards, deterministic event ids, multi-event rotation (#316)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -88,6 +88,8 @@ Set these on a Source in the editor (and at bulk add / bulk edit). **EPG** requi
 
 The **Event Lookahead** controls how far ahead Teamarr matches streams to sporting events — streams are matched only to events within this window. Default is 3 days; options are 1, 3, 7, 14, or 30 days.
 
+**Tennis: majors only** (same card) restricts tennis matching to the four Grand Slams (Australian Open, French Open, Wimbledon, US Open). Smaller ATP/WTA tournaments are ignored entirely — no channels are created for them. Off by default.
+
 ## EPG Program Matching
 
 Traditional linear channels (ESPN, NBA1, FS1) carry many different games across a day under a single static stream name, so Teamarr can't match them by name. **EPG program-data matching** uses Dispatcharr's program guide to match these streams to events by the program *title* (e.g. "MLB Baseball" / "Chicago Cubs at St. Louis Cardinals"), then **time-shares** one linear stream across many event channels — attaching it to each event's channel only near game time and detaching it after.

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -60,6 +60,7 @@ export interface EPGSettings {
   epg_channel_source_groups: number[]
   epg_stream_pre_buffer_minutes: number
   epg_stream_post_buffer_minutes: number
+  tennis_majors_only: boolean
   /** Game-thumbs base URL prefixed onto relative art paths in templates (z02s). */
   art_base_url: string
 }

--- a/frontend/src/components/EventMatchingSettings.tsx
+++ b/frontend/src/components/EventMatchingSettings.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Select } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { ToggleCard } from "@/components/ui/toggle-card"
 import { CheckboxListPicker } from "@/components/ui/checkbox-list-picker"
 import {
@@ -220,6 +221,28 @@ export function EventLookaheadSetting() {
           </Select>
           <p className="text-xs text-muted-foreground">
             How many days of upcoming events to match streams against.
+          </p>
+        </div>
+
+        {/* Same card + save as the lookahead: both edit the shared epg blob,
+            and two full-PUT components in one view would overwrite each other. */}
+        <div className="space-y-2 border-t pt-4">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="tennis-majors-only"
+              checked={epg?.tennis_majors_only ?? false}
+              onCheckedChange={(checked) =>
+                epg && setEPG({ ...epg, tennis_majors_only: checked })
+              }
+            />
+            <Label htmlFor="tennis-majors-only" className="cursor-pointer">
+              Tennis: majors only
+            </Label>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Only match Grand Slam tournaments (Australian Open, French Open, Wimbledon,
+            US Open). Smaller ATP/WTA tournaments are ignored entirely — no channels are
+            created for them.
           </p>
         </div>
 

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -224,6 +224,7 @@ class EPGSettingsModel(BaseModel):
     epg_channel_source_groups: list[int] = []
     epg_stream_pre_buffer_minutes: int = 60
     epg_stream_post_buffer_minutes: int = 60
+    tennis_majors_only: bool = False
     art_base_url: str = ""
 
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -64,7 +64,8 @@ class StreamMatching:
             row = conn.execute(
                 "SELECT include_final_events, "
                 "epg_xtream_fallback_enabled, epg_xtream_cache_hours, "
-                "event_match_days_back, event_match_days_ahead "
+                "event_match_days_back, event_match_days_ahead, "
+                "tennis_majors_only "
                 "FROM settings WHERE id = 1"
             ).fetchone()
             include_final_events = (
@@ -74,6 +75,7 @@ class StreamMatching:
             xtream_cache_hours = (row["epg_xtream_cache_hours"] if row else 24) or 24
             match_days_back = (row["event_match_days_back"] if row else 7) or 7
             match_days_ahead = (row["event_match_days_ahead"] if row else 3) or 3
+            tennis_majors_only = bool(row["tennis_majors_only"]) if row else False
 
             # Load feed separation settings
             feed_settings = get_feed_separation_settings(conn)
@@ -132,6 +134,7 @@ class StreamMatching:
             feed_home_terms=feed_home_terms,
             feed_away_terms=feed_away_terms,
             name_match_enabled=group.name_match_enabled,
+            tennis_majors_only=tennis_majors_only,
             team_streams_enabled=group.team_streams_enabled,
             epg_index=epg_index,
         )

--- a/teamarr/consumers/lifecycle/cleanup.py
+++ b/teamarr/consumers/lifecycle/cleanup.py
@@ -294,8 +294,12 @@ class ChannelCleanup(_LifecycleHost):
         result = StreamProcessResult()
         current_ids_set = set(current_streams.keys())
 
-        # Build reverse index: stream_id → event_id (from current match results)
-        stream_event_map: dict[int, str] = {}
+        # Reverse index: stream_id → event_ids (from current match results).
+        # Multi-valued (#316): a fanned stream (tennis court/round feed, EPG
+        # time-share) legitimately matches MANY events per run — a single-value
+        # map kept only the last one, so every other channel it fed looked
+        # "rotated" and was deleted and recreated each generation.
+        stream_event_map: dict[int, set[str]] = {}
         if matched_streams:
             for ms in matched_streams:
                 stream_info = ms.get("stream", {})
@@ -304,7 +308,7 @@ class ChannelCleanup(_LifecycleHost):
                 segment = ms.get("card_segment")
                 if sid and event:
                     eid = f"{event.id}-{segment}" if segment else str(event.id)
-                    stream_event_map[sid] = eid
+                    stream_event_map.setdefault(sid, set()).add(eid)
 
         try:
             with self._db_factory() as conn:
@@ -361,13 +365,13 @@ class ChannelCleanup(_LifecycleHost):
                             # Cross-group stream: skip "missing from M3U" check
                             # But still check event rotation if we have match data
                             if stream_event_map and channel_event_id:
-                                matched_event = stream_event_map.get(stream_id)
-                                if matched_event and matched_event != channel_event_id:
+                                matched_events = stream_event_map.get(stream_id)
+                                if matched_events and channel_event_id not in matched_events:
                                     changed_streams.append(
                                         {
                                             "stream": s,
                                             "old_name": stored_name,
-                                            "new_name": f"rotated: {matched_event}",
+                                            "new_name": f"rotated: {sorted(matched_events)[0]}",
                                             "reason": "event_rotated",
                                         }
                                     )
@@ -384,11 +388,13 @@ class ChannelCleanup(_LifecycleHost):
                         current_stream = current_streams.get(stream_id, {})
                         current_name = current_stream.get("name", "")
 
-                        # Event-aware validation (when match data available)
+                        # Event-aware validation (when match data available).
+                        # Rotation = the stream's current match set no longer
+                        # CONTAINS this channel's event (fanned feeds match many).
                         if stream_event_map and channel_event_id:
-                            matched_event = stream_event_map.get(stream_id)
-                            if matched_event and matched_event != channel_event_id:
-                                # Stream now matches a different event → content rotated
+                            matched_events = stream_event_map.get(stream_id)
+                            if matched_events and channel_event_id not in matched_events:
+                                # Stream now matches different event(s) → content rotated
                                 changed_streams.append(
                                     {
                                         "stream": s,
@@ -399,10 +405,10 @@ class ChannelCleanup(_LifecycleHost):
                                 )
                                 logger.debug(
                                     "[LIFECYCLE] Stream %d rotated: "
-                        "channel event=%s, now matched to=%s",
+                                    "channel event=%s, now matched to=%s",
                                     stream_id,
                                     channel_event_id,
-                                    matched_event,
+                                    sorted(matched_events),
                                 )
                                 continue
 
@@ -410,9 +416,10 @@ class ChannelCleanup(_LifecycleHost):
                         if stored_name and current_name and stored_name != current_name:
                             # Name changed — check if it's still the same event
                             if stream_event_map:
-                                matched_event = stream_event_map.get(stream_id)
-                                if matched_event and (
-                                    not channel_event_id or matched_event == channel_event_id
+                                matched_events = stream_event_map.get(stream_id)
+                                if matched_events and (
+                                    not channel_event_id
+                                    or channel_event_id in matched_events
                                 ):
                                     # Same event, just renamed — update stored name, keep
                                     update_stream_name(conn, channel.id, stream_id, current_name)

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -231,6 +231,7 @@ class StreamMatcher:
         feed_away_terms: list[str] | None = None,
         name_match_enabled: bool = True,
         team_streams_enabled: bool = False,
+        tennis_majors_only: bool = False,
         epg_index: "EPGProgramIndex | None" = None,
     ):
         """Initialize the matcher.
@@ -346,7 +347,9 @@ class StreamMatcher:
         )
         self._event_matcher = EventCardMatcher(service, self._cache)
         self._racing_matcher = RacingMatcher(service, self._cache)
-        self._tennis_matcher = TennisMatcher(service, self._cache)
+        self._tennis_matcher = TennisMatcher(
+            service, self._cache, majors_only=tennis_majors_only
+        )
 
         # League event types + sports cache
         self._league_event_types: dict[str, str] = {}

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -1748,6 +1748,7 @@ class TeamMatcher:
                 round_name=cached_data.get("round_name"),
                 court=cached_data.get("court"),
                 draw_type=cached_data.get("draw_type"),
+                is_major=bool(cached_data.get("is_major", False)),
             )
         except Exception as e:
             logger.warning("[MATCH_CACHE] Failed to reconstruct event from cache: %s", e)

--- a/teamarr/consumers/matching/tennis_matcher.py
+++ b/teamarr/consumers/matching/tennis_matcher.py
@@ -206,9 +206,14 @@ class TennisMatcher:
         self,
         service: SportsDataService,
         cache: StreamMatchCache,
+        majors_only: bool = False,
     ):
         self._service = service
         self._cache = cache
+        # Only match grand-slam tournaments (#283): ESPN marks tournaments
+        # major=true; with the flag on, smaller tournaments never enter the
+        # candidate pool, so their channels are never created.
+        self._majors_only = majors_only
 
     def match(
         self,
@@ -412,6 +417,7 @@ class TennisMatcher:
         events: list[Event] = []
         for offset in (-1, 0, 1):
             events.extend(self._service.get_events(league, match_date + timedelta(days=offset)))
+        events = self._apply_majors_filter(events)
         return [
             e for e in events if e.start_time.astimezone(user_tz).date() == match_date
         ]
@@ -428,11 +434,18 @@ class TennisMatcher:
             events.extend(self._service.get_events(league, match_date + timedelta(days=offset)))
         window_start = match_date - timedelta(days=self._FALLBACK_LOOKBACK_DAYS)
         window_end = match_date + timedelta(days=1)
+        events = self._apply_majors_filter(events)
         return [
             e
             for e in events
             if window_start <= e.start_time.astimezone(user_tz).date() <= window_end
         ]
+
+    def _apply_majors_filter(self, events: list[Event]) -> list[Event]:
+        """Drop non-major tournaments when tennis_majors_only is set (#283)."""
+        if not self._majors_only:
+            return events
+        return [e for e in events if e.is_major]
 
     def _check_cache(self, ctx: TennisMatchContext) -> MatchOutcome | None:
         """Check cache for existing match."""

--- a/teamarr/consumers/matching/tennis_matcher.py
+++ b/teamarr/consumers/matching/tennis_matcher.py
@@ -58,6 +58,81 @@ _COURT_PATTERNS = [
 # Ordinal / keyword round labels → canonical ESPN round.displayName form
 _ROUND_ORDINALS = {"first": "1", "second": "2", "third": "3", "fourth": "4"}
 
+# Tokens too generic to identify a tournament ("Hall of Fame Open" must match
+# on hall/fame, never on open/cup) — used by the feed tournament guard (#316).
+_GENERIC_TOURNAMENT_TOKENS = frozenset(
+    {
+        "atp", "wta", "tour", "tennis", "open", "cup", "championship",
+        "championships", "masters", "classic", "international", "invitational",
+        "presented", "by", "the", "for", "of", "and", "at", "in", "de", "du",
+    }
+)
+
+# Draw hints a feed stream can declare ("Ladies' Singles Semifinals").
+# normalize_text strips apostrophes, so match the flattened token forms.
+_DRAW_GENDER_HINTS = [
+    (re.compile(r"\b(?:ladies|womens?)\b"), "women"),
+    (re.compile(r"\b(?:gentlemens?|mens?)\b"), "men"),
+]
+_DRAW_TYPE_HINTS = [
+    (re.compile(r"\bmixed\b"), "mixed"),
+    (re.compile(r"\bsingles\b"), "singles"),
+    (re.compile(r"\bdoubles\b"), "doubles"),
+]
+
+
+def _extract_draw_hints(text: str) -> tuple[str | None, str | None]:
+    """(gender, type) a feed stream declares, e.g. ("women", "singles").
+
+    "Mixed" implies doubles with no gender split, so it wins over a stray
+    gender token and suppresses the gender hint.
+    """
+    draw_type = next((v for p, v in _DRAW_TYPE_HINTS if p.search(text)), None)
+    if draw_type == "mixed":
+        return None, "mixed"
+    gender = next((v for p, v in _DRAW_GENDER_HINTS if p.search(text)), None)
+    return gender, draw_type
+
+
+def _draw_key(draw_type: str | None) -> tuple[str | None, str | None]:
+    """Canonical (gender, type) for an ESPN grouping displayName.
+
+    "Gentlemen's Singles" / "Men's Singles" → ("men", "singles");
+    "Mixed Doubles" → (None, "mixed").
+    """
+    if not draw_type:
+        return None, None
+    return _extract_draw_hints(normalize_text(draw_type))
+
+
+def _tournament_guard(text: str, pool: list[Event]) -> list[Event]:
+    """Restrict candidates to tournaments the stream names, when it names any.
+
+    A court feed says "Wimbledon Day #8 No 1 Court" — without this, its
+    court key also joins Court 1 at every OTHER tournament running that day
+    (#316). The hint set is derived from the candidate pool itself: a
+    tournament is "named" when any of its distinctive name tokens (generic
+    words like open/cup/masters excluded) appears in the stream text. When
+    the stream names no pooled tournament, the pool passes unfiltered.
+    """
+    text_tokens = set(text.split())
+    named: set[str] = set()
+    seen: dict[str, bool] = {}
+    for event in pool:
+        tname = event.tournament_name or ""
+        if not tname or tname in seen:
+            continue
+        distinctive = (
+            set(normalize_text(tname).split()) - _GENERIC_TOURNAMENT_TOKENS
+        )
+        hit = bool(distinctive and distinctive & text_tokens)
+        seen[tname] = hit
+        if hit:
+            named.add(tname)
+    if not named:
+        return pool
+    return [e for e in pool if (e.tournament_name or "") in named]
+
 
 def _extract_courts(text: str) -> set[str]:
     """All canonical court keys mentioned in a (normalized) stream name.
@@ -259,6 +334,16 @@ class TennisMatcher:
         for league in leagues:
             pool.extend(self._events_for_local_date(league, match_date, user_tz))
 
+        # Tournament guard (#316): "Wimbledon ... No 1 Court" must not join
+        # Court 1 at other tournaments running the same day.
+        pool = _tournament_guard(text, pool)
+
+        # Draw guard (#316): a round feed that declares its draw ("Ladies'
+        # Singles Semifinals") must not fan onto other groupings. Court feeds
+        # skip it — the court is authoritative for its whole slate, and their
+        # "ft Doubles Semifinals" suffixes are marketing, not scope.
+        gender_hint, type_hint = (None, None) if courts else _extract_draw_hints(text)
+
         candidates = []
         for event in pool:
             if courts:
@@ -267,6 +352,12 @@ class TennisMatcher:
                     continue
             if round_label and _round_key(event.round_name) != round_label:
                 continue
+            if gender_hint or type_hint:
+                event_gender, event_type = _draw_key(event.draw_type)
+                if gender_hint and event_gender and event_gender != gender_hint:
+                    continue
+                if type_hint and event_type and event_type != type_hint:
+                    continue
             candidates.append(event)
 
         if not candidates:

--- a/teamarr/core/types.py
+++ b/teamarr/core/types.py
@@ -180,6 +180,7 @@ class Event:
     round_name: str | None = None  # e.g., "Round 4", "Qualifying 1st Round"
     court: str | None = None  # e.g., "Centre Court", "No. 1 Court"
     draw_type: str | None = None  # e.g., "Men's Singles", "Mixed Doubles"
+    is_major: bool = False  # ESPN tournament major flag (grand slams)
 
 
 @dataclass(frozen=True)

--- a/teamarr/database/provider_cache.py
+++ b/teamarr/database/provider_cache.py
@@ -53,6 +53,7 @@ def event_to_dict(event: Event) -> dict:
         "round_name": event.round_name,
         "court": event.court,
         "draw_type": event.draw_type,
+        "is_major": event.is_major,
     }
 
 
@@ -154,6 +155,7 @@ def dict_to_event(data: dict) -> Event:
         round_name=data.get("round_name"),
         court=data.get("court"),
         draw_type=data.get("draw_type"),
+        is_major=bool(data.get("is_major", False)),
     )
 
 

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -204,6 +204,9 @@ CREATE TABLE IF NOT EXISTS settings (
     epg_stream_pre_buffer_minutes INTEGER DEFAULT 60,
     epg_stream_post_buffer_minutes INTEGER DEFAULT 60,
 
+    -- Tennis: only match grand-slam tournaments (#283)
+    tennis_majors_only INTEGER DEFAULT 0,
+
     -- Filler Settings
     midnight_crossover_mode TEXT DEFAULT 'postgame' CHECK(midnight_crossover_mode IN ('postgame', 'idle')),
 

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -92,6 +92,10 @@ class EPGSettings:
     epg_channel_source_groups: list[int] = field(default_factory=list)
     epg_stream_pre_buffer_minutes: int = 60
     epg_stream_post_buffer_minutes: int = 60
+    # Tennis: only match/attach grand-slam tournaments (#283 first slice) —
+    # ESPN marks tournaments major=true; smaller events are filtered at the
+    # tennis matcher so junk-tour channels never get created.
+    tennis_majors_only: bool = False
     # Game-thumbs base URL (epic z02s): optional prefix for relative art paths in
     # templates. Empty = no prefixing. Absolute (http(s)://) art values bypass it.
     art_base_url: str = ""

--- a/teamarr/providers/espn/tennis.py
+++ b/teamarr/providers/espn/tennis.py
@@ -98,6 +98,7 @@ class TennisParserMixin:
             return []
 
         venue_name = (data.get("venue") or {}).get("displayName", "")
+        is_major = bool(data.get("major"))
 
         allowed = _TENNIS_LEAGUE_GROUPINGS.get(league)
         events: list[Event] = []
@@ -119,6 +120,7 @@ class TennisParserMixin:
                     draw_type=draw_type,
                     venue_name=venue_name,
                     target_date=target_date,
+                    is_major=is_major,
                 )
                 if event is None:
                     continue
@@ -143,6 +145,7 @@ class TennisParserMixin:
         draw_type: str,
         venue_name: str,
         target_date: date,
+        is_major: bool = False,
     ) -> Event | None:
         """Parse a single tennis match (one groupings[].competitions[] entry)."""
         try:
@@ -222,6 +225,7 @@ class TennisParserMixin:
                 round_name=round_name,
                 court=court,
                 draw_type=draw_type,
+                is_major=is_major,
             )
         except Exception as e:
             logger.warning("[ESPN_TENNIS] Failed to parse match: %s", e)

--- a/teamarr/providers/espn/tennis.py
+++ b/teamarr/providers/espn/tennis.py
@@ -11,6 +11,7 @@ as Team objects, with the surname as the abbreviation (streams reference
 players by surname only: "Wimbledon: Zheng vs Norrie @ Jun 29 12:30 PM").
 """
 
+import hashlib
 import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING
@@ -18,6 +19,23 @@ from typing import TYPE_CHECKING
 from teamarr.core import Event, EventStatus, Team, Venue
 
 logger = logging.getLogger(__name__)
+
+
+def _tennis_event_id(
+    tournament_id: str, start_time: datetime, first: Team, second: Team
+) -> str:
+    """Deterministic match id: (tournament, UTC date, player pair).
+
+    ESPN's tennis competition ids are UNSTABLE — the same match resurfaces
+    under a new id across fetches (observed: 177435 → 177461 → 181129 for one
+    Wimbledon semifinal, #316). Keying Events on them churns channels every
+    generation and duplicates the same match across groups. The player pair +
+    tournament + UTC date is the match's real identity (single elimination:
+    a pair meets at most once per tournament), so derive the id from that.
+    """
+    pair = "|".join(sorted((first.id, second.id)))
+    digest = hashlib.sha1(pair.encode()).hexdigest()[:10]
+    return f"{tournament_id}-{start_time.strftime('%Y%m%d')}-{digest}"
 
 # Draw types (grouping slugs) each tennis league keeps. Grand slams appear
 # verbatim on BOTH the atp and wta endpoints with all five groupings, so the
@@ -83,6 +101,7 @@ class TennisParserMixin:
 
         allowed = _TENNIS_LEAGUE_GROUPINGS.get(league)
         events: list[Event] = []
+        seen_ids: set[str] = set()
         for grouping in data.get("groupings", []):
             grouping_info = grouping.get("grouping") or {}
             slug = grouping_info.get("slug", "")
@@ -101,8 +120,15 @@ class TennisParserMixin:
                     venue_name=venue_name,
                     target_date=target_date,
                 )
-                if event:
-                    events.append(event)
+                if event is None:
+                    continue
+                # ESPN sometimes lists the same match under multiple
+                # competition entries; deterministic ids collapse those —
+                # keep the first (#316).
+                if event.id in seen_ids:
+                    continue
+                seen_ids.add(event.id)
+                events.append(event)
 
         return events
 
@@ -179,7 +205,7 @@ class TennisParserMixin:
                     game_recap = notes[0].get("text") or ""
 
             return Event(
-                id=f"{tournament_id}-{comp_id}",
+                id=_tennis_event_id(tournament_id, start_time, first, second),
                 provider=self.name,
                 name=f"{tournament_name}: {first.name} vs {second.name}",
                 short_name=f"{first.short_name} vs {second.short_name}",

--- a/tests/test_tennis.py
+++ b/tests/test_tennis.py
@@ -116,12 +116,22 @@ class _Parser(TennisParserMixin):
 def test_parser_expands_matches_and_gender_filters_atp():
     events = _Parser()._parse_tennis_matches(WIMBLEDON, "atp", "tennis", date(2026, 7, 6))
     # atp keeps mens-singles + mixed-doubles; womens sliced out; 07-05 match sliced out
-    assert {e.id for e in events} == {"188-2026-177486", "188-2026-177500"}
+    assert {e.short_name for e in events} == {
+        "F. Cobolli vs A. de Minaur",
+        "Laura Siegemund / Edouard Roger-Vasselin vs John Peers / Katie Swan",
+    }
+    # Deterministic ids (#316): tournament + UTC date + player-pair digest —
+    # NOT ESPN's unstable competition id
+    for e in events:
+        assert e.id.startswith("188-2026-20260706-")
+    # Stable across re-parses (ESPN comp-id churn must not change identity)
+    again = _Parser()._parse_tennis_matches(WIMBLEDON, "atp", "tennis", date(2026, 7, 6))
+    assert {e.id for e in events} == {e.id for e in again}
 
 
 def test_parser_gender_filters_wta():
     events = _Parser()._parse_tennis_matches(WIMBLEDON, "wta", "tennis", date(2026, 7, 6))
-    assert {e.id for e in events} == {"188-2026-180100"}
+    assert {e.short_name for e in events} == {"A. Anisimova vs S. Kenin"}
 
 
 def test_atp_wta_grand_slam_split_is_disjoint():
@@ -132,7 +142,7 @@ def test_atp_wta_grand_slam_split_is_disjoint():
 
 def test_parser_match_fields():
     events = _Parser()._parse_tennis_matches(WIMBLEDON, "atp", "tennis", date(2026, 7, 6))
-    e = next(ev for ev in events if ev.id == "188-2026-177486")
+    e = next(ev for ev in events if ev.short_name == "F. Cobolli vs A. de Minaur")
     assert e.name == "Wimbledon: Flavio Cobolli vs Alex de Minaur"
     assert e.short_name == "F. Cobolli vs A. de Minaur"
     assert e.tournament_name == "Wimbledon"
@@ -151,7 +161,7 @@ def test_parser_match_fields():
 
 def test_parser_doubles_roster():
     events = _Parser()._parse_tennis_matches(WIMBLEDON, "atp", "tennis", date(2026, 7, 6))
-    e = next(ev for ev in events if ev.id == "188-2026-177500")
+    e = next(ev for ev in events if "Siegemund" in ev.short_name)
     assert e.away_team.name == "Laura Siegemund / Edouard Roger-Vasselin"
     assert e.away_team.abbreviation == "Siegemund/Roger-Vasselin"
 
@@ -214,10 +224,8 @@ def test_player_variables_match_title_order():
     )
 
     events = _Parser()._parse_tennis_matches(WIMBLEDON, "atp", "tennis", date(2026, 7, 6))
-    e = next(ev for ev in events if ev.id == "188-2026-177486")
-    ctx = TemplateContext(
-        game_context=GameContext(event=e), team_config=None, team_stats=None
-    )
+    e = next(ev for ev in events if ev.short_name == "F. Cobolli vs A. de Minaur")
+    ctx = TemplateContext(game_context=GameContext(event=e), team_config=None, team_stats=None)
     game_ctx = ctx.game_context
 
     # Title is "Wimbledon: Flavio Cobolli vs Alex de Minaur" — player1 = Cobolli
@@ -236,9 +244,7 @@ def test_player_variables_empty_for_non_tennis():
         "x", _player("A B", "B"), _player("C D", "D"), datetime(2026, 7, 6, tzinfo=ZoneInfo("UTC"))
     )
     hockey.sport = "hockey"
-    ctx = TemplateContext(
-        game_context=GameContext(event=hockey), team_config=None, team_stats=None
-    )
+    ctx = TemplateContext(game_context=GameContext(event=hockey), team_config=None, team_stats=None)
     assert extract_player1(ctx, ctx.game_context) == ""
 
 
@@ -374,9 +380,7 @@ def test_side_score_multiword_surname():
 
 
 def test_side_score_doubles_with_underscores():
-    player = _player(
-        "Edouard Roger-Vasselin / Laura Siegemund", "Roger-Vasselin/Siegemund"
-    )
+    player = _player("Edouard Roger-Vasselin / Laura Siegemund", "Roger-Vasselin/Siegemund")
     assert _TM._side_score("roger_vasselin siegemund", player) >= 75
 
 
@@ -524,9 +528,11 @@ def test_court_extraction_from_real_stream_names():
         "12",
     }
     assert _extract_courts("wimbledon day 5 centre court ft djokovic sabalenka") == {"centre"}
-    assert _extract_courts(
-        "wimbledon day 6 court 18 court 16 no 2 court ft fernandez doubles"
-    ) == {"18", "16", "2"}
+    assert _extract_courts("wimbledon day 6 court 18 court 16 no 2 court ft fernandez doubles") == {
+        "18",
+        "16",
+        "2",
+    }
     assert _extract_courts("wimbledon second round") == set()
 
 
@@ -620,9 +626,7 @@ def test_round_feed_fans_out_to_rounds_matches():
         league_event_type="event",
         event_league_sport="tennis",
     )
-    outcomes = tm.match_feed(
-        c, ["atp", "wta"], date(2026, 7, 2), stream_id=1, user_tz=tz
-    )
+    outcomes = tm.match_feed(c, ["atp", "wta"], date(2026, 7, 2), stream_id=1, user_tz=tz)
     assert {o.event.id for o in outcomes if o.is_matched} == {"r1", "r2"}
 
 
@@ -652,3 +656,145 @@ def test_court_feed_no_matches_on_court_fails():
     outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 4), stream_id=1, user_tz=tz)
     assert len(outcomes) == 1 and not outcomes[0].is_matched
     assert "No tennis matches on" in (outcomes[0].detail or "")
+
+
+# ---------------------------------------------------------------------------
+# Feed fan-out guards (#316): tournament + draw
+# ---------------------------------------------------------------------------
+
+
+def _tournament_event(eid, tournament, court, start, draw="Men's Singles", round_name="Semifinals"):
+    e = _court_event(eid, "atp", court, start, round_name=round_name)
+    e.tournament_name = tournament
+    e.draw_type = draw
+    return e
+
+
+def test_court_feed_does_not_cross_tournaments():
+    """A Wimbledon court stream must not join Court 1 at other tournaments."""
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 6, 8, 0, tzinfo=tz)
+    events = [
+        _tournament_event("wim1", "Wimbledon", "No. 1 Court", day),
+        _tournament_event("nor1", "Nordea Open", "Court 1", day.replace(hour=9)),
+        _tournament_event(
+            "hof1",
+            "Cerity Partners Hall of Fame Open for the Van Alen Cup",
+            "Court 1",
+            day.replace(hour=10),
+        ),
+    ]
+    tm = TennisMatcher(service=_PoolService(events), cache=_NoCache())
+    c = classify_stream(
+        "Wimbledon Day #8 No 1 Court ft De Minaur Fritz @ Jul 6 8:00 AM :Tennis  05",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 6), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"wim1"}
+
+
+def test_court_feed_without_tournament_hint_is_unfiltered():
+    """No tournament named in the stream → pool passes through (old behavior)."""
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 6, 8, 0, tzinfo=tz)
+    events = [
+        _tournament_event("a1", "Wimbledon", "Court 2", day),
+        _tournament_event("b1", "Nordea Open", "Court 2", day.replace(hour=9)),
+    ]
+    tm = TennisMatcher(service=_PoolService(events), cache=_NoCache())
+    c = classify_stream(
+        "Day #8 No 2 Court @ Jul 6 8:00 AM :Tennis  02",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 6), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"a1", "b1"}
+
+
+def test_generic_tournament_tokens_do_not_create_hints():
+    """'Open'/'Masters' alone must not read as naming a tournament."""
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 6, 8, 0, tzinfo=tz)
+    events = [
+        _tournament_event("a1", "Nordea Open", "Court 2", day),
+    ]
+    tm = TennisMatcher(service=_PoolService(events), cache=_NoCache())
+    c = classify_stream(
+        "Open Day #8 No 2 Court @ Jul 6 8:00 AM",  # "Open" is generic
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 6), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"a1"}
+
+
+def test_round_feed_respects_declared_draw():
+    """'Ladies' Singles Semifinals' must not fan onto the men's doubles semi."""
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 9, 7, 0, tzinfo=tz)
+    events = [
+        _tournament_event("ls1", "Wimbledon", "Centre Court", day, draw="Ladies' Singles"),
+        _tournament_event(
+            "ls2", "Wimbledon", "No. 1 Court", day.replace(hour=9), draw="Women's Singles"
+        ),
+        _tournament_event(
+            "md1", "Wimbledon", "No. 1 Court", day.replace(hour=8), draw="Gentlemen's Doubles"
+        ),
+    ]
+    tm = TennisMatcher(service=_PoolService(events), cache=_NoCache())
+    c = classify_stream(
+        "Ladies' Singles Semifinals @ Jul 9 7:00 AM :Tennis  01",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 9), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"ls1", "ls2"}
+
+
+def test_court_feed_ft_suffix_does_not_scope_draw():
+    """Court feeds cover the court's whole slate — 'ft Doubles Semifinals' is
+    marketing, not scope; singles on the same court must stay."""
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 9, 8, 0, tzinfo=tz)
+    events = [
+        _tournament_event("s1", "Wimbledon", "No. 1 Court", day, draw="Gentlemen's Singles"),
+        _tournament_event(
+            "d1", "Wimbledon", "No. 1 Court", day.replace(hour=10), draw="Gentlemen's Doubles"
+        ),
+    ]
+    tm = TennisMatcher(service=_PoolService(events), cache=_NoCache())
+    c = classify_stream(
+        "Wimbledon Day #11 No 1 Court ft Doubles Semifinals @ Jul 9 8:00 AM :Tennis  06",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 9), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"s1", "d1"}
+
+
+def test_draw_hint_extraction():
+    from teamarr.consumers.matching.tennis_matcher import _extract_draw_hints
+
+    assert _extract_draw_hints("ladies singles semifinals") == ("women", "singles")
+    assert _extract_draw_hints("gentlemens doubles semifinals") == ("men", "doubles")
+    assert _extract_draw_hints("womens doubles") == ("women", "doubles")
+    # "womens" must not read as "mens"
+    assert _extract_draw_hints("womens singles")[0] == "women"
+    assert _extract_draw_hints("mixed doubles final") == (None, "mixed")
+    assert _extract_draw_hints("wimbledon day 8 no 1 court") == (None, None)
+
+
+def test_parser_dedups_duplicate_competition_entries():
+    """ESPN sometimes lists one match twice — deterministic ids collapse it."""
+    import copy
+
+    doubled = copy.deepcopy(WIMBLEDON)
+    grouping = doubled["groupings"][0]
+    dup = copy.deepcopy(grouping["competitions"][0])
+    dup["id"] = "999999"  # different unstable comp id, same players/time
+    grouping["competitions"].append(dup)
+
+    events = _Parser()._parse_tennis_matches(doubled, "atp", "tennis", date(2026, 7, 6))
+    names = [e.short_name for e in events]
+    assert names.count("F. Cobolli vs A. de Minaur") == 1

--- a/tests/test_tennis.py
+++ b/tests/test_tennis.py
@@ -798,3 +798,73 @@ def test_parser_dedups_duplicate_competition_entries():
     events = _Parser()._parse_tennis_matches(doubled, "atp", "tennis", date(2026, 7, 6))
     names = [e.short_name for e in events]
     assert names.count("F. Cobolli vs A. de Minaur") == 1
+
+
+# ---------------------------------------------------------------------------
+# Majors-only subscription (#283 first slice)
+# ---------------------------------------------------------------------------
+
+
+def test_parser_carries_major_flag():
+    import copy
+
+    slam = copy.deepcopy(WIMBLEDON)
+    slam["major"] = True
+    events = _Parser()._parse_tennis_matches(slam, "atp", "tennis", date(2026, 7, 6))
+    assert events and all(e.is_major for e in events)
+
+    minor = copy.deepcopy(WIMBLEDON)
+    minor["major"] = False
+    events = _Parser()._parse_tennis_matches(minor, "atp", "tennis", date(2026, 7, 6))
+    assert events and not any(e.is_major for e in events)
+
+
+def test_majors_only_filters_feed_fanout():
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 6, 8, 0, tzinfo=tz)
+    slam = _tournament_event("wim1", "Wimbledon", "No. 1 Court", day)
+    slam.is_major = True
+    minor = _tournament_event("nor1", "Nordea Open", "Court 1", day.replace(hour=9))
+    minor.is_major = False
+
+    tm = TennisMatcher(service=_PoolService([slam, minor]), cache=_NoCache(), majors_only=True)
+    # Generic court feed with no tournament hint — majors filter must still
+    # keep Nordea out of the pool entirely.
+    c = classify_stream(
+        "Day #8 No 1 Court @ Jul 6 8:00 AM :Tennis  02",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcomes = tm.match_feed(c, ["atp"], date(2026, 7, 6), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes if o.is_matched} == {"wim1"}
+
+    # Same court key for both — filter must be the reason Nordea is out
+    tm_off = TennisMatcher(service=_PoolService([slam, minor]), cache=_NoCache(), majors_only=False)
+    outcomes_off = tm_off.match_feed(c, ["atp"], date(2026, 7, 6), stream_id=1, user_tz=tz)
+    assert {o.event.id for o in outcomes_off if o.is_matched} == {"wim1", "nor1"}
+
+
+def test_majors_only_filters_player_matching():
+    tz = ZoneInfo("America/New_York")
+    day = datetime(2026, 7, 6, 12, 0, tzinfo=tz)
+    minor = _tennis_event(
+        "nor2", _player("Casper Ruud", "Ruud"), _player("Holger Rune", "Rune"), day
+    )
+    minor.is_major = False
+
+    tm = TennisMatcher(service=_PoolService([minor]), cache=_NoCache(), majors_only=True)
+    c = classify_stream(
+        "Nordea Open: Ruud vs Rune @ Jul 6 12:00 PM",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+    outcome = tm.match(
+        c,
+        "atp",
+        date(2026, 7, 6),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=tz,
+    )
+    assert not outcome.is_matched


### PR DESCRIPTION
## Summary
Fixes #316 — three tennis failure modes diagnosed from live production data during Wimbledon week:

1. **Cross-tournament fan-out**: `match_feed` joined court feeds to events by court key across every tournament running that day — "Wimbledon Day #8 No 1 Court" created channels for Nordea Open and Hall of Fame Open matches. Now restricted to tournaments the stream actually names (distinctive-token matching derived from the candidate pool itself — no hardcoded tournament list; streams naming no pooled tournament pass unfiltered, preserving existing behavior).
2. **Draw-blind round feeds**: "Ladies' Singles Semifinals" fanned onto the men's doubles semifinal. Round feeds now filter on `event.draw_type` (gender + singles/doubles/mixed hints). Court feeds deliberately skip the draw guard — a court's slate spans draws and "ft Doubles Semifinals" suffixes are marketing.
3. **Channel churn + duplicates**: ESPN's tennis competition ids are unstable (one semifinal observed as 177435 → 177461 → 181129 across fetches), and cleanup's stream→event rotation map was single-valued — a feed stream fanning to 8 matches made 7 channels look "rotated" every run (observed: 10 delete+recreate cycles for one channel in one day). Tennis event ids are now deterministic — `(tournament, UTC date, player-pair digest)` — and the rotation map is multi-valued with membership checks. Parse-time dedup collapses ESPN double-listings.

**Transition note**: channels keyed on old-format ids survive until their cached events end (same day); match caches are intentionally NOT cleared to preserve user corrections.

## Test plan
- [x] 7 new regression tests (guards, hint extraction, id determinism/stability, ESPN double-listing dedup) — 39/39 tennis tests pass
- [x] Full suite 1403 passed · ruff clean · Pyright 0 on touched files
- [x] **Live-verified on production data**: junk-tournament channels 4 → 0 (8 channels, all Wimbledon); two consecutive full generations → byte-identical channel id sets (previously hourly churn); duplicate Krawietz channel converges as cached events expire