### PR TITLE
feat: soccer match-register idle/offseason filler (#368)

### DIFF
--- a/docs/guide/templates/defaults.md
+++ b/docs/guide/templates/defaults.md
@@ -72,6 +72,9 @@ constructed prose when it isn't available:
 - **Subtitles** — the US-register starters connect matchups with the
   neutral-aware `{at_vs}` variable: "Pistons at Celtics" for hosted games,
   "Ohio State vs. Texas" at neutral sites (the Gracenote convention).
+- **Idle / offseason filler** — soccer team channels phrase filler in the
+  match register ("No Chelsea Match Today", "No upcoming Chelsea matches
+  scheduled."); other families keep the US "game" phrasing.
 - **Postgame** — once a game is final and ESPN publishes a recap headline,
   the filler shows `{game_recap}`; until then a constructed result line
   ("The X defeated the Y 4–2") renders instead.

--- a/teamarr/database/default_templates.py
+++ b/teamarr/database/default_templates.py
@@ -466,6 +466,36 @@ DEFAULT_TEMPLATE_SET: list[dict] = [
     _team_base(
         name="Soccer Team (Starter)",
         subtitle_template="{away_team} vs {home_team}",
+        # Match register (#355 item 5): soccer filler says 'match', never
+        # 'game'. College keeps the base text — 'game' IS its register.
+        idle_content={
+            "title": "No {team_name} Match Today",
+            "subtitle": (
+                "Next match: {game_date.next} at {game_time.next} "
+                "{vs_at.next} {opponent_the.next}"
+            ),
+            "description": "Next match: {game_date.next} at {game_time.next} vs {opponent.next}",
+            "art_url": "",
+        },
+        idle_conditional={
+            "enabled": True,
+            "description_final": (
+                "{team_name_the} {result_text.last} {opponent_the.last} "
+                "{final_score.last} on {game_date.last}. "
+                "Next match is against {opponent_the.next} on {game_date.next}"
+            ),
+            "description_not_final": (
+                "{team_name_the} last played {opponent_the.last} on {game_date.last}."
+            ),
+        },
+        idle_offseason={
+            "title_enabled": False,
+            "title": None,
+            "subtitle_enabled": True,
+            "subtitle": "No upcoming match currently on schedule in next 30 days",
+            "description_enabled": True,
+            "description": "No upcoming {team_name} matches scheduled.",
+        },
         pregame_fallback={
             "title": "Coming up: {gracenote_category} at {game_time.next}",
             "subtitle": "{away_team.next} vs {home_team.next}",

--- a/tests/templates/test_starter_rendering.py
+++ b/tests/templates/test_starter_rendering.py
@@ -15,6 +15,7 @@ Conventions under test (docs/reference/gracenote-categories.md):
 - MiLB titles as "Minor League Baseball" (via the seeded category)
 """
 
+import re
 from datetime import UTC, datetime
 
 import pytest
@@ -460,6 +461,21 @@ def test_milb_titles_as_minor_league_baseball_via_default_event(resolver):
     # Channel prefix is the per-level alias ('AAA |'), the more informative form
     channel = resolver.resolve(spec["event_channel_name"], ctx)
     assert channel == "AAA | ABQ/SUG"
+
+
+def test_soccer_idle_uses_match_register(resolver):
+    """#355 item 5: soccer filler says 'match', never 'game'."""
+    spec = SPECS["Soccer Team (Starter)"]
+    ctx = _soccer_club_ctx()
+    title = resolver.resolve(spec["idle_content"]["title"], ctx)
+    assert title == "No Chelsea Match Today"
+    for section in ("idle_content", "idle_conditional", "idle_offseason"):
+        for key, val in spec[section].items():
+            if isinstance(val, str):
+                prose = re.sub(r"\{[^}]+\}", "", val)  # 'game' inside {vars} is fine
+                assert "game" not in prose.lower(), (
+                    f"{section}.{key} uses the US 'game' register: {val!r}"
+                )
 
 
 def test_soccer_channel_name_uses_v_connector(resolver):


### PR DESCRIPTION
For #368 (#355 item 5, accepted in triage).

Pure seed-content authoring: Soccer Team (Starter) overrides `idle_content`/`idle_conditional`/`idle_offseason` with the match register — 'No Chelsea Match Today', 'Next match: …', 'No upcoming Chelsea matches scheduled.' College reviewed and deliberately unchanged ('game' is the correct college register).

Existing installs keep their current filler (conditional/idle content isn't part of the seed-heal fingerprint — #355 item 14); fresh installs and re-created starters get it.

Tests: match-register rendering + a regex guard that no prose 'game' survives in any soccer idle surface. 1585 passed; ruff clean; frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)