### PR TITLE
feat(templates): starter-set v2 — (Starter) names + abbrev fallback (#329)

### DIFF
--- a/docs/guide/templates/defaults.md
+++ b/docs/guide/templates/defaults.md
@@ -24,13 +24,16 @@ same assignments, fixed art.
 
 | Template | Type | Designed for | Channel name style |
 |----------|------|--------------|--------------------|
-| **Default Team** | team | Any team channel | `{team_name}` |
-| **Default Event** | event | US pro leagues with abbreviations (NBA, NFL, MLB, NHL…) | `NBA \| DET/LAL` |
-| **Combat Event** | event | UFC / PFL / boxing (card segments) | `UFC 310 Main Card` |
-| **International Event** | event | National teams, international competitions | `NED v JPN` |
-| **No-Abbrev Event** | event | Leagues without team abbreviations (niche soccer…) | `Full Name / Full Name` |
-| **MiLB Event** | event | Minor-league baseball | `MiLB \| ABQ/SUG` |
-| **Tennis Event** | event | ATP / WTA (per-match channels) | `Alcaraz v Sinner` |
+| **Default Team (Starter)** | team | Any team channel | `{team_name}` |
+| **Default Event (Starter)** | event | Any matchup league — team abbreviations fall back to short/full names automatically | `NBA \| DET/LAL` |
+| **Combat Event (Starter)** | event | UFC / PFL / boxing (card segments) | `UFC 310 Main Card` |
+| **International Event (Starter)** | event | National teams, international competitions | `NED v JPN` |
+| **MiLB Event (Starter)** | event | Minor-league baseball | `MiLB \| ABQ/SUG` |
+| **Tennis Event (Starter)** | event | ATP / WTA (per-match channels) | `Alcaraz v Sinner` |
+
+Every starter template carries a **"(Starter)"** suffix so it's always clear
+which templates shipped with Teamarr; rename freely — a renamed or edited
+starter is yours and is never touched by upgrades.
 
 Channel names are deliberately **short**: TV guide grids truncate channel
 names aggressively (often ~15–20 visible characters), so the set leads with
@@ -44,7 +47,6 @@ abbreviations and surnames.
 | Default Event | Global event default |
 | Combat Event | UFC, PFL, boxing leagues |
 | International Event | Soccer + international competitions |
-| No-Abbrev Event | Leagues whose teams lack abbreviations |
 | MiLB Event | MiLB levels (Triple-A … Rookie) |
 | Tennis Event | ATP, WTA |
 

--- a/frontend/src/hooks/useSubscription.ts
+++ b/frontend/src/hooks/useSubscription.ts
@@ -45,6 +45,8 @@ export function useCreateSubscriptionTemplate() {
     mutationFn: (data: SubscriptionTemplateCreate) => createSubscriptionTemplate(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-templates"] })
+      // Templates list renders per-template Usage from global_assignments
+      queryClient.invalidateQueries({ queryKey: ["templates"] })
     },
   })
 }
@@ -62,6 +64,8 @@ export function useUpdateSubscriptionTemplate() {
     }) => updateSubscriptionTemplate(assignmentId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-templates"] })
+      // Templates list renders per-template Usage from global_assignments
+      queryClient.invalidateQueries({ queryKey: ["templates"] })
     },
   })
 }
@@ -73,6 +77,8 @@ export function useDeleteSubscriptionTemplate() {
     mutationFn: (assignmentId: number) => deleteSubscriptionTemplate(assignmentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-templates"] })
+      // Templates list renders per-template Usage from global_assignments
+      queryClient.invalidateQueries({ queryKey: ["templates"] })
     },
   })
 }

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -29,6 +29,10 @@ import {
   useDeleteTemplate,
 } from "@/hooks/useTemplates"
 import { getTemplate, type Template } from "@/api/templates"
+import { useQuery } from "@tanstack/react-query"
+import { getLeagues } from "@/api/teams"
+import { getLeagueDisplayName, getSportDisplayName } from "@/lib/utils"
+import { useSports } from "@/hooks/useSports"
 import { TemplateAssignmentManager } from "@/components/TemplateAssignmentModal"
 import { useSubscription } from "@/hooks/useSubscription"
 
