### PR TITLE
fix(templates): event-seed scope violations, graceful rank display, preview cleanup parity (#354)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 ## Key Subsystems
 
 **Template Engine** (`teamarr/templates/`):
-- 253 variables in `variables/` (20 categories)
+- 255 variables in `variables/` (20 categories)
 - 26 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`

--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -11,7 +11,7 @@ redirect_from:
 
 # Template Variables
 
-Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 253 variables across 20 categories.
+Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 255 variables across 20 categories.
 
 ## Team vs Event Templates
 
@@ -414,6 +414,8 @@ College rankings (NCAAF, NCAAM, NCAAW).
 | `{is_ranked_matchup}` | 'true' if both teams are ranked | base, .next, .last | `` |
 | `{home_team_rank}` | Home team's ranking for this game | base, .next, .last | `` |
 | `{away_team_rank}` | Away team's ranking for this game | base, .next, .last | `` |
+| `{home_team_rank_display}` | Home team's rank in Gracenote prose form ('No. 20'), empty when unranked | base, .next, .last | `No. 20` |
+| `{away_team_rank_display}` | Away team's rank in Gracenote prose form ('No. 15'), empty when unranked | base, .next, .last | `No. 15` |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 ## Features
 
 - **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 142 pre-configured leagues plus dynamically discovered soccer leagues.
-- **253 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
+- **255 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
 - **Flexible matching** - Aliases, fuzzy matching, and configurable stream ordering to handle inconsistent IPTV naming
 - **Channel groups & profiles** - Use existing Dispatcharr groups/profiles or create them dynamically using variables and wildcards
 - **Smart sorting** - Configurable stream and channel sorting modes based on priority rules

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -17,6 +17,6 @@ Internal design documentation for Teamarr's backend systems.
 | [Dispatcharr Integration](dispatcharr-layer) | HTTP client, managers, OperationResult pattern, self-healing sync |
 | [Detection Keyword Service](detection-keywords) | Stream classification patterns, sport/league hints, multi-sport hints |
 | [Database](database) | SQLite schema, settings, channel numbering, database modules |
-| [Template Engine](template-engine) | 253 variables, 26 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
+| [Template Engine](template-engine) | 255 variables, 26 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
 | [Gracenote Template Design](gracenote-template-design) | Gracenote-modeled best-in-class template design, data sources, scoping, fallback |
 | [Database Migrations](migrations) | Checkpoint + incremental migration system, schema versioning |

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -8,13 +8,13 @@ docs_version: "2.3.1"
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 253 variables across 20 categories, 26 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 255 variables across 20 categories, 26 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
 ```
 TemplateResolver
-  ├── VariableRegistry (253 variables, 20 categories)
+  ├── VariableRegistry (255 variables, 20 categories)
   ├── ConditionEvaluator (23 evaluators)
   └── ContextBuilder (Event + Team → TemplateContext)
 ```

--- a/frontend/src/pages/template-form/constants.ts
+++ b/frontend/src/pages/template-form/constants.ts
@@ -70,17 +70,28 @@ export const DEFAULT_SAMPLE_DATA: Record<string, string> = {
   sport: "Football",
 }
 
+// Mirror of the backend resolver's cleanup pass (resolver.py _cleanup_result,
+// #354): empty-variable artifacts and the article-aware leading-"the"
+// capitalization must render in the preview exactly as the engine emits them.
+function cleanupResolved(text: string): string {
+  let out = text.replace(/\s*\(\s*\)/g, "").replace(/\s*\[\s*\]/g, "")
+  out = out.replace(/ {2,}/g, " ").trim()
+  if (out.startsWith("the ")) out = "T" + out.slice(1)
+  return out
+}
+
 // Helper to create resolveTemplate function with custom sample data.
 // A known variable resolves to its value even when that value is empty (e.g.
 // a pre-game {team_score.next}); only genuinely unknown variables stay literal.
 export function createResolver(sampleData: Record<string, string>) {
   return function resolveTemplate(template: string): string {
     if (!template) return ""
-    return template.replace(/\{([^}]+)\}/g, (match, varName) => {
+    const substituted = template.replace(/\{([^}]+)\}/g, (match, varName) => {
       if (varName in sampleData) return sampleData[varName]
       const lower = varName.toLowerCase()
       if (lower in sampleData) return sampleData[lower]
       return match
     })
+    return cleanupResolved(substituted)
   }
 }

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -306,11 +306,13 @@ def _event_base(**overrides) -> dict:
         "postgame_periods": [],
         # Postgame chain (tvnk.14): conditional recap wins when the game is
         # final AND the provider published one; otherwise the fallback's
-        # constructed result line renders.
+        # constructed result line renders. Event templates are positional —
+        # only event-scope vars here ({event_result}, never {team_name_the}/
+        # {result_text}, which are TEAM_ONLY and fail builder validation, #354).
         "postgame_fallback": {
             "title": "{gracenote_category}: Postgame",
             "subtitle": "{away_team} at {home_team}",
-            "description": "{team_name_the} {result_text} {opponent_the} {final_score}",
+            "description": "Final: {event_result}",
             "art_url": _EVENT_ART,
         },
         "postgame_conditional": {
@@ -322,7 +324,9 @@ def _event_base(**overrides) -> dict:
             ),
         },
         "idle_content": {
-            "title": "{team_name} Programming",
+            # {league}, not {team_name} — event templates have no "our team"
+            # and TEAM_ONLY vars fail the event editor's validation (#354).
+            "title": "{league} Programming",
             "subtitle": "",
             "description": "",
             "art_url": "",
@@ -431,31 +435,22 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
     ),
     # College team channels (tvnk.8): Gracenote's college register is home-led
     # host framing with rank + record ("No. 20 Arkansas (20-7) hosts Texas A&M
-    # (19-8) at Bud Walton Arena") — rank row only when BOTH teams are ranked
-    # (bare {away_team_rank} is empty when unranked), conference framing when
-    # it's a conference game.
+    # (19-8) at Bud Walton Arena"). Ranks render inline via the empty-safe
+    # {*_rank_display} vars ('No. 20' or nothing, #354) — no ranked-only row
+    # needed, and one-ranked matchups show the one rank. Names are bare per
+    # the captured college register (no article).
     _team_base(
         name="College Team (Starter)",
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
             {
-                "condition": "is_ranked_matchup",
-                "condition_value": None,
-                "template": (
-                    "No. {home_team_rank} {home_team} ({home_team_record}) host "
-                    "No. {away_team_rank} {away_team} ({away_team_record}) at "
-                    "{venue}. {last_five_summary} {series_summary}"
-                ),
-                "priority": 15,
-                "label": "Ranked matchup",
-            },
-            {
                 "condition": "is_conference_game",
                 "condition_value": None,
                 "template": (
-                    "{home_team_the} ({home_team_record}) host "
-                    "{away_team_the} ({away_team_record}) in {college_conference} "
-                    "play at {venue}. {last_five_summary} {series_summary}"
+                    "{home_team_rank_display} {home_team} ({home_team_record}) host "
+                    "{away_team_rank_display} {away_team} ({away_team_record}) in "
+                    "{college_conference} play at {venue}. "
+                    "{last_five_summary} {series_summary}"
                 ),
                 "priority": 18,
                 "label": "Conference game",
@@ -464,9 +459,9 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
                 "condition": "has_structured_preview",
                 "condition_value": None,
                 "template": (
-                    "{home_team_the} ({home_team_record}) host "
-                    "{away_team_the} ({away_team_record}) at {venue}. "
-                    "{last_five_summary} {series_summary}"
+                    "{home_team_rank_display} {home_team} ({home_team_record}) host "
+                    "{away_team_rank_display} {away_team} ({away_team_record}) at "
+                    "{venue}. {last_five_summary} {series_summary}"
                 ),
                 "priority": 20,
                 "label": "Structured preview",
@@ -475,8 +470,9 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
                 "condition": None,
                 "condition_value": None,
                 "template": (
-                    "{home_team_the} ({home_team_record}) host "
-                    "{away_team_the} ({away_team_record}) at {venue}."
+                    "{home_team_rank_display} {home_team} ({home_team_record}) host "
+                    "{away_team_rank_display} {away_team} ({away_team_record}) at "
+                    "{venue}."
                 ),
                 "priority": 100,
                 "label": "Default",
@@ -486,30 +482,19 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
     # Universal event fallback — US pro leagues with abbreviations.
     _event_base(name="Default Event (Starter)"),
     # College events (tvnk.8): same home-led rank/record register as College
-    # Team; conference row omitted (conference stats aren't reliably present
-    # in event-channel context).
+    # Team via the empty-safe {*_rank_display} vars (#354); conference row
+    # omitted (conference stats aren't reliably present in event context).
     _event_base(
         name="College Event (Starter)",
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
             {
-                "condition": "is_ranked_matchup",
-                "condition_value": None,
-                "template": (
-                    "No. {home_team_rank} {home_team} ({home_team_record}) host "
-                    "No. {away_team_rank} {away_team} ({away_team_record}) at "
-                    "{venue}. {last_five_summary} {series_summary}"
-                ),
-                "priority": 15,
-                "label": "Ranked matchup",
-            },
-            {
                 "condition": "has_structured_preview",
                 "condition_value": None,
                 "template": (
-                    "{home_team_the} ({home_team_record}) host "
-                    "{away_team_the} ({away_team_record}) at {venue}. "
-                    "{last_five_summary} {series_summary}"
+                    "{home_team_rank_display} {home_team} ({home_team_record}) host "
+                    "{away_team_rank_display} {away_team} ({away_team_record}) at "
+                    "{venue}. {last_five_summary} {series_summary}"
                 ),
                 "priority": 20,
                 "label": "Structured preview",
@@ -518,8 +503,9 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
                 "condition": None,
                 "condition_value": None,
                 "template": (
-                    "{home_team_the} ({home_team_record}) host "
-                    "{away_team_the} ({away_team_record}) at {venue}."
+                    "{home_team_rank_display} {home_team} ({home_team_record}) host "
+                    "{away_team_rank_display} {away_team} ({away_team_record}) at "
+                    "{venue}."
                 ),
                 "priority": 100,
                 "label": "Default",
@@ -539,6 +525,12 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
                 "{away_team_the} face {home_team_the} at {venue} "
                 "{today_tonight} at {game_time}."
             ),
+            "art_url": _EVENT_ART,
+        },
+        postgame_fallback={
+            "title": "{gracenote_category}: Full Time",
+            "subtitle": "{away_team} vs {home_team}",
+            "description": "Full time: {event_result}",
             "art_url": _EVENT_ART,
         },
         conditional_descriptions=[
@@ -578,6 +570,22 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
             ),
             "art_url": _EVENT_ART,
         },
+        # MMA carries no home/away scores, so the base 'Final: {event_result}'
+        # would render empty — constructed bout-register line instead (#354).
+        postgame_fallback={
+            "title": "{league} {event_number}: Postgame",
+            "subtitle": "{away_team} vs {home_team}",
+            "description": "{away_team} vs {home_team} has concluded at {venue}.",
+            "art_url": _EVENT_ART,
+        },
+        postgame_conditional={
+            "enabled": True,
+            "description_final": "{game_recap}",
+            "description_not_final": (
+                "The bout between {away_team} and {home_team} has not yet ended "
+                "as of the last update."
+            ),
+        },
         conditional_descriptions=[
             {
                 "condition": "has_preview",
@@ -608,6 +616,12 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         subtitle_template="{away_team} vs {home_team}",
         # "NED v JPN"
         event_channel_name="{away_team_abbrev} v {home_team_abbrev}",
+        postgame_fallback={
+            "title": "{gracenote_category}: Full Time",
+            "subtitle": "{away_team} vs {home_team}",
+            "description": "Full time: {event_result}",
+            "art_url": _EVENT_ART,
+        },
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
             {

--- a/teamarr/templates/variables/rankings.py
+++ b/teamarr/templates/variables/rankings.py
@@ -139,3 +139,32 @@ def extract_away_team_rank(ctx: TemplateContext, game_ctx: GameContext | None) -
     elif is_home and game_ctx.opponent_stats and game_ctx.opponent_stats.rank:
         return str(game_ctx.opponent_stats.rank)
     return ""
+
+
+# Empty-safe Gracenote-form rank prefixes (#354): render 'No. 20' or nothing,
+# so prose like '{home_team_rank_display} {home_team}' degrades gracefully for
+# unranked teams instead of leaving an orphan 'No. '. Gracenote's college
+# register spells 'No. 20'; the shorter '#20' form is the *_rank_display pair
+# above (team perspective).
+
+
+@register_variable(
+    name="home_team_rank_display",
+    category=Category.RANKINGS,
+    suffix_rules=SuffixRules.ALL,
+    description="Home team's rank in Gracenote prose form ('No. 20'), empty when unranked",
+)
+def extract_home_team_rank_display(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    rank = extract_home_team_rank(ctx, game_ctx)
+    return f"No. {rank}" if rank else ""
+
+
+@register_variable(
+    name="away_team_rank_display",
+    category=Category.RANKINGS,
+    suffix_rules=SuffixRules.ALL,
+    description="Away team's rank in Gracenote prose form ('No. 15'), empty when unranked",
+)
+def extract_away_team_rank_display(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    rank = extract_away_team_rank(ctx, game_ctx)
+    return f"No. {rank}" if rank else ""

--- a/tests/templates/test_default_template_seeding.py
+++ b/tests/templates/test_default_template_seeding.py
@@ -445,3 +445,25 @@ def test_abbrev_variables_fall_back_without_abbreviation():
     ctx = TemplateContext(game_context=GameContext(event=e), team_config=None, team_stats=None)
     assert extract_home_team_abbrev(ctx, ctx.game_context) == "Man United"
     assert extract_away_team_abbrev(ctx, ctx.game_context) == "ARS"
+
+
+def test_seed_variables_respect_template_scope():
+    """Every variable a seed uses must be visible in that template type's
+    picker/validator (#354) — a TEAM_ONLY var in an event seed makes the
+    builder's real-time validation flag our own shipped content."""
+    import teamarr.templates.variables  # noqa: F401 — triggers registration
+    from teamarr.templates.variables import registry as reg_module
+
+    registry = reg_module.VariableRegistry()
+    by_scope = {
+        "team": {v.name for v in registry.filter_by_template_type("team")},
+        "event": {v.name for v in registry.filter_by_template_type("event")},
+    }
+    violations = []
+    for spec in DEFAULT_TEMPLATE_SET:
+        allowed = by_scope[spec["template_type"]]
+        for text in _collect_strings(spec):
+            for m in _VAR_TOKEN.finditer(text):
+                if m.group(1) not in allowed:
+                    violations.append((spec["name"], m.group(1)))
+    assert not violations, f"scope-invalid variables in seeds: {sorted(set(violations))}"

--- a/tests/templates/test_starter_rendering.py
+++ b/tests/templates/test_starter_rendering.py
@@ -260,20 +260,22 @@ def test_college_ranked_matchup_leads_with_ranks(resolver):
 
 
 def test_college_unranked_never_shows_rank_prefix(resolver):
+    """{*_rank_display} is empty-safe (#354): no orphan 'No. ' ever renders."""
     spec = SPECS["College Event (Starter)"]
     ctx = _college_ctx()  # no ranks
     out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
     assert "No." not in out
-    assert out.startswith("The Arkansas Razorbacks (20-7) host the Texas A&M Aggies (19-8)")
+    assert out.startswith("Arkansas Razorbacks (20-7) host Texas A&M Aggies (19-8)")
 
 
-def test_college_one_ranked_team_is_not_a_ranked_matchup(resolver):
-    """Gate hardening: the 'No. {rank}' row needs BOTH ranks (a bare rank var
-    is empty when unranked and would render 'No. ')."""
+def test_college_one_ranked_team_shows_only_that_rank(resolver):
+    """One-ranked matchups (the common case) show the one rank gracefully —
+    previously the both-ranked gate hid ranks entirely (#354)."""
     spec = SPECS["College Event (Starter)"]
     ctx = _college_ctx(home_rank=7)  # away unranked
     out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
-    assert "No." not in out
+    assert out.startswith("No. 7 Arkansas Razorbacks (20-7) host Texas A&M Aggies (19-8)")
+    assert out.count("No.") == 1
 
 
 def test_college_conference_game_names_the_conference(resolver):


### PR DESCRIPTION
Fixes #354 (bead `teamarrv2-imcd`). Three user-reported template-builder bugs, in priority order:

## 1. Event seeds violated variable scope ("Unknown variable: {team_name_the}" etc.)
The builder's real-time validation was **working correctly** — our own event seeds were the invalid content. Every event starter carried TEAM_ONLY vars (`{team_name_the} {result_text} {opponent_the} {final_score}` in `postgame_fallback`, `{team_name}` in idle title). Now event-scope throughout: `Final: {event_result}` (base), `Full time: {event_result}` (soccer registers), a constructed bout line for combat (MMA carries no home/away scores so `{event_result}` would render empty), `{league} Programming` idle. A new seed test mirrors the picker's scope filter over every text surface of every seed — **a scope-invalid seed can never ship again**.
Rendering was never broken (the resolver resolves regardless of scope tags), so existing unedited dev rows degrade gracefully; no heal machinery needed — fresh installs and the v2.9.1 upgrade path both get fixed content. Live starters will be reset post-merge as before.

## 2. Ranks now disappear gracefully
New `{home_team_rank_display}` / `{away_team_rank_display}`: `No. 20` when ranked, empty otherwise. College rows use them inline — the `is_ranked_matchup`-gated row is gone, one-ranked matchups (the common case) now show their one rank, and an orphan `No. ` can never render. College names go bare per the captured Gracenote register (`No. 20 Arkansas (20-7) hosts Texas A&M (19-8)`). Variable count 253 → 255; all doc count claims + the variables table updated.

## 3. Preview now matches the engine
`createResolver` (builder preview) mirrors the backend resolver's cleanup pass — leading-article capitalization (`the Boston Celtics…` → `The Boston Celtics…`), empty-paren removal, space collapse. What the preview shows is what the engine emits.

Suite at **1532 passing**, ruff clean, frontend build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)