### PR TITLE
feat: Racing Event (Starter) template — Gracenote race shapes (#361)

### DIFF
--- a/docs/guide/epg/templates.md
+++ b/docs/guide/epg/templates.md
@@ -110,7 +110,7 @@ See [Conditions](conditions) for available condition types.
 
 The fastest path is the shipped starter set — every install seeds ten
 Gracenote-modeled templates covering team channels, US pro events, soccer
-(club and international), college, combat, minor-league baseball, and tennis.
+(club and international), college, combat, tennis, and racing.
 See [Default Templates](../templates/defaults) for the full
 set and recommended scoping.
 

--- a/docs/guide/templates/defaults.md
+++ b/docs/guide/templates/defaults.md
@@ -33,6 +33,7 @@ same assignments, fixed art.
 | **Combat Event (Starter)** | event | UFC / PFL / boxing (card segments) | `UFC 310 Main Card` |
 | **International Event (Starter)** | event | National-team tournaments — year-composed title (`FIFA World Cup 2026`) | `NED v JPN` |
 | **Tennis Event (Starter)** | event | ATP / WTA (per-match channels) — year-prefixed tournament title | `Alcaraz v Sinner` |
+| **Racing Event (Starter)** | event | NASCAR / F1 / IndyCar / IMSA / WEC (per-session channels) — series-led title, race + session subtitle (`Navy 250, Practice 1`) | `NASCAR Cup \| Race` |
 
 Minor-league baseball needs no dedicated starter: **Default Event** titles
 every MiLB level as Gracenote's real `Minor League Baseball` (from the league
@@ -87,6 +88,7 @@ description is used. Pregame fillers support the same pattern via the
 | Combat Event | UFC, PFL, boxing leagues |
 | International Event | National-team tournaments (World Cup, Euro, Gold Cup, …) |
 | Tennis Event | ATP, WTA |
+| Racing Event | Racing leagues (NASCAR, F1, IndyCar, IMSA, WEC) |
 
 MiLB levels (Triple-A … Rookie) are covered by **Default Event**.
 
@@ -97,3 +99,6 @@ Program art uses **relative paths** (e.g.
 the **art base URL** setting — point it at your image server and every
 template resolves against it. Absolute URLs in your own templates bypass the
 base URL.
+
+The racing starter ships without program art: race weekends have no home/away
+matchup for the cover path to compose from.

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -31,7 +31,8 @@ decisions (bead tvnk.1, 2026-07-09):
   vars, 'v' channel connector), college (home-led host framing with rank +
   record + conference rows, per the captured Gracenote preview register), and
   year-composed tournament titles (International ``{gracenote_category}
-  {year}`` per the tvnk.12 decision; Tennis ``{year} {tournament_name}``).
+  {year}`` per the tvnk.12 decision; Tennis ``{year} {tournament_name}``;
+  Racing series-led titles with race + session subtitles, #355 item 1).
   Combat/tennis/racing get no team variants — no meaningful team channels
   (racing driver channels are epic hjzo).
 """
@@ -700,6 +701,58 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         ],
         # "Alcaraz v Sinner" — surnames only, super short.
         event_channel_name="{player1_last} v {player2_last}",
+    ),
+    # Racing (F1/NASCAR/IndyCar/IMSA/WEC, #355 item 1): weekends expand into
+    # one channel per session (racing_segments.py), and home/away are the SAME
+    # placeholder team — every matchup-shaped surface (subtitle, art paths,
+    # abbrev channel names) must be overridden or it renders "Navy 250 at
+    # Navy 250". Captured Gracenote shape: title 'NASCAR Cup Series', subtitle
+    # 'Navy 250, Practice 1' — series-led title, race + session subtitle.
+    _event_base(
+        name="Racing Event (Starter)",
+        title_format="{gracenote_category}",
+        subtitle_template="{race_name}, {session_name}",
+        # No matchup art: the pascal-var cover path would compose from the
+        # placeholder team and render broken.
+        program_art_url="",
+        event_channel_logo_url="",
+        pregame_fallback={
+            "title": "Coming up: {session_name} at {game_time}",
+            "subtitle": "{race_name}, {session_name}",
+            "description": "{game_preview}",
+            "description_fallback": (
+                "{race_name} {session_name} from {circuit_name} {today_tonight} at {game_time}."
+            ),
+            "art_url": "",
+        },
+        # "Postgame" reads wrong for racing ("Navy 250: Postgame" for a
+        # practice session) — session-complete register instead, mirroring
+        # the tennis starter's "Match Complete".
+        postgame_fallback={
+            "title": "{race_name}: {session_name} Complete",
+            "subtitle": "{race_name}, {session_name}",
+            "description": "{race_name} {session_name} has concluded at {circuit_name}.",
+            "art_url": "",
+        },
+        postgame_conditional={
+            "enabled": True,
+            "description_final": "{game_recap}",
+            "description_not_final": (
+                "{race_name} {session_name} has not yet ended as of the last update."
+            ),
+        },
+        conditional_descriptions=[
+            dict(_PREVIEW_ROW),
+            {
+                "condition": None,
+                "condition_value": None,
+                "template": "{race_name} {session_name} at {circuit_name}.",
+                "priority": 100,
+                "label": "Default",
+            },
+        ],
+        # "NASCAR Cup | Race", "F1 | Qualifying" — series alias + session.
+        event_channel_name="{league} | {session_name}",
     ),
 ]
 

--- a/tests/templates/test_default_template_seeding.py
+++ b/tests/templates/test_default_template_seeding.py
@@ -58,7 +58,7 @@ def test_fresh_install_seeds_full_set(db_conn):
     # init_db already seeded (the wiring under test); re-run is a no-op
     seed_default_templates(db_conn)
     assert _names(db_conn) == SET_NAMES
-    assert len(SET_NAMES) == 9
+    assert len(SET_NAMES) == 10
 
     for t in get_all_templates(db_conn):
         # Seeded UNASSIGNED — the user scopes them

--- a/tests/templates/test_starter_rendering.py
+++ b/tests/templates/test_starter_rendering.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from teamarr.core.types import Event, EventStatus, Team, TeamStats, Venue
+from teamarr.core.types import Event, EventStatus, RacingSession, Team, TeamStats, Venue
 from teamarr.database.default_templates import DEFAULT_TEMPLATE_SET
 from teamarr.services import league_mappings as lm
 from teamarr.templates.context import GameContext, TeamChannelContext, TemplateContext
@@ -158,6 +158,37 @@ def _tennis_ctx(**kw):
     return _ctx(ev)
 
 
+def _racing_ctx(**kw):
+    # Racing home/away are the SAME placeholder team (named after the race);
+    # the session code rides in card_segment, set per-channel by the
+    # racing_segments expansion.
+    car = _team("Navy 250", "N250", "nascar-cup", "racing", "1")
+    ev = Event(
+        id="e1", provider="nascar", name="Navy 250", short_name="Navy 250",
+        start_time=datetime(2026, 7, 10, 19, 0, tzinfo=UTC),
+        home_team=car, away_team=car, status=EventStatus(state="pre"),
+        league="nascar-cup", sport="racing",
+        venue=Venue(name="Nashville Superspeedway", city="Lebanon", state="TN"),
+        circuit_name="Nashville Superspeedway",
+        sessions=[
+            RacingSession(code="fp1", name="Practice 1",
+                          start_time=datetime(2026, 7, 10, 19, 0, tzinfo=UTC)),
+            RacingSession(code="qualifying", name="Qualifying",
+                          start_time=datetime(2026, 7, 11, 17, 0, tzinfo=UTC)),
+            RacingSession(code="race", name="Race",
+                          start_time=datetime(2026, 7, 12, 19, 0, tzinfo=UTC)),
+        ],
+    )
+    game_ctx = GameContext(event=ev, is_home=True, card_segment="fp1", **kw)
+    return TemplateContext(
+        game_context=game_ctx,
+        team_config=TeamChannelContext(
+            team_id="1", league="nascar-cup", sport="racing", team_name=car.name,
+        ),
+        team_stats=None, next_game=game_ctx, last_game=game_ctx,
+    )
+
+
 def _milb_ctx(**kw):
     home = _team("Sugar Land Space Cowboys", "SUG", "milb-aaa", "baseball", "1")
     away = _team("Albuquerque Isotopes", "ABQ", "milb-aaa", "baseball", "2")
@@ -176,6 +207,7 @@ _CTX_FOR_TEMPLATE = {
     "Combat Event (Starter)": _combat_ctx,
     "International Event (Starter)": _national_ctx,
     "Tennis Event (Starter)": _tennis_ctx,
+    "Racing Event (Starter)": _racing_ctx,
 }
 
 
@@ -319,6 +351,28 @@ def test_tennis_year_prefixed_tournament_title(resolver):
     # player1 mirrors fighter1 = the away slot (first in ESPN's event title)
     sub = resolver.resolve(spec["subtitle_template"], ctx)
     assert sub == "Final - Jannik Sinner vs Carlos Alcaraz"
+
+
+def test_racing_series_title_and_session_surfaces(resolver):
+    """Racing convention (#355 item 1, captured Gracenote shape): series-led
+    title ('NASCAR Cup Series'), 'race, session' subtitle, session-led channel
+    name — never the placeholder-team matchup ('Navy 250 at Navy 250')."""
+    spec = SPECS["Racing Event (Starter)"]
+    ctx = _racing_ctx()
+    title = resolver.resolve(spec["title_format"], ctx)
+    assert title == "NASCAR Cup Series"
+    sub = resolver.resolve(spec["subtitle_template"], ctx)
+    assert sub == "Navy 250, Practice 1"
+    channel = resolver.resolve(spec["event_channel_name"], ctx)
+    assert channel == "NASCAR Cup | Practice 1"
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out == "Navy 250 Practice 1 at Nashville Superspeedway."
+    # Racing home/away are the same placeholder team — no surface may use
+    # matchup vars, or it renders "Navy 250 at Navy 250".
+    for label, template in _text_surfaces(spec):
+        assert "{away_team" not in template and "{home_team" not in template, (
+            f"matchup var in racing surface {label}: {template!r}"
+        )
 
 
 def test_milb_titles_as_minor_league_baseball_via_default_event(resolver):


### PR DESCRIPTION
Closes-to-dev for #361 (#355 item 1, accepted in triage).

## What
- New `Racing Event (Starter)` in `DEFAULT_TEMPLATE_SET` — racing leagues previously fell through to Default Event, whose `{away_team} at {home_team}` subtitle renders the placeholder team twice ("Navy 250 at Navy 250").
- Captured Gracenote shape: title `{gracenote_category}` ("NASCAR Cup Series"), subtitle `{race_name}, {session_name}` ("Navy 250, Practice 1"), channel name `{league} | {session_name}` ("NASCAR Cup | Race").
- Session-complete postgame register ("Navy 250: Practice 1 Complete") — "Postgame" reads wrong for racing sessions.
- No matchup art: racing home/away are the same placeholder team, so the pascal-var cover path would compose broken URLs.
- Docs: set + scoping tables in `docs/guide/templates/defaults.md`; fixed the stale family list in `docs/guide/epg/templates.md` (still counted retired MiLB).

## Tests
- `_racing_ctx` added to the starter-rendering harness — every surface renders clean through the real resolver.
- New `test_racing_series_title_and_session_surfaces` asserts the conventions above and that **no racing surface uses matchup vars**.
- Seeding set-count 9 → 10.

Gates: ruff clean, 1570 passed, frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)