### PR TITLE
fix(ui): move tennis majors-only toggle to Subscriptions → Teams tile (#283)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -88,7 +88,7 @@ Set these on a Source in the editor (and at bulk add / bulk edit). **EPG** requi
 
 The **Event Lookahead** controls how far ahead Teamarr matches streams to sporting events — streams are matched only to events within this window. Default is 3 days; options are 1, 3, 7, 14, or 30 days.
 
-**Tennis: majors only** (same card) restricts tennis matching to the four Grand Slams (Australian Open, French Open, Wimbledon, US Open). Smaller ATP/WTA tournaments are ignored entirely — no channels are created for them. Off by default.
+**Tennis: majors only** (Global Defaults → Teams tile, next to the playoff bypass; shown when subscribed to ATP/WTA) restricts tennis matching to the four Grand Slams (Australian Open, French Open, Wimbledon, US Open). Smaller ATP/WTA tournaments are ignored entirely — no channels are created for them. Off by default.
 
 ## EPG Program Matching
 

--- a/frontend/src/components/EventMatchingSettings.tsx
+++ b/frontend/src/components/EventMatchingSettings.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Select } from "@/components/ui/select"
-import { Switch } from "@/components/ui/switch"
 import { ToggleCard } from "@/components/ui/toggle-card"
 import { CheckboxListPicker } from "@/components/ui/checkbox-list-picker"
 import {
@@ -221,28 +220,6 @@ export function EventLookaheadSetting() {
           </Select>
           <p className="text-xs text-muted-foreground">
             How many days of upcoming events to match streams against.
-          </p>
-        </div>
-
-        {/* Same card + save as the lookahead: both edit the shared epg blob,
-            and two full-PUT components in one view would overwrite each other. */}
-        <div className="space-y-2 border-t pt-4">
-          <div className="flex items-center gap-2">
-            <Switch
-              id="tennis-majors-only"
-              checked={epg?.tennis_majors_only ?? false}
-              onCheckedChange={(checked) =>
-                epg && setEPG({ ...epg, tennis_majors_only: checked })
-              }
-            />
-            <Label htmlFor="tennis-majors-only" className="cursor-pointer">
-              Tennis: majors only
-            </Label>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            Only match Grand Slam tournaments (Australian Open, French Open, Wimbledon,
-            US Open). Smaller ATP/WTA tournaments are ignored entirely — no channels are
-            created for them.
           </p>
         </div>
 

--- a/frontend/src/components/GlobalDefaults.tsx
+++ b/frontend/src/components/GlobalDefaults.tsx
@@ -24,7 +24,12 @@ import { LeaguePicker } from "@/components/LeaguePicker"
 import { SoccerModeSelector, type SoccerMode } from "@/components/SoccerModeSelector"
 import { TeamPicker } from "@/components/TeamPicker"
 import { useSubscription, useUpdateSubscription } from "@/hooks/useSubscription"
-import { useTeamFilterSettings, useUpdateTeamFilterSettings } from "@/hooks/useSettings"
+import {
+  useEPGSettings,
+  useTeamFilterSettings,
+  useUpdateEPGSettings,
+  useUpdateTeamFilterSettings,
+} from "@/hooks/useSettings"
 import { getLeagues } from "@/api/teams"
 import type { SoccerFollowedTeam } from "@/api/types"
 import type { TeamFilterSettings } from "@/api/settings"
@@ -71,6 +76,18 @@ export function GlobalDefaults({
   // Team filter settings
   const { data: teamFilterData } = useTeamFilterSettings()
   const updateTeamFilter = useUpdateTeamFilterSettings()
+
+  // EPG settings blob — carries tennis_majors_only, edited alongside the team
+  // filter (both are "narrow what becomes a channel" controls). Full-blob PUT;
+  // safe: no other mounted view edits the epg blob at the same time.
+  const { data: epgData } = useEPGSettings()
+  const updateEPG = useUpdateEPGSettings()
+  const [tennisMajorsOnly, setTennisMajorsOnly] = useState(false)
+  const [syncedEpgData, setSyncedEpgData] = useState<typeof epgData>(undefined)
+  if (epgData && epgData !== syncedEpgData) {
+    setSyncedEpgData(epgData)
+    setTennisMajorsOnly(epgData.tennis_majors_only ?? false)
+  }
 
   // Local state for editing (synced from subscription on load)
   const [nonSoccerLeagues, setNonSoccerLeagues] = useState<string[]>([])
@@ -186,7 +203,15 @@ export function GlobalDefaults({
       onSuccess: () => toast.success("Default team filter saved"),
       onError: () => toast.error("Failed to save team filter"),
     })
-  }, [teamFilter, updateTeamFilter])
+    // tennis_majors_only rides the epg blob (separate endpoint) — only PUT
+    // when it actually changed, to avoid clobbering concurrent epg edits.
+    if (epgData && (epgData.tennis_majors_only ?? false) !== tennisMajorsOnly) {
+      updateEPG.mutate(
+        { ...epgData, tennis_majors_only: tennisMajorsOnly },
+        { onError: () => toast.error("Failed to save tennis majors-only") }
+      )
+    }
+  }, [teamFilter, updateTeamFilter, epgData, tennisMajorsOnly, updateEPG])
 
   if (subLoading || !leaguesData) {
     return (
@@ -335,6 +360,21 @@ export function GlobalDefaults({
                   Include all playoff games (bypass team filter for postseason events)
                 </span>
               </label>
+
+              {/* Tennis majors-only (#283) — shown only for tennis subscribers */}
+              {allSubscribedLeagues.some((l) => l === "atp" || l === "wta") && (
+                <label className="flex items-center gap-2 cursor-pointer py-2">
+                  <Checkbox
+                    checked={tennisMajorsOnly}
+                    onCheckedChange={(checked) => setTennisMajorsOnly(!!checked)}
+                  />
+                  <span className="text-sm">
+                    Tennis: only match Grand Slams (Australian Open, French Open,
+                    Wimbledon, US Open) — smaller ATP/WTA tournaments never create
+                    channels
+                  </span>
+                </label>
+              )}
 
               {/* Status message and Save button */}
               <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
Placement feedback: the majors-only toggle belongs next to the **playoff bypass** in Subscriptions → Teams (the "narrow what becomes a channel" card), not on the Matching page. Moved; shown only when atp/wta is subscribed; saves via the existing Save Team Filter button (epg blob PUT only when the value changed, to avoid clobbering concurrent epg edits). Docs updated.

## Test plan
- [x] Playwright on live instance: checkbox renders under playoff bypass (only with tennis subscribed), check → save → API shows `tennis_majors_only: true`, uncheck → save → restored to false
- [x] eslint + build clean
- [x] Noted pre-existing (unrelated) nested-button console error in TeamPicker — 5hq.16 class, will file for the next audit