### PR TITLE
fix(ui): show Conditions tab for event templates (#329)

### DIFF
--- a/frontend/src/pages/TemplateForm.tsx
+++ b/frontend/src/pages/TemplateForm.tsx
@@ -305,8 +305,6 @@ export function TemplateForm() {
             onClick={() => {
               const nextIsTeam = !isTeamTemplate
               setFormData((prev) => ({ ...prev, template_type: nextIsTeam ? "team" : "event" }))
-              // Conditions tab is team-only; avoid landing on a hidden tab.
-              if (!nextIsTeam && activeTab === "conditions") setActiveTab("basic")
             }}
             className="ml-auto inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-sm font-medium text-primary transition-colors hover:bg-primary/10"
           >
@@ -321,13 +319,11 @@ export function TemplateForm() {
         className="mb-4"
         value={activeTab}
         onChange={(key) => setActiveTab(key as Tab)}
-        items={TABS
-          .filter((tab) => tab.id !== "conditions" || isTeamTemplate) // Hide conditions tab for event templates
-          .map((tab) => ({
-            key: tab.id,
-            label: tab.label,
-            icon: <tab.icon className="h-4 w-4" />,
-          }))}
+        items={TABS.map((tab) => ({
+          key: tab.id,
+          label: tab.label,
+          icon: <tab.icon className="h-4 w-4" />,
+        }))}
       />
 
       {/* Main content with sidebar */}


### PR DESCRIPTION
Follow-up to #341: event templates fully support conditional descriptions on the backend (the event EPG path runs the condition selector, `/variables/conditions?template_type=event` serves the event-scoped list — now led by `has_preview`/`has_recap` — and the starter set seeds a `has_preview` row), but the template form hid the Conditions tab for event templates, so users couldn't see or edit those rows.

Unhides the tab; `ConditionsTab` was already template-type aware (fetches the event-filtered condition list, defaults new rows to the first available condition).

Verified in the live UI via Playwright: Conditions tab renders on an event starter; the condition dropdown lists the provider-copy conditions first, then combat/motorsports. Gates: 1428 tests pass, ruff clean, frontend builds.