### PR TITLE
feat: seed marquee/stage notes via has_event_note + has_match_note (#363)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 
 **Template Engine** (`teamarr/templates/`):
 - 259 variables in `variables/` (20 categories)
-- 26 condition evaluators in `conditions.py`
+- 28 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`
 

--- a/docs/guide/epg/conditions.md
+++ b/docs/guide/epg/conditions.md
@@ -146,6 +146,8 @@ When generating EPG, Teamarr evaluates all conditions and selects the highest-pr
 | `has_preview` | - | Provider preview blurb is available (populates same-day pregame) |
 | `has_recap` | - | Provider recap headline is available (populates once the game is final) |
 | `has_structured_preview` | - | Recent-form data is available (populates days ahead) |
+| `has_event_note` | - | Marquee/playoff note is available (`NBA Finals - Game 5`, `CFP Quarterfinal at the Cotton Bowl Classic`); empty for ordinary games |
+| `has_match_note` | - | Soccer competition note is available (`FIFA World Cup, Group C`); soccer only |
 
 Use these to prefer ESPN's editorial copy and fall back to constructed prose
 when it isn't published yet — the pattern the starter templates ship with:
@@ -154,6 +156,7 @@ when it isn't published yet — the pattern the starter templates ship with:
 ```json
 [
   {"condition": "has_preview", "priority": 10, "template": "{game_preview}"},
+  {"condition": "has_event_note", "priority": 15, "template": "{game_event_note}. {team_name} vs {opponent} at {venue}"},
   {"priority": 100, "template": "{team_name} vs {opponent} at {venue}"}
 ]
 ```

--- a/docs/guide/templates/defaults.md
+++ b/docs/guide/templates/defaults.md
@@ -61,10 +61,12 @@ constructed prose when it isn't available:
 
 - **Pregame / main program** — when ESPN publishes a preview blurb (usually
   on game day), it's used verbatim via a `has_preview → {game_preview}`
-  conditional row; for games further out, a structured-preview row enriches
-  the constructed line with recent form and series state ("The Rays have won
-  2 of their last five… BOS leads series 3-2"); otherwise the plain
-  constructed "X travel to Y…" line renders.
+  conditional row; marquee games lead with the provider's designation when
+  one exists ("NBA Finals - Game 5. …", "FIFA World Cup, Group C. …" via
+  `has_event_note` / `has_match_note` rows); for games further out, a
+  structured-preview row enriches the constructed line with recent form and
+  series state ("The Rays have won 2 of their last five… BOS leads series
+  3-2"); otherwise the plain constructed "X travel to Y…" line renders.
 - **Postgame** — once a game is final and ESPN publishes a recap headline,
   the filler shows `{game_recap}`; until then a constructed result line
   ("The X defeated the Y 4–2") renders instead.

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -17,6 +17,6 @@ Internal design documentation for Teamarr's backend systems.
 | [Dispatcharr Integration](dispatcharr-layer) | HTTP client, managers, OperationResult pattern, self-healing sync |
 | [Detection Keyword Service](detection-keywords) | Stream classification patterns, sport/league hints, multi-sport hints |
 | [Database](database) | SQLite schema, settings, channel numbering, database modules |
-| [Template Engine](template-engine) | 259 variables, 26 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
+| [Template Engine](template-engine) | 259 variables, 28 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
 | [Gracenote Template Design](gracenote-template-design) | Gracenote-modeled best-in-class template design, data sources, scoping, fallback |
 | [Database Migrations](migrations) | Checkpoint + incremental migration system, schema versioning |

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -8,7 +8,7 @@ docs_version: "2.3.1"
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 26 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 28 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
@@ -221,7 +221,7 @@ optimistic layer while the debounced server render is in flight.
 | File | Purpose |
 |------|---------|
 | `templates/resolver.py` | Variable resolution pipeline |
-| `templates/conditions.py` | 26 condition evaluators |
+| `templates/conditions.py` | 28 condition evaluators |
 | `templates/context.py` | Context dataclasses (Odds, GameContext, TemplateContext) |
 | `templates/context_builder.py` | Build TemplateContext from Event + Team |
 | `templates/variables/` | 20 category modules with 240 variable definitions |

--- a/teamarr/api/routes/variables.py
+++ b/teamarr/api/routes/variables.py
@@ -344,6 +344,18 @@ def get_conditions(template_type: str = "team"):
             "requires_value": False,
             "providers": "espn",
         },
+        {
+            "name": "has_event_note",
+            "description": "Marquee/playoff note is available ('NBA Finals - Game 5')",
+            "requires_value": False,
+            "providers": "espn",
+        },
+        {
+            "name": "has_match_note",
+            "description": "Soccer competition note is available ('FIFA World Cup, Group C')",
+            "requires_value": False,
+            "providers": "espn",
+        },
     ]
 
     # Team-only conditions (require "our team" perspective)

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -246,6 +246,19 @@ def _team_base(**overrides) -> dict:
                 "priority": 10,
                 "label": "Preview (provider)",
             },
+            # Marquee/playoff note (#355 item 2): 'NBA Finals - Game 5. The…'
+            # — fires only when ESPN attaches a note; ordinary games skip it.
+            {
+                "condition": "has_event_note",
+                "condition_value": None,
+                "template": (
+                    "{game_event_note}. The {away_team_record} {away_team} travel to "
+                    "{venue_city}, {venue_state} to take on the {home_team_record} "
+                    "{home_team} at {venue}."
+                ),
+                "priority": 15,
+                "label": "Marquee note",
+            },
             {
                 "condition": "has_structured_preview",
                 "condition_value": None,
@@ -353,6 +366,19 @@ def _event_base(**overrides) -> dict:
                 "priority": 10,
                 "label": "Preview (provider)",
             },
+            # Marquee/playoff note (#355 item 2): 'NBA Finals - Game 5. The…'
+            # — fires only when ESPN attaches a note; ordinary games skip it.
+            {
+                "condition": "has_event_note",
+                "condition_value": None,
+                "template": (
+                    "{game_event_note}. The {away_team_record} {away_team} travel to "
+                    "{venue_city}, {venue_state} to take on the {home_team_record} "
+                    "{home_team} at {venue}."
+                ),
+                "priority": 15,
+                "label": "Marquee note",
+            },
             # Tier-2 (tvnk.15): constructed line enriched with recent form +
             # series state — populates days ahead, unlike preview prose.
             {
@@ -394,6 +420,17 @@ _PREVIEW_ROW = {
     "label": "Preview (provider)",
 }
 
+# Competition/stage note for the soccer-register starters (#355 item 2):
+# 'FIFA World Cup, Group C. Belgium face Spain at MetLife Stadium.' — fires
+# only when the provider attaches a note.
+_MATCH_NOTE_ROW = {
+    "condition": "has_match_note",
+    "condition_value": None,
+    "template": "{soccer_match_note}. {away_team_the} face {home_team_the} at {venue}.",
+    "priority": 15,
+    "label": "Competition note",
+}
+
 
 DEFAULT_TEMPLATE_SET: list[dict] = [
     _team_base(name="Default Team (Starter)"),
@@ -415,6 +452,7 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         },
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
+            dict(_MATCH_NOTE_ROW),
             {
                 "condition": "has_structured_preview",
                 "condition_value": None,
@@ -444,6 +482,19 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         name="College Team (Starter)",
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
+            # Marquee note: bowls, CFP rounds, tournament designations
+            # ('CFP Quarterfinal at the Cotton Bowl Classic. …', #355 item 2).
+            {
+                "condition": "has_event_note",
+                "condition_value": None,
+                "template": (
+                    "{game_event_note}. {home_team_rank_display} {home_team} "
+                    "({home_team_record}) host {away_team_rank_display} {away_team} "
+                    "({away_team_record}) at {venue}."
+                ),
+                "priority": 15,
+                "label": "Marquee note",
+            },
             {
                 "condition": "is_conference_game",
                 "condition_value": None,
@@ -489,6 +540,19 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         name="College Event (Starter)",
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
+            # Marquee note: bowls, CFP rounds, tournament designations
+            # ('CFP Quarterfinal at the Cotton Bowl Classic. …', #355 item 2).
+            {
+                "condition": "has_event_note",
+                "condition_value": None,
+                "template": (
+                    "{game_event_note}. {home_team_rank_display} {home_team} "
+                    "({home_team_record}) host {away_team_rank_display} {away_team} "
+                    "({away_team_record}) at {venue}."
+                ),
+                "priority": 15,
+                "label": "Marquee note",
+            },
             {
                 "condition": "has_structured_preview",
                 "condition_value": None,
@@ -536,6 +600,7 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         },
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
+            dict(_MATCH_NOTE_ROW),
             {
                 "condition": "has_structured_preview",
                 "condition_value": None,
@@ -625,6 +690,7 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
         },
         conditional_descriptions=[
             dict(_PREVIEW_ROW),
+            dict(_MATCH_NOTE_ROW),
             {
                 "condition": "has_structured_preview",
                 "condition_value": None,

--- a/teamarr/templates/conditions.py
+++ b/teamarr/templates/conditions.py
@@ -15,6 +15,8 @@ Condition Types:
 - has_recap: Provider recap headline available (postgame)
 - has_preview: Provider preview blurb available (same-day pregame)
 - has_structured_preview: Recent-form data available (days-ahead)
+- has_event_note: Marquee/playoff note available ('NBA Finals - Game 5')
+- has_match_note: Soccer competition note available ('FIFA World Cup, Group C')
 - opponent_name_contains: Opponent name contains string
 
 Priority:
@@ -265,6 +267,23 @@ class ConditionEvaluator:
         """Check if structured preview data (recent form) is available."""
         event = game_ctx.event
         return bool(event and (event.home_last_five or event.away_last_five))
+
+    def _eval_has_event_note(
+        self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
+    ) -> bool:
+        """Check if the provider's marquee/playoff note is available
+        ('NBA Finals - Game 5', 'CFP Quarterfinal at the Cotton Bowl Classic').
+        Empty for ordinary regular-season games."""
+        event = game_ctx.event
+        return bool(event and event.game_event_note)
+
+    def _eval_has_match_note(
+        self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
+    ) -> bool:
+        """Check if the provider's soccer competition note is available
+        ('FIFA World Cup, Group C'). Soccer-only; empty otherwise."""
+        event = game_ctx.event
+        return bool(event and event.soccer_match_note)
 
     # =========================================================================
     # Opponent conditions

--- a/tests/templates/test_espn_copy_first.py
+++ b/tests/templates/test_espn_copy_first.py
@@ -101,6 +101,24 @@ def test_has_preview_condition():
     assert ev.evaluate("has_preview", None, ctx, gc) is False
 
 
+def test_has_event_note_condition():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(game_event_note="NBA Finals - Game 5"))
+    assert ev.evaluate("has_event_note", None, ctx, gc) is True
+
+    ctx, gc = _ctx(_event())
+    assert ev.evaluate("has_event_note", None, ctx, gc) is False
+
+
+def test_has_match_note_condition():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(soccer_match_note="FIFA World Cup, Group C"))
+    assert ev.evaluate("has_match_note", None, ctx, gc) is True
+
+    ctx, gc = _ctx(_event())
+    assert ev.evaluate("has_match_note", None, ctx, gc) is False
+
+
 def test_selector_prefers_preview_row_then_constructed_default():
     options = [
         {"condition": "has_preview", "priority": 10, "template": "{game_preview}"},

--- a/tests/templates/test_starter_rendering.py
+++ b/tests/templates/test_starter_rendering.py
@@ -317,6 +317,43 @@ def test_college_conference_game_names_the_conference(resolver):
     assert "in Southeastern Conference play" in out
 
 
+def test_marquee_note_leads_us_pro_description(resolver):
+    """#355 item 2: an NBA Finals game must not describe like a random
+    February game — the has_event_note row prefixes the marquee designation."""
+    spec = SPECS["Default Event (Starter)"]
+    ctx = _nba_ctx(game_event_note="NBA Finals - Game 5")
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out.startswith("NBA Finals - Game 5. The 8-4 Detroit Pistons travel to")
+
+
+def test_marquee_note_leads_college_description(resolver):
+    """Bowls/CFP rounds lead the college register when the note exists."""
+    spec = SPECS["College Event (Starter)"]
+    ctx = _college_ctx(home_rank=20, away_rank=15,
+                       game_event_note="CFP Quarterfinal at the Cotton Bowl Classic")
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out.startswith(
+        "CFP Quarterfinal at the Cotton Bowl Classic. No. 20 Arkansas Razorbacks"
+    )
+
+
+def test_match_note_leads_soccer_description(resolver):
+    """Competition + group/stage lead the soccer register when present."""
+    spec = SPECS["International Event (Starter)"]
+    ctx = _national_ctx(soccer_match_note="FIFA World Cup, Group C")
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out == "FIFA World Cup, Group C. Belgium face Spain at MetLife Stadium."
+
+
+def test_provider_preview_still_beats_marquee_note(resolver):
+    """ESPN-copy-first holds: the preview blurb outranks the note row."""
+    spec = SPECS["Default Event (Starter)"]
+    ctx = _nba_ctx(game_event_note="NBA Finals - Game 5",
+                   game_preview="Pistons look to even the series in Boston.")
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out == "Pistons look to even the series in Boston."
+
+
 def test_provider_preview_short_circuits_construction(resolver):
     """has_preview beats every constructed row (ESPN-copy-first, tvnk.14)."""
     spec = SPECS["Default Event (Starter)"]


### PR DESCRIPTION
For #363 (#355 item 2, accepted in triage).

## What
- Two new condition evaluators, `has_event_note` and `has_match_note` (`has_preview` pattern) — the note vars are empty on ordinary games, and `is_playoff` is the wrong gate (fires without a note; misses cups/bowls).
- Priority-15 note rows in **7 starters** (below provider preview per ESPN-copy-first, above structured/conference/default rows):
  - Default Team/Event + College Team/Event → `has_event_note`: *"NBA Finals - Game 5. The 8-4 Detroit Pistons travel to…"* / *"CFP Quarterfinal at the Cotton Bowl Classic. No. 20 Arkansas…host…"*
  - Soccer Team, Soccer Club Event, International Event → `has_match_note`: *"FIFA World Cup, Group C. Belgium face Spain at MetLife Stadium."*
  - Combat/Tennis/Racing skip deliberately — brand/round/session already lead their titles.
- Conditions exposed in the `GET /variables/conditions` picker for both template types.
- Docs: `conditions.md` table + example, `defaults.md` description-precedence section, condition-count claims 26 → 28 (CLAUDE.md, template-engine.md ×2, architecture index).

## Notes
- Existing installs keep their current descriptions: conditional-row content isn't part of the seed-heal fingerprint (#355 item 14, still to triage). Rows reach fresh installs and re-created starters.

## Tests
- Evaluator tests (present/absent) in `test_espn_copy_first.py`.
- Rendering tests: marquee leads US-pro + college registers, match note leads soccer register, preview still beats the note row. 1576 passed; ruff clean; frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)