@@ -39,6 +43,16 @@ export function Templates() {
   const subscribedLeagues = subscription?.leagues ?? []
   const createMutation = useCreateTemplate()
   const deleteMutation = useDeleteTemplate()
+
+  // Friendly names for the Usage chips (league slugs like "fifa.world" are
+  // not user-facing). Query is shared/cached with the assignment manager below.
+  const { data: leaguesResponse } = useQuery({ queryKey: ["leagues"], queryFn: () => getLeagues() })
+  const leagueName = (slug: string) => {
+    const lg = leaguesResponse?.leagues?.find((l) => l.slug === slug)
+    return lg ? getLeagueDisplayName(lg, true) : slug.toUpperCase()
+  }
+  const { data: sportsData } = useSports()
+  const sportName = (s: string) => getSportDisplayName(s, sportsData?.sports)
 
   const [deleteConfirm, setDeleteConfirm] = useState<Template | null>(null)
   const [isImporting, setIsImporting] = useState(false)
@@ -312,14 +326,14 @@ export function Templates() {
                               if (a.leagues?.length) {
                                 return (
                                   <Badge key={i} variant="outline" className="text-xs">
-                                    {a.leagues.join(", ")}
+                                    {a.leagues.map(leagueName).join(", ")}
                                   </Badge>
                                 )
                               }
                               if (a.sports?.length) {
                                 return (
                                   <Badge key={i} variant="outline" className="text-xs">
-                                    {a.sports.join(", ")}
+                                    {a.sports.map(sportName).join(", ")}
                                   </Badge>
                                 )
                               }

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -242,8 +242,8 @@ export function Templates() {
           (teamarr/database/default_templates.py). */}
       {(() => {
         const SEEDED_NAMES = new Set([
-          "Default Team", "Default Event", "Combat Event", "International Event",
-          "No-Abbrev Event", "MiLB Event", "Tennis Event",
+          "Default Team (Starter)", "Default Event (Starter)", "Combat Event (Starter)",
+          "International Event (Starter)", "MiLB Event (Starter)", "Tennis Event (Starter)",
         ])
         const unassignedSeeded = (templates ?? []).filter(
           (t) =>
@@ -255,17 +255,10 @@ export function Templates() {
         return (
           <Alert variant="info" className="mb-3">
             {unassignedSeeded.length} starter template{unassignedSeeded.length !== 1 ? "s are" : " is"} not
-            assigned yet. They're designed for specific scopes (e.g. Combat Event → UFC/boxing,
-            Tennis Event → ATP/WTA) — see the{" "}
-            <a
-              href="https://pharaoh-labs.github.io/teamarr/guide/templates/defaults"
-              target="_blank"
-              rel="noreferrer"
-              className="underline"
-            >
-              recommended scoping guide
-            </a>
-            .
+            assigned yet. Recommended scoping — Default Team/Event: global defaults ·
+            Combat: UFC/boxing · International: soccer & national teams ·
+            MiLB: minor-league baseball · Tennis: ATP/WTA. Assign below or via
+            Template Assignments.
           </Alert>
         )
       })()}

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -55,7 +55,19 @@ _LEGACY_STRIPPED_ART = "{league_id}/{away_team_pascal}/{home_team_pascal}/cover.
 
 # Legacy seed name → curated replacement name (upgrade-in-place keeps the row
 # id, so assignments and group references survive the rename).
-LEGACY_UPGRADES = {"Team": "Default Team", "Event": "Default Event"}
+LEGACY_UPGRADES = {"Team": "Default Team (Starter)", "Event": "Default Event (Starter)"}
+
+# Earlier curated-set iterations used these names / had these members. An
+# UNEDITED row under a prior name is renamed in place (same id); an unedited
+# retired member is removed. Edited rows are always left alone.
+PRIOR_NAME_UPGRADES = {
+    "Default Team": "Default Team (Starter)",
+    "Default Event": "Default Event (Starter)",
+    "Combat Event": "Combat Event (Starter)",
+    "International Event": "International Event (Starter)",
+    "MiLB Event": "MiLB Event (Starter)",
+    "Tennis Event": "Tennis Event (Starter)",
+}
 
 # Content fingerprint of the stock legacy seeds — a row is "pristine" (safe to
 # upgrade in place) only when title, subtitle, art AND the default description
@@ -120,7 +132,7 @@ def _is_unedited_curated(row, spec: dict) -> bool:
 def _team_default() -> dict:
     """Universal team-channel fallback (persistent team channels)."""
     return {
-        "name": "Default Team",
+        "name": "Default Team (Starter)",
         "template_type": "team",
         "title_format": "{gracenote_category}",
         "subtitle_template": "{away_team} at {home_team}",
@@ -292,10 +304,10 @@ def _event_base(**overrides) -> dict:
 DEFAULT_TEMPLATE_SET: list[dict] = [
     _team_default(),
     # Universal event fallback — US pro leagues with abbreviations.
-    _event_base(name="Default Event"),
+    _event_base(name="Default Event (Starter)"),
     # Combat (MMA/boxing): card-segment channels, event-number titles.
     _event_base(
-        name="Combat Event",
+        name="Combat Event (Starter)",
         title_format="{league} {event_number}: {card_segment_display}",
         subtitle_template="{away_team} vs {home_team}",
         pregame_fallback={
@@ -320,7 +332,7 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
     ),
     # International (national teams / tournaments): category-led naming.
     _event_base(
-        name="International Event",
+        name="International Event (Starter)",
         title_format="{gracenote_category}",
         subtitle_template="{away_team} vs {home_team}",
         # "NED v JPN"
@@ -335,19 +347,14 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
             }
         ],
     ),
-    # Leagues without abbreviations: full names everywhere.
-    _event_base(
-        name="No-Abbrev Event",
-        event_channel_name="{away_team} / {home_team}",
-    ),
     # Minor-league baseball: explicit MiLB branding (league var is the level).
     _event_base(
-        name="MiLB Event",
+        name="MiLB Event (Starter)",
         event_channel_name="MiLB | {away_team_abbrev}/{home_team_abbrev}",
     ),
     # Tennis (bead tvnk.13): tournament-led titles, player-surname channels.
     _event_base(
-        name="Tennis Event",
+        name="Tennis Event (Starter)",
         title_format="{tournament_name}",
         subtitle_template="{tennis_round} - {player1} vs {player2}",
         pregame_fallback={
@@ -390,6 +397,17 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
 ]
 
 
+def _retired_no_abbrev_spec() -> dict:
+    """The retired "No-Abbrev Event" member's content, for removal healing.
+
+    Retired because the *_team_abbrev variables now fall back to short/full
+    names when a league has none — Default Event covers the case (#329)."""
+    return _event_base(
+        name="No-Abbrev Event",
+        event_channel_name="{away_team} / {home_team}",
+    )
+
+
 def seed_default_templates(conn: Connection) -> None:
     """Seed the curated default set — idempotent, safe on every startup.
 
@@ -427,6 +445,25 @@ def seed_default_templates(conn: Connection) -> None:
         spec = dict(specs[curated_name])
         update_template(conn, row.id, **spec)
         existing[curated_name] = existing.pop(legacy_name)
+
+    # 1b. Rename unedited prior-iteration curated rows in place (same id).
+    for prior, current in PRIOR_NAME_UPGRADES.items():
+        row = existing.get(prior)
+        if row is None or current in existing or current not in specs:
+            continue
+        prior_spec = dict(specs[current])
+        prior_spec["name"] = prior
+        if not _is_unedited_curated(row, prior_spec):
+            continue
+        update_template(conn, row.id, **specs[current])
+        existing[current] = existing.pop(prior)
+
+    # 1c. Remove retired members that are still our unedited seed.
+    for retired_spec in [_retired_no_abbrev_spec()]:
+        row = existing.get(retired_spec["name"])
+        if row is not None and _is_unedited_curated(row, retired_spec):
+            delete_template(conn, row.id)
+            del existing[retired_spec["name"]]
 
     # 2. Add missing set members.
     for name, spec in specs.items():

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -158,28 +158,44 @@ def extract_away_team_short(ctx: TemplateContext, game_ctx: GameContext | None) 
     return game_ctx.event.away_team.short_name
 
 
+def _abbrev_or_name(team) -> str:
+    """Abbreviation (uppercased) with a graceful fallback for leagues whose
+    teams have none: short_name, then full name — kept as-is (uppercasing a
+    full club name would shout). Retires the need for a separate "No-Abbrev"
+    template variant (#329)."""
+    if team.abbreviation:
+        return team.abbreviation.upper()
+    return team.short_name or team.name
+
+
 @register_variable(
     name="home_team_abbrev",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.ALL,
-    description="Home team abbreviation uppercase",
+    description=(
+        "Home team abbreviation uppercase (falls back to short/full name "
+        "when the league has none)"
+    ),
 )
 def extract_home_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not game_ctx or not game_ctx.event:
         return ""
-    return game_ctx.event.home_team.abbreviation.upper()
+    return _abbrev_or_name(game_ctx.event.home_team)
 
 
 @register_variable(
     name="away_team_abbrev",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.ALL,
-    description="Away team abbreviation uppercase",
+    description=(
+        "Away team abbreviation uppercase (falls back to short/full name "
+        "when the league has none)"
+    ),
 )
 def extract_away_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not game_ctx or not game_ctx.event:
         return ""
-    return game_ctx.event.away_team.abbreviation.upper()
+    return _abbrev_or_name(game_ctx.event.away_team)
 
 
 @register_variable(
@@ -191,7 +207,7 @@ def extract_away_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None)
 def extract_home_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not game_ctx or not game_ctx.event:
         return ""
-    return game_ctx.event.home_team.abbreviation.lower()
+    return _abbrev_or_name(game_ctx.event.home_team).lower()
 
 
 @register_variable(
@@ -203,7 +219,7 @@ def extract_home_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext |
 def extract_away_team_abbrev_lower(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not game_ctx or not game_ctx.event:
         return ""
-    return game_ctx.event.away_team.abbreviation.lower()
+    return _abbrev_or_name(game_ctx.event.away_team).lower()
 
 
 @register_variable(
@@ -334,10 +350,7 @@ def extract_feed_team_logo(ctx: TemplateContext, game_ctx: GameContext | None) -
 def extract_is_home_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team or not game_ctx or not game_ctx.event:
         return ""
-    is_home = (
-        game_ctx.event.home_team
-        and game_ctx.event.home_team.id == ctx.feed_team.id
-    )
+    is_home = game_ctx.event.home_team and game_ctx.event.home_team.id == ctx.feed_team.id
     return "true" if is_home else "false"
 
 
@@ -351,10 +364,7 @@ def extract_is_home_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> 
 def extract_is_away_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team or not game_ctx or not game_ctx.event:
         return ""
-    is_away = (
-        game_ctx.event.away_team
-        and game_ctx.event.away_team.id == ctx.feed_team.id
-    )
+    is_away = game_ctx.event.away_team and game_ctx.event.away_team.id == ctx.feed_team.id
     return "true" if is_away else "false"
 
 
@@ -368,10 +378,7 @@ def extract_is_away_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> 
 def extract_feed_home_away(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team or not game_ctx or not game_ctx.event:
         return ""
-    is_home = (
-        game_ctx.event.home_team
-        and game_ctx.event.home_team.id == ctx.feed_team.id
-    )
+    is_home = game_ctx.event.home_team and game_ctx.event.home_team.id == ctx.feed_team.id
     return "Home" if is_home else "Away"
 
 
@@ -393,10 +400,7 @@ def extract_feed_home_away(ctx: TemplateContext, game_ctx: GameContext | None) -
 def extract_broadcast_feed(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team or not game_ctx or not game_ctx.event:
         return ""
-    is_home = (
-        game_ctx.event.home_team
-        and game_ctx.event.home_team.id == ctx.feed_team.id
-    )
+    is_home = game_ctx.event.home_team and game_ctx.event.home_team.id == ctx.feed_team.id
     return "Home Team Feed" if is_home else "Away Team Feed"
 
 
@@ -407,9 +411,7 @@ def extract_broadcast_feed(ctx: TemplateContext, game_ctx: GameContext | None) -
     description="'{Team Name} Feed' (e.g., 'Seattle Mariners Feed') or '' if no feed",
     scope=TemplateScope.EVENT_ONLY,
 )
-def extract_broadcast_feed_team(
-    ctx: TemplateContext, game_ctx: GameContext | None
-) -> str:
+def extract_broadcast_feed_team(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not ctx.feed_team:
         return ""
     return f"{ctx.feed_team.name} Feed"

--- a/tests/templates/test_default_template_seeding.py
+++ b/tests/templates/test_default_template_seeding.py
@@ -58,7 +58,7 @@ def test_fresh_install_seeds_full_set(db_conn):
     # init_db already seeded (the wiring under test); re-run is a no-op
     seed_default_templates(db_conn)
     assert _names(db_conn) == SET_NAMES
-    assert len(SET_NAMES) == 7
+    assert len(SET_NAMES) == 6
 
     for t in get_all_templates(db_conn):
         # Seeded UNASSIGNED — the user scopes them
@@ -88,7 +88,7 @@ def test_pristine_legacy_seed_upgraded_in_place(db_conn):
 
     templates = {t.name: t for t in get_all_templates(db_conn)}
     assert "Event" not in templates  # renamed, not duplicated
-    upgraded = templates["Default Event"]
+    upgraded = templates["Default Event (Starter)"]
     assert upgraded.id == legacy_id  # same row → assignments survive
     assert (upgraded.program_art_url or "").startswith("{")
     assert _names(db_conn) == SET_NAMES
@@ -103,7 +103,7 @@ def test_pristine_legacy_with_localhost_art_also_upgrades(db_conn):
     )
     seed_default_templates(db_conn)
     templates = {t.name: t for t in get_all_templates(db_conn)}
-    assert templates["Default Team"].id == legacy_id
+    assert templates["Default Team (Starter)"].id == legacy_id
     assert _names(db_conn) == SET_NAMES
 
 
@@ -136,14 +136,14 @@ def test_upgrade_adds_missing_members_only(db_conn):
     templates = {t.name: t for t in get_all_templates(db_conn)}
     from teamarr.database.templates import delete_template, update_template
 
-    delete_template(db_conn, templates["MiLB Event"].id)
-    update_template(db_conn, templates["Tennis Event"].id, title_format="Custom Tennis")
+    delete_template(db_conn, templates["MiLB Event (Starter)"].id)
+    update_template(db_conn, templates["Tennis Event (Starter)"].id, title_format="Custom Tennis")
 
     seed_default_templates(db_conn)
 
     templates = {t.name: t for t in get_all_templates(db_conn)}
-    assert "MiLB Event" in templates  # re-added (missing by name)
-    assert templates["Tennis Event"].title_format == "Custom Tennis"  # untouched
+    assert "MiLB Event (Starter)" in templates  # re-added (missing by name)
+    assert templates["Tennis Event (Starter)"].title_format == "Custom Tennis"  # untouched
 
 
 _VAR_TOKEN = re.compile(r"\{([a-z0-9_]+)(?:\.(?:next|last))?\}")
@@ -190,7 +190,7 @@ def test_parameterized_stock_art_counts_as_pristine(db_conn):
     )
     seed_default_templates(db_conn)
     templates = {t.name: t for t in get_all_templates(db_conn)}
-    assert templates["Default Event"].id == legacy_id
+    assert templates["Default Event (Starter)"].id == legacy_id
     assert _names(db_conn) == SET_NAMES
 
 
@@ -217,7 +217,7 @@ def test_healing_folds_unedited_curated_duplicate_into_legacy(db_conn):
 
     templates = {t.name: t for t in get_all_templates(db_conn)}
     assert _names(db_conn) == SET_NAMES  # duplicate folded, 7 total
-    assert templates["Default Event"].id == legacy_id  # legacy row won
+    assert templates["Default Event (Starter)"].id == legacy_id  # legacy row won
 
 
 def test_edited_curated_duplicate_is_not_folded(db_conn):
@@ -234,11 +234,99 @@ def test_edited_curated_duplicate_is_not_folded(db_conn):
     from teamarr.database.templates import update_template
 
     templates = {t.name: t for t in get_all_templates(db_conn)}
-    update_template(db_conn, templates["Default Event"].id, title_format="Edited")
+    update_template(db_conn, templates["Default Event (Starter)"].id, title_format="Edited")
 
     seed_default_templates(db_conn)
 
     templates = {t.name: t for t in get_all_templates(db_conn)}
     # Both survive: user's edit is sacred, legacy left alone
-    assert "Event" in templates and "Default Event" in templates
-    assert templates["Default Event"].title_format == "Edited"
+    assert "Event" in templates and "Default Event (Starter)" in templates
+    assert templates["Default Event (Starter)"].title_format == "Edited"
+
+
+def test_prior_iteration_names_renamed_in_place(db_conn):
+    """Rows seeded by the first curated iteration (no parenthetical) get the
+    (Starter) name on the same row id when unedited."""
+    from teamarr.database.default_templates import PRIOR_NAME_UPGRADES
+
+    db_conn.execute("DELETE FROM templates")
+    db_conn.commit()
+    # Simulate the prior iteration: same specs, prior names
+    prior_ids = {}
+    for spec in DEFAULT_TEMPLATE_SET:
+        prior_name = next((p for p, c in PRIOR_NAME_UPGRADES.items() if c == spec["name"]), None)
+        assert prior_name is not None
+        prior = dict(spec)
+        prior["name"] = prior_name
+        prior_ids[spec["name"]] = create_template(db_conn, **prior)
+
+    seed_default_templates(db_conn)
+
+    templates = {t.name: t for t in get_all_templates(db_conn)}
+    assert _names(db_conn) == SET_NAMES
+    for current, tid in prior_ids.items():
+        assert templates[current].id == tid  # renamed in place
+
+
+def test_retired_no_abbrev_member_removed_when_unedited(db_conn):
+    from teamarr.database.default_templates import _retired_no_abbrev_spec
+
+    db_conn.execute("DELETE FROM templates")
+    db_conn.commit()
+    create_template(db_conn, **_retired_no_abbrev_spec())
+
+    seed_default_templates(db_conn)
+    assert _names(db_conn) == SET_NAMES  # retired member gone, set complete
+
+
+def test_retired_member_kept_when_edited(db_conn):
+    from teamarr.database.default_templates import _retired_no_abbrev_spec
+    from teamarr.database.templates import update_template
+
+    db_conn.execute("DELETE FROM templates")
+    db_conn.commit()
+    tid = create_template(db_conn, **_retired_no_abbrev_spec())
+    update_template(db_conn, tid, title_format="I use this")
+
+    seed_default_templates(db_conn)
+    assert "No-Abbrev Event" in _names(db_conn)  # user's row survives
+
+
+def test_abbrev_variables_fall_back_without_abbreviation():
+    """*_team_abbrev render short/full names for leagues without abbrevs —
+    the reason the No-Abbrev variant could retire (#329)."""
+    from datetime import UTC, datetime
+
+    from teamarr.core import Event, EventStatus, Team
+    from teamarr.templates.context import GameContext, TemplateContext
+    from teamarr.templates.variables.home_away import (
+        extract_away_team_abbrev,
+        extract_home_team_abbrev,
+    )
+
+    def team(name, short, abbrev):
+        return Team(
+            id="t",
+            provider="espn",
+            name=name,
+            short_name=short,
+            abbreviation=abbrev,
+            league="epl",
+            sport="soccer",
+        )
+
+    e = Event(
+        id="e1",
+        provider="espn",
+        name="x",
+        short_name="x",
+        start_time=datetime(2026, 7, 9, tzinfo=UTC),
+        home_team=team("Manchester United", "Man United", ""),
+        away_team=team("Arsenal", "Arsenal", "ARS"),
+        status=EventStatus(state="scheduled"),
+        league="epl",
+        sport="soccer",
+    )
+    ctx = TemplateContext(game_context=GameContext(event=e), team_config=None, team_stats=None)
+    assert extract_home_team_abbrev(ctx, ctx.game_context) == "Man United"
+    assert extract_away_team_abbrev(ctx, ctx.game_context) == "ARS"


### PR DESCRIPTION
## Summary
Maintainer feedback on #330's set:

- **"(Starter)" parentheticals** on all 6 members — the included-with-Teamarr origin is visible in every list/picker/export. Unedited rows from the first iteration rename **in place** (same id; live-verified: a production DB's 7 references all survived two healing generations).
- **No-Abbrev Event retired**: the four `*_team_abbrev` variables now fall back `abbreviation → short_name → name` (only real abbrevs uppercased → `EPL | Man United/Arsenal`), so Default Event covers abbrev-less leagues. The retired member is removed only when it's still our unedited seed.
- **MiLB kept** deliberately — folding it is an alias/branding decision better made after the Gracenote analysis (tvnk.9/12).
- **Hint link fixed**: the "recommended scoping guide" link 404'd (docs site publishes from main at release time). The hint is now self-contained with an inline scoping summary.

## Test plan
- [x] 14 seeding tests (4 new: prior-name rename-in-place, retired-member removal, edited-retired safety, abbrev fallback rendering)
- [x] 1420 passed · ruff · Pyright clean · frontend build clean
- [x] Live-verified on production DB: 6 templates, ids stable across rename, references intact; hint renders inline (correctly counting only unassigned starters)