### PR TITLE
feat: neutral-site awareness — ingest, vs-flip, is_neutral_site, seed rows (#365)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 
 **Template Engine** (`teamarr/templates/`):
 - 259 variables in `variables/` (20 categories)
-- 28 condition evaluators in `conditions.py`
+- 29 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`
 

--- a/docs/guide/epg/conditions.md
+++ b/docs/guide/epg/conditions.md
@@ -100,6 +100,24 @@ When generating EPG, Teamarr evaluates all conditions and selects the highest-pr
 
 ---
 
+### Neutral Site
+
+| Condition | Value | Description |
+|-----------|-------|-------------|
+| `is_neutral_site` | - | Game is at a neutral site (bowls, CFP/NCAA tournament rounds, showcase games) |
+
+Host framing ("X travel to…", "Y host X…") misrepresents a game nobody
+hosts — branch to neutral prose instead. The `{at_vs}` / `{vs_at}` / `{vs_@}`
+connector variables also read `vs` automatically at neutral sites, so
+subtitles flip without a condition.
+
+**Example:**
+```json
+{"condition": "is_neutral_site", "priority": 17, "template": "{away_team} and {home_team} meet at {venue}."}
+```
+
+---
+
 ### Conference (College)
 
 | Condition | Value | Description |

--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -176,10 +176,10 @@ Positional team references and home/away context.
 | `{is_home}` | 'true' if team is home, 'false' if away | base, .next, .last | `true` |
 | `{is_away}` | 'true' if team is away, 'false' if home | base, .next, .last | `false` |
 | `{home_away_text}` | 'at home' or 'on the road' | base, .next, .last | `at home` |
-| `{vs_at}` | 'vs' if home, 'at' if away | base, .next, .last | `vs` |
-| `{at_vs}` | Perspective-free connector: 'at' for US team sports, 'vs.' otherwise | base, .next, .last | `at` |
+| `{vs_at}` | 'vs' if home, 'at' if away; neutral-site games read 'vs' | base, .next, .last | `vs` |
+| `{at_vs}` | Perspective-free connector: 'at' for US team sports, 'vs.' otherwise; neutral-site games always read 'vs.' | base, .next, .last | `at` |
 | `{home_away_verb}` | 'host' at home, 'visit' away | base, .next, .last | `host` |
-| `{vs_@}` | 'vs' if home, '@' if away | base, .next, .last | `vs` |
+| `{vs_@}` | 'vs' if home, '@' if away; neutral-site games read 'vs' | base, .next, .last | `vs` |
 
 {: .note }
 The `_the` variables emit a lowercase `the` for mid-sentence use ("take on

--- a/docs/guide/templates/defaults.md
+++ b/docs/guide/templates/defaults.md
@@ -63,10 +63,15 @@ constructed prose when it isn't available:
   on game day), it's used verbatim via a `has_preview → {game_preview}`
   conditional row; marquee games lead with the provider's designation when
   one exists ("NBA Finals - Game 5. …", "FIFA World Cup, Group C. …" via
-  `has_event_note` / `has_match_note` rows); for games further out, a
-  structured-preview row enriches the constructed line with recent form and
-  series state ("The Rays have won 2 of their last five… BOS leads series
-  3-2"); otherwise the plain constructed "X travel to Y…" line renders.
+  `has_event_note` / `has_match_note` rows); neutral-site games (bowls,
+  CFP/NCAA tournament rounds) drop host framing for "X and Y meet at {venue}"
+  via an `is_neutral_site` row; for games further out, a structured-preview
+  row enriches the constructed line with recent form and series state ("The
+  Rays have won 2 of their last five… BOS leads series 3-2"); otherwise the
+  plain constructed "X travel to Y…" line renders.
+- **Subtitles** — the US-register starters connect matchups with the
+  neutral-aware `{at_vs}` variable: "Pistons at Celtics" for hosted games,
+  "Ohio State vs. Texas" at neutral sites (the Gracenote convention).
 - **Postgame** — once a game is final and ESPN publishes a recap headline,
   the filler shows `{game_recap}`; until then a constructed result line
   ("The X defeated the Y 4–2") renders instead.

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -17,6 +17,6 @@ Internal design documentation for Teamarr's backend systems.
 | [Dispatcharr Integration](dispatcharr-layer) | HTTP client, managers, OperationResult pattern, self-healing sync |
 | [Detection Keyword Service](detection-keywords) | Stream classification patterns, sport/league hints, multi-sport hints |
 | [Database](database) | SQLite schema, settings, channel numbering, database modules |
-| [Template Engine](template-engine) | 259 variables, 28 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
+| [Template Engine](template-engine) | 259 variables, 29 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
 | [Gracenote Template Design](gracenote-template-design) | Gracenote-modeled best-in-class template design, data sources, scoping, fallback |
 | [Database Migrations](migrations) | Checkpoint + incremental migration system, schema versioning |

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -8,7 +8,7 @@ docs_version: "2.3.1"
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 28 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 29 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
@@ -221,7 +221,7 @@ optimistic layer while the debounced server render is in flight.
 | File | Purpose |
 |------|---------|
 | `templates/resolver.py` | Variable resolution pipeline |
-| `templates/conditions.py` | 28 condition evaluators |
+| `templates/conditions.py` | 29 condition evaluators |
 | `templates/context.py` | Context dataclasses (Odds, GameContext, TemplateContext) |
 | `templates/context_builder.py` | Build TemplateContext from Event + Team |
 | `templates/variables/` | 20 category modules with 240 variable definitions |

--- a/teamarr/api/routes/variables.py
+++ b/teamarr/api/routes/variables.py
@@ -356,6 +356,12 @@ def get_conditions(template_type: str = "team"):
             "requires_value": False,
             "providers": "espn",
         },
+        {
+            "name": "is_neutral_site",
+            "description": "Game is at a neutral site (bowls, CFP/NCAA tournament rounds)",
+            "requires_value": False,
+            "providers": "espn",
+        },
     ]
 
     # Team-only conditions (require "our team" perspective)

--- a/teamarr/core/naming.py
+++ b/teamarr/core/naming.py
@@ -141,8 +141,14 @@ def tournament_with_article(name: str) -> str:
 _AT_SPORTS = frozenset({"football", "basketball", "baseball", "hockey"})
 
 
-def matchup_connector(sport: str | None) -> str:
-    """Perspective-free matchup connector: 'at' for US team sports, 'vs.' else."""
+def matchup_connector(sport: str | None, neutral_site: bool = False) -> str:
+    """Perspective-free matchup connector: 'at' for US team sports, 'vs.' else.
+
+    Neutral-site games read 'vs.' regardless of sport — Gracenote drops the
+    away-at-home framing when nobody hosts (#355 item 3).
+    """
+    if neutral_site:
+        return "vs."
     return "at" if (sport or "").lower() in _AT_SPORTS else "vs."
 
 

--- a/teamarr/core/types.py
+++ b/teamarr/core/types.py
@@ -122,6 +122,11 @@ class Event:
     season_year: int | None = None
     season_type: str | None = None
 
+    # Neutral-site flag (ESPN competitions[].neutralSite): bowls, CFP/NCAA
+    # tournament rounds, showcase games. Flips matchup framing to 'vs.' and
+    # drops host framing (Gracenote convention, #355 item 3).
+    neutral_site: bool = False
+
     # Betting odds (from scoreboard API, usually same-day only)
     odds_data: dict | None = None
 

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -166,7 +166,7 @@ def _team_base(**overrides) -> dict:
     base = {
         "template_type": "team",
         "title_format": "{gracenote_category}",
-        "subtitle_template": "{away_team} at {home_team}",
+        "subtitle_template": "{away_team} {at_vs} {home_team}",
         "program_art_url": _TEAM_ART,
         "game_duration_mode": "sport",
         "pregame_enabled": True,
@@ -181,7 +181,7 @@ def _team_base(**overrides) -> dict:
         # the constructed prose is the fallback when no preview exists yet.
         "pregame_fallback": {
             "title": "Coming up: {gracenote_category} at {game_time.next}",
-            "subtitle": "{away_team.next} at {home_team.next}",
+            "subtitle": "{away_team.next} {at_vs.next} {home_team.next}",
             "description": "{game_preview.next}",
             "description_fallback": (
                 "The {away_team_record.next} {away_team.next} travel to "
@@ -197,7 +197,7 @@ def _team_base(**overrides) -> dict:
         # constructed result line renders.
         "postgame_fallback": {
             "title": "{gracenote_category}: {team_name} Postgame",
-            "subtitle": "{away_team.last} at {home_team.last}",
+            "subtitle": "{away_team.last} {at_vs.last} {home_team.last}",
             "description": (
                 "{team_name_the} {result_text.last} {opponent_the.last} {final_score.last}"
             ),
@@ -248,16 +248,29 @@ def _team_base(**overrides) -> dict:
             },
             # Marquee/playoff note (#355 item 2): 'NBA Finals - Game 5. The…'
             # — fires only when ESPN attaches a note; ordinary games skip it.
+            # Framing-neutral 'meet at' prose (#355 item 3): marquee games are
+            # often neutral-site (bowls, CFP), where host/travel framing lies.
             {
                 "condition": "has_event_note",
                 "condition_value": None,
                 "template": (
-                    "{game_event_note}. The {away_team_record} {away_team} travel to "
-                    "{venue_city}, {venue_state} to take on the {home_team_record} "
-                    "{home_team} at {venue}."
+                    "{game_event_note}. The {away_team_record} {away_team} and the "
+                    "{home_team_record} {home_team} meet at {venue}."
                 ),
                 "priority": 15,
                 "label": "Marquee note",
+            },
+            # Neutral site without a note (#355 item 3): kickoff classics,
+            # unnoted tournament rounds — nobody hosts, so 'meet at' framing.
+            {
+                "condition": "is_neutral_site",
+                "condition_value": None,
+                "template": (
+                    "The {away_team_record} {away_team} and the {home_team_record} "
+                    "{home_team} meet at {venue}. {last_five_summary} {series_summary}"
+                ),
+                "priority": 17,
+                "label": "Neutral site",
             },
             {
                 "condition": "has_structured_preview",
@@ -293,7 +306,7 @@ def _event_base(**overrides) -> dict:
     base = {
         "template_type": "event",
         "title_format": "{gracenote_category}",
-        "subtitle_template": "{away_team} at {home_team}",
+        "subtitle_template": "{away_team} {at_vs} {home_team}",
         "program_art_url": _EVENT_ART,
         "game_duration_mode": "sport",
         "pregame_enabled": True,
@@ -308,7 +321,7 @@ def _event_base(**overrides) -> dict:
         # the constructed prose is the fallback when no preview exists yet.
         "pregame_fallback": {
             "title": "Coming up: {gracenote_category} at {game_time}",
-            "subtitle": "{away_team} at {home_team}",
+            "subtitle": "{away_team} {at_vs} {home_team}",
             "description": "{game_preview}",
             "description_fallback": (
                 "The {away_team_record} {away_team} travel to {venue_city}, "
@@ -325,7 +338,7 @@ def _event_base(**overrides) -> dict:
         # {result_text}, which are TEAM_ONLY and fail builder validation, #354).
         "postgame_fallback": {
             "title": "{gracenote_category}: Postgame",
-            "subtitle": "{away_team} at {home_team}",
+            "subtitle": "{away_team} {at_vs} {home_team}",
             "description": "Final: {event_result}",
             "art_url": _EVENT_ART,
         },
@@ -368,16 +381,29 @@ def _event_base(**overrides) -> dict:
             },
             # Marquee/playoff note (#355 item 2): 'NBA Finals - Game 5. The…'
             # — fires only when ESPN attaches a note; ordinary games skip it.
+            # Framing-neutral 'meet at' prose (#355 item 3): marquee games are
+            # often neutral-site (bowls, CFP), where host/travel framing lies.
             {
                 "condition": "has_event_note",
                 "condition_value": None,
                 "template": (
-                    "{game_event_note}. The {away_team_record} {away_team} travel to "
-                    "{venue_city}, {venue_state} to take on the {home_team_record} "
-                    "{home_team} at {venue}."
+                    "{game_event_note}. The {away_team_record} {away_team} and the "
+                    "{home_team_record} {home_team} meet at {venue}."
                 ),
                 "priority": 15,
                 "label": "Marquee note",
+            },
+            # Neutral site without a note (#355 item 3): kickoff classics,
+            # unnoted tournament rounds — nobody hosts, so 'meet at' framing.
+            {
+                "condition": "is_neutral_site",
+                "condition_value": None,
+                "template": (
+                    "The {away_team_record} {away_team} and the {home_team_record} "
+                    "{home_team} meet at {venue}. {last_five_summary} {series_summary}"
+                ),
+                "priority": 17,
+                "label": "Neutral site",
             },
             # Tier-2 (tvnk.15): constructed line enriched with recent form +
             # series state — populates days ahead, unlike preview prose.
@@ -484,16 +510,30 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
             dict(_PREVIEW_ROW),
             # Marquee note: bowls, CFP rounds, tournament designations
             # ('CFP Quarterfinal at the Cotton Bowl Classic. …', #355 item 2).
+            # 'Meet at' framing, not 'host' — these are mostly neutral-site
+            # games (#355 item 3).
             {
                 "condition": "has_event_note",
                 "condition_value": None,
                 "template": (
-                    "{game_event_note}. {home_team_rank_display} {home_team} "
-                    "({home_team_record}) host {away_team_rank_display} {away_team} "
-                    "({away_team_record}) at {venue}."
+                    "{game_event_note}. {away_team_rank_display} {away_team} "
+                    "({away_team_record}) and {home_team_rank_display} {home_team} "
+                    "({home_team_record}) meet at {venue}."
                 ),
                 "priority": 15,
                 "label": "Marquee note",
+            },
+            # Neutral site without a note (#355 item 3).
+            {
+                "condition": "is_neutral_site",
+                "condition_value": None,
+                "template": (
+                    "{away_team_rank_display} {away_team} ({away_team_record}) and "
+                    "{home_team_rank_display} {home_team} ({home_team_record}) meet "
+                    "at {venue}. {last_five_summary} {series_summary}"
+                ),
+                "priority": 17,
+                "label": "Neutral site",
             },
             {
                 "condition": "is_conference_game",
@@ -542,16 +582,30 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
             dict(_PREVIEW_ROW),
             # Marquee note: bowls, CFP rounds, tournament designations
             # ('CFP Quarterfinal at the Cotton Bowl Classic. …', #355 item 2).
+            # 'Meet at' framing, not 'host' — these are mostly neutral-site
+            # games (#355 item 3).
             {
                 "condition": "has_event_note",
                 "condition_value": None,
                 "template": (
-                    "{game_event_note}. {home_team_rank_display} {home_team} "
-                    "({home_team_record}) host {away_team_rank_display} {away_team} "
-                    "({away_team_record}) at {venue}."
+                    "{game_event_note}. {away_team_rank_display} {away_team} "
+                    "({away_team_record}) and {home_team_rank_display} {home_team} "
+                    "({home_team_record}) meet at {venue}."
                 ),
                 "priority": 15,
                 "label": "Marquee note",
+            },
+            # Neutral site without a note (#355 item 3).
+            {
+                "condition": "is_neutral_site",
+                "condition_value": None,
+                "template": (
+                    "{away_team_rank_display} {away_team} ({away_team_record}) and "
+                    "{home_team_rank_display} {home_team} ({home_team_record}) meet "
+                    "at {venue}. {last_five_summary} {series_summary}"
+                ),
+                "priority": 17,
+                "label": "Neutral site",
             },
             {
                 "condition": "has_structured_preview",

--- a/teamarr/database/provider_cache.py
+++ b/teamarr/database/provider_cache.py
@@ -39,6 +39,17 @@ def event_to_dict(event: Event) -> dict:
         "broadcasts": event.broadcasts,
         "season_year": event.season_year,
         "season_type": event.season_type,
+        "neutral_site": event.neutral_site,
+        # Editorial/context copy — the has_recap/has_preview/has_event_note/
+        # has_match_note conditions and their template vars read these; a
+        # cache hit must not silently drop them (#363, #365).
+        "game_recap": event.game_recap,
+        "game_event_note": event.game_event_note,
+        "soccer_match_note": event.soccer_match_note,
+        "game_preview": event.game_preview,
+        "series_summary": event.series_summary,
+        "home_last_five": event.home_last_five,
+        "away_last_five": event.away_last_five,
         # UFC-specific fields
         "segment_times": segment_times_dict,
         "main_card_start": event.main_card_start.isoformat() if event.main_card_start else None,
@@ -141,6 +152,16 @@ def dict_to_event(data: dict) -> Event:
         broadcasts=data.get("broadcasts", []),
         season_year=data.get("season_year"),
         season_type=data.get("season_type"),
+        neutral_site=bool(data.get("neutral_site", False)),
+        # Editorial/context copy (#363, #365) — absent in pre-upgrade cache
+        # entries, so default to empty.
+        game_recap=data.get("game_recap", ""),
+        game_event_note=data.get("game_event_note", ""),
+        soccer_match_note=data.get("soccer_match_note", ""),
+        game_preview=data.get("game_preview", ""),
+        series_summary=data.get("series_summary", ""),
+        home_last_five=data.get("home_last_five", ""),
+        away_last_five=data.get("away_last_five", ""),
         # UFC-specific fields
         segment_times=segment_times or {},
         main_card_start=main_card_start,

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -678,6 +678,7 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
             notes = competition.get("notes") or []
             game_event_note = (notes[0].get("headline") if notes else "") or ""
             soccer_match_note = competition.get("altGameNote") or ""
+            neutral_site = bool(competition.get("neutralSite"))
 
             home_score = self._parse_score(home_data.get("score"))
             away_score = self._parse_score(away_data.get("score"))
@@ -708,6 +709,7 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
                 game_recap=game_recap,
                 game_event_note=game_event_note,
                 soccer_match_note=soccer_match_note,
+                neutral_site=neutral_site,
             )
         except Exception as e:
             logger.warning("[ESPN] Failed to parse event %s: %s", data.get("id", "unknown"), e)

--- a/teamarr/templates/conditions.py
+++ b/teamarr/templates/conditions.py
@@ -10,6 +10,7 @@ Condition Types:
 - is_top_ten_matchup: Both teams in top 10
 - is_conference_game: Same conference (college)
 - is_playoff, is_preseason: Season type
+- is_neutral_site: Game is at a neutral site (bowls, CFP/NCAA tournament)
 - is_national_broadcast: National TV broadcast
 - has_odds: Betting odds available
 - has_recap: Provider recap headline available (postgame)
@@ -267,6 +268,15 @@ class ConditionEvaluator:
         """Check if structured preview data (recent form) is available."""
         event = game_ctx.event
         return bool(event and (event.home_last_five or event.away_last_five))
+
+    def _eval_is_neutral_site(
+        self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
+    ) -> bool:
+        """Check if the game is at a neutral site (ESPN neutralSite: bowls,
+        CFP/NCAA tournament rounds, showcase games). Host framing ('X travel
+        to…', 'Y host X…') misrepresents these games (#355 item 3)."""
+        event = game_ctx.event
+        return bool(event and event.neutral_site)
 
     def _eval_has_event_note(
         self, value: str | None, ctx: TemplateContext, game_ctx: GameContext

--- a/teamarr/templates/sample_data.py
+++ b/teamarr/templates/sample_data.py
@@ -69,6 +69,12 @@ SAMPLE_DATA: dict[str, dict[str, str]] = {
     "at_vs": {
         "NBA": "at",
     },
+    "at_vs.next": {
+        "NBA": "at",
+    },
+    "at_vs.last": {
+        "NBA": "at",
+    },
     "home_away_verb": {
         "NBA": "host",
     },

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -87,13 +87,16 @@ def extract_home_away_text(ctx: TemplateContext, game_ctx: GameContext | None) -
     name="vs_at",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.ALL,
-    description="'vs' if home, 'at' if away",
+    description="'vs' if home, 'at' if away; neutral-site games read 'vs'",
     scope=TemplateScope.TEAM_ONLY,
 )
 def extract_vs_at(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     is_home = _is_home(ctx, game_ctx)
     if is_home is None:
         return ""
+    # Neutral site: "at Opponent" misframes a game nobody hosts (#355 item 3).
+    if game_ctx and game_ctx.event and game_ctx.event.neutral_site:
+        return "vs"
     return "vs" if is_home else "at"
 
 
@@ -101,13 +104,15 @@ def extract_vs_at(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     name="vs_@",
     category=Category.HOME_AWAY,
     suffix_rules=SuffixRules.ALL,
-    description="'vs' if home, '@' if away",
+    description="'vs' if home, '@' if away; neutral-site games read 'vs'",
     scope=TemplateScope.TEAM_ONLY,
 )
 def extract_vs_symbol(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     is_home = _is_home(ctx, game_ctx)
     if is_home is None:
         return ""
+    if game_ctx and game_ctx.event and game_ctx.event.neutral_site:
+        return "vs"
     return "vs" if is_home else "@"
 
 
@@ -492,12 +497,12 @@ def extract_away_team_ranked_the(ctx: TemplateContext, game_ctx: GameContext | N
     suffix_rules=SuffixRules.ALL,
     description="Perspective-free matchup connector between away and home — "
     "'at' for US team sports ('Mystics at Liberty'), 'vs.' otherwise "
-    "('Scotland vs. Morocco')",
+    "('Scotland vs. Morocco'); neutral-site games always read 'vs.'",
 )
 def extract_at_vs(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
     if not game_ctx or not game_ctx.event:
         return ""
-    return matchup_connector(game_ctx.event.sport)
+    return matchup_connector(game_ctx.event.sport, game_ctx.event.neutral_site)
 
 
 @register_variable(

--- a/tests/providers/test_event_cache_roundtrip.py
+++ b/tests/providers/test_event_cache_roundtrip.py
@@ -1,0 +1,67 @@
+"""Event cache serialization round-trip (#363, #365).
+
+The scoreboard cache (SportsDataService → event_to_dict/dict_to_event) must
+carry every field the template layer reads — a cache hit that silently drops
+editorial copy or the neutral-site flag would make the has_event_note /
+has_match_note / is_neutral_site conditions and their vars flicker off for
+the whole TTL window.
+"""
+
+from datetime import UTC, datetime
+
+from teamarr.core.types import Event, EventStatus, Team, Venue
+from teamarr.database.provider_cache import dict_to_event, event_to_dict
+
+
+def _event(**kw) -> Event:
+    team = Team(
+        id="1", provider="espn", name="Boston Celtics", short_name="Celtics",
+        abbreviation="BOS", league="nba", sport="basketball",
+    )
+    base = dict(
+        id="e1", provider="espn", name="DET @ BOS", short_name="DET @ BOS",
+        start_time=datetime(2026, 7, 10, 19, 0, tzinfo=UTC),
+        home_team=team, away_team=team, status=EventStatus(state="pre"),
+        league="nba", sport="basketball",
+        venue=Venue(name="TD Garden", city="Boston", state="MA"),
+    )
+    base.update(kw)
+    return Event(**base)
+
+
+def test_editorial_fields_survive_cache_roundtrip():
+    ev = _event(
+        game_recap="Celtics top Pistons for the title",
+        game_event_note="NBA Finals - Game 5",
+        soccer_match_note="FIFA World Cup, Group C",
+        game_preview="Pistons (8-4) vs. Celtics…",
+        series_summary="Series tied 1-1",
+        home_last_five="4-1",
+        away_last_five="2-3",
+    )
+    back = dict_to_event(event_to_dict(ev))
+    assert back.game_recap == ev.game_recap
+    assert back.game_event_note == ev.game_event_note
+    assert back.soccer_match_note == ev.soccer_match_note
+    assert back.game_preview == ev.game_preview
+    assert back.series_summary == ev.series_summary
+    assert back.home_last_five == ev.home_last_five
+    assert back.away_last_five == ev.away_last_five
+
+
+def test_neutral_site_survives_cache_roundtrip():
+    assert dict_to_event(event_to_dict(_event(neutral_site=True))).neutral_site is True
+    assert dict_to_event(event_to_dict(_event())).neutral_site is False
+
+
+def test_pre_upgrade_cache_entries_deserialize():
+    """Entries written before these fields existed must still load."""
+    data = event_to_dict(_event())
+    for key in (
+        "neutral_site", "game_recap", "game_event_note", "soccer_match_note",
+        "game_preview", "series_summary", "home_last_five", "away_last_five",
+    ):
+        data.pop(key)
+    back = dict_to_event(data)
+    assert back.neutral_site is False
+    assert back.game_event_note == ""

--- a/tests/templates/test_article_aware_naming.py
+++ b/tests/templates/test_article_aware_naming.py
@@ -100,6 +100,13 @@ def test_matchup_connector():
     assert matchup_connector("mma") == "vs."
 
 
+def test_matchup_connector_neutral_site_always_vs():
+    """Neutral-site games read 'vs.' even for US at-sports (#355 item 3)."""
+    assert matchup_connector("basketball", neutral_site=True) == "vs."
+    assert matchup_connector("football", neutral_site=True) == "vs."
+    assert matchup_connector("soccer", neutral_site=True) == "vs."
+
+
 def test_surnames():
     assert surnames("Alex de Minaur") == "de Minaur"
     assert surnames("Camilo Ugo Carabelli") == "Ugo Carabelli"

--- a/tests/templates/test_espn_copy_first.py
+++ b/tests/templates/test_espn_copy_first.py
@@ -110,6 +110,15 @@ def test_has_event_note_condition():
     assert ev.evaluate("has_event_note", None, ctx, gc) is False
 
 
+def test_is_neutral_site_condition():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(neutral_site=True))
+    assert ev.evaluate("is_neutral_site", None, ctx, gc) is True
+
+    ctx, gc = _ctx(_event())
+    assert ev.evaluate("is_neutral_site", None, ctx, gc) is False
+
+
 def test_has_match_note_condition():
     ev = ConditionEvaluator()
     ctx, gc = _ctx(_event(soccer_match_note="FIFA World Cup, Group C"))

--- a/tests/templates/test_starter_rendering.py
+++ b/tests/templates/test_starter_rendering.py
@@ -319,11 +319,16 @@ def test_college_conference_game_names_the_conference(resolver):
 
 def test_marquee_note_leads_us_pro_description(resolver):
     """#355 item 2: an NBA Finals game must not describe like a random
-    February game — the has_event_note row prefixes the marquee designation."""
+    February game — the has_event_note row prefixes the marquee designation.
+    Framing-neutral 'meet at' prose (#355 item 3): marquee games are often
+    neutral-site, where host/travel framing lies."""
     spec = SPECS["Default Event (Starter)"]
     ctx = _nba_ctx(game_event_note="NBA Finals - Game 5")
     out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
-    assert out.startswith("NBA Finals - Game 5. The 8-4 Detroit Pistons travel to")
+    assert out == (
+        "NBA Finals - Game 5. The 8-4 Detroit Pistons and the "
+        "10-2 Boston Celtics meet at The Palace."
+    )
 
 
 def test_marquee_note_leads_college_description(resolver):
@@ -332,8 +337,40 @@ def test_marquee_note_leads_college_description(resolver):
     ctx = _college_ctx(home_rank=20, away_rank=15,
                        game_event_note="CFP Quarterfinal at the Cotton Bowl Classic")
     out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out == (
+        "CFP Quarterfinal at the Cotton Bowl Classic. No. 15 Texas A&M Aggies "
+        "(19-8) and No. 20 Arkansas Razorbacks (20-7) meet at Bud Walton Arena."
+    )
+
+
+def test_neutral_site_subtitle_flips_to_vs(resolver):
+    """#355 item 3: the {at_vs} connector reads 'vs.' at neutral sites,
+    'at' for ordinary hosted US-sport games."""
+    spec = SPECS["Default Event (Starter)"]
+    hosted = resolver.resolve(spec["subtitle_template"], _nba_ctx())
+    assert hosted == "Detroit Pistons at Boston Celtics"
+    neutral = resolver.resolve(spec["subtitle_template"], _nba_ctx(neutral_site=True))
+    assert neutral == "Detroit Pistons vs. Boston Celtics"
+
+
+def test_neutral_site_description_drops_host_framing(resolver):
+    """Unnoted neutral games get 'meet at' prose instead of the travel line."""
+    spec = SPECS["Default Event (Starter)"]
+    ctx = _nba_ctx(neutral_site=True)
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
     assert out.startswith(
-        "CFP Quarterfinal at the Cotton Bowl Classic. No. 20 Arkansas Razorbacks"
+        "The 8-4 Detroit Pistons and the 10-2 Boston Celtics meet at The Palace."
+    )
+    assert "travel to" not in out and "host" not in out
+
+
+def test_neutral_site_college_keeps_ranks(resolver):
+    spec = SPECS["College Event (Starter)"]
+    ctx = _college_ctx(home_rank=7, neutral_site=True)
+    out = resolver.resolve_conditional(spec["conditional_descriptions"], ctx)
+    assert out.startswith(
+        "Texas A&M Aggies (19-8) and No. 7 Arkansas Razorbacks (20-7) meet at "
+        "Bud Walton Arena."
     )
 
 


### PR DESCRIPTION
For #365 (#355 item 3, accepted in triage — closes the issue's top-3 content gaps).

## What
- **Ingest**: `Event.neutral_site` from ESPN `competitions[].neutralSite` (scoreboard parse; no schema change).
- **Connector flip**: `{at_vs}`, `{vs_at}`, `{vs_@}` read `vs` at neutral sites — subtitles get the Gracenote 'vs.' flip through a variable, without waiting on conditions-in-titles (#355 item 11). US-register starter subtitles switch from hardcoded `at` to `{at_vs}` (base + pregame/postgame with suffixes).
- **Condition**: `is_neutral_site` (count 28 → 29), exposed to both template types.
- **Seed rows**: marquee note rows reframed to *"X and Y meet at {venue}"* — bowls/CFP are mostly neutral, and one row can't carry two conditions, so the marquee row must be framing-neutral; `is_neutral_site` rows at priority 17 (with form/series enrichment) cover unnoted neutral games. Layer: preview 10 / note 15 / neutral 17 / structured 20 / default 100.
- **Cache correctness fix**: `event_to_dict`/`dict_to_event` silently dropped ALL editorial fields — cache-hit reads lost #363's notes (and recap/preview/form) for the whole TTL window. Now carries them plus `neutral_site`, absent-safe for pre-upgrade entries. Remaining dropped fields (odds, MMA fight results, bouts) filed as **#366**.

## Example
- Hosted: subtitle `Detroit Pistons at Boston Celtics`, travel-line description.
- Neutral bowl: subtitle `Ohio State vs. Texas`, description `CFP Quarterfinal at the Cotton Bowl Classic. No. 5 Ohio State (11-2) and No. 3 Texas (12-1) meet at AT&T Stadium.`

## Docs
conditions.md (new Neutral Site section), variables.md connector rows, defaults.md description/subtitle conventions, condition-count claims ×4.

## Tests
Connector unit tests, `is_neutral_site` evaluator, subtitle flip, neutral description register (US-pro + college), reframed marquee assertions, and a new cache round-trip suite (`test_event_cache_roundtrip.py`) incl. pre-upgrade entries. 1584 passed; ruff clean; frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)