### PR TITLE
fix: feed detection via ESPN broadcasts[].market + team-branded .tv token (#343)

### DIFF
--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -32,8 +32,9 @@ When multiple IPTV providers carry separate home and away broadcast feeds for th
 ### How It Works
 
 1. **Literal token detection** — stream names containing terms like "HOME" or "AWAY" are detected before team matching. The token is stripped so it doesn't interfere with team-name parsing.
-2. **Team-name detection** — if enabled, stream names are scanned for team names (e.g., "Orioles Feed") and matched against the event's home and away teams.
-3. **Channel discrimination** — streams resolved to different teams get separate channels, even for the same event. Unlabeled streams go to their own channel as usual.
+2. **Broadcast-market detection** — the stream name is matched against the event's actual broadcast listings from the provider (ESPN reports each network's market: national, home, or away). This is how team-branded channels ("Brewers.TV") and regional networks that don't carry the team's name at all ("YES", "Marquee Sports Network") resolve to the right feed. Always on; national networks never count as a team feed.
+3. **Team-name detection** — if enabled, stream names are scanned for team names in a feed context (e.g., "Orioles Feed", "Orioles.TV") and matched against the event's home and away teams.
+4. **Channel discrimination** — streams resolved to different teams get separate channels, even for the same event. Unlabeled streams go to their own channel as usual.
 
 ### Settings
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -390,10 +390,14 @@ class StreamMatching:
     ) -> list[dict]:
         """Resolve feed hints to actual teams (Phase 2 feed separation).
 
-        For each matched stream:
-        - feed_hint="home" → feed_team = event.home_team
-        - feed_hint="away" → feed_team = event.away_team
-        - No hint + detect_team_names → scan stream name for team name/short_name
+        For each matched stream, in precedence order:
+        - feed_hint="home"/"away" (explicit HOME/AWAY term) → that side's team
+        - No hint → match the stream name against the event's home/away-market
+          broadcast names (ESPN broadcasts[].market: 'Brewers.TV' → away,
+          'YES' → home) — catches team-branded and regional channels no term
+          list or team name covers (#343)
+        - Still nothing + detect_team_names → scan stream name for team
+          name/short_name in a feed-specific context
         - No match → feed_team = None (normal channel)
 
         Args:
@@ -404,17 +408,21 @@ class StreamMatching:
             event = entry.get("event")
             feed_hint = entry.get("feed_hint")
             feed_team = None
+            source = feed_hint
 
             if event and feed_hint == "home":
                 feed_team = event.home_team
             elif event and feed_hint == "away":
                 feed_team = event.away_team
-            elif event and not feed_hint and detect_team_names:
-                # Scan stream name for team name/short_name
+            elif event and not feed_hint:
                 stream_name = entry["stream"]["name"].lower()
-                feed_team = self._detect_team_in_stream_name(
-                    stream_name, event.home_team, event.away_team
-                )
+                feed_team = self._detect_feed_from_broadcast_markets(stream_name, event)
+                source = "broadcast_market"
+                if feed_team is None and detect_team_names:
+                    feed_team = self._detect_team_in_stream_name(
+                        stream_name, event.home_team, event.away_team
+                    )
+                    source = "team_name_detect"
 
             entry["feed_team"] = feed_team
 
@@ -423,10 +431,36 @@ class StreamMatching:
                     "[FEED] Stream '%s' → feed_team=%s (hint=%s)",
                     entry["stream"]["name"][:50],
                     feed_team.name,
-                    feed_hint or "team_name_detect",
+                    source,
                 )
 
         return matched_streams
+
+    @staticmethod
+    def _detect_feed_from_broadcast_markets(stream_name_lower: str, event):
+        """Match the stream name against the event's home/away-market
+        broadcast names (ESPN broadcasts[].market, #343).
+
+        'national' names never make a team feed; a stream matching BOTH
+        sides' names is ambiguous and stays a normal channel. Names shorter
+        than 3 characters are skipped (false-positive guard, same threshold
+        as team abbreviations).
+        """
+        import re
+
+        markets = getattr(event, "broadcast_markets", None) or {}
+        matched_sides: set[str] = set()
+        for name, market in markets.items():
+            if market not in ("home", "away") or len(name) < 3:
+                continue
+            if re.search(rf"\b{re.escape(name.lower())}\b", stream_name_lower):
+                matched_sides.add(market)
+
+        if matched_sides == {"home"}:
+            return event.home_team
+        if matched_sides == {"away"}:
+            return event.away_team
+        return None
 
     @staticmethod
     def _detect_team_in_stream_name(
@@ -439,6 +473,7 @@ class StreamMatching:
         - With feed keyword: "Penguins Feed", "Penguins Broadcast"
         - After pipe/dash at end: "Game | Penguins", "Game - Penguins"
         - With home/away: "Penguins Home", "Home Penguins"
+        - Team-branded channel token: "Penguins.TV" (#343)
 
         Does NOT match team names that just appear in a matchup title like
         "Penguins vs Jets" — that's a shared feed, not team-specific.
@@ -471,6 +506,8 @@ class StreamMatching:
                     rf"\b(?:feed|broadcast)[:\s]+{esc}\b",
                     rf"\b{esc}\s+(?:home|away)\b",
                     rf"\b(?:home|away)\s+{esc}\b",
+                    # Team-branded channel token: "Brewers.TV" (#343)
+                    rf"\b{esc}\.tv\b",
                 ]
 
                 for pattern in patterns:

--- a/teamarr/core/types.py
+++ b/teamarr/core/types.py
@@ -127,6 +127,12 @@ class Event:
     # drops host framing (Gracenote convention, #355 item 3).
     neutral_site: bool = False
 
+    # Broadcast name → market ('national'/'home'/'away') from ESPN
+    # broadcasts[] — data-driven feed discrimination for team-branded and
+    # regional channels ('Brewers.TV', 'YES') that carry no HOME/AWAY term
+    # (#343). broadcasts above keeps the flat name list for display.
+    broadcast_markets: dict[str, str] = field(default_factory=dict)
+
     # Betting odds (from scoreboard API, usually same-day only)
     odds_data: dict | None = None
 

--- a/teamarr/database/provider_cache.py
+++ b/teamarr/database/provider_cache.py
@@ -40,6 +40,7 @@ def event_to_dict(event: Event) -> dict:
         "season_year": event.season_year,
         "season_type": event.season_type,
         "neutral_site": event.neutral_site,
+        "broadcast_markets": event.broadcast_markets,
         # Editorial/context copy — the has_recap/has_preview/has_event_note/
         # has_match_note conditions and their template vars read these; a
         # cache hit must not silently drop them (#363, #365).
@@ -153,6 +154,7 @@ def dict_to_event(data: dict) -> Event:
         season_year=data.get("season_year"),
         season_type=data.get("season_type"),
         neutral_site=bool(data.get("neutral_site", False)),
+        broadcast_markets=data.get("broadcast_markets") or {},
         # Editorial/context copy (#363, #365) — absent in pre-upgrade cache
         # entries, so default to empty.
         game_recap=data.get("game_recap", ""),

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -671,6 +671,7 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
             status = self._parse_status(competition.get("status", {}))
             venue = self._parse_venue(competition.get("venue"))
             broadcasts = self._parse_broadcasts(competition.get("broadcasts", []))
+            broadcast_markets = self._parse_broadcast_markets(competition.get("broadcasts", []))
             odds_data = self._parse_odds(competition.get("odds", []))
 
             # Editorial/context copy — straight from the scoreboard, no per-event call.
@@ -710,6 +711,7 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
                 game_event_note=game_event_note,
                 soccer_match_note=soccer_match_note,
                 neutral_site=neutral_site,
+                broadcast_markets=broadcast_markets,
             )
         except Exception as e:
             logger.warning("[ESPN] Failed to parse event %s: %s", data.get("id", "unknown"), e)
@@ -794,6 +796,23 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
             state=address.get("state"),
             country=address.get("country"),
         )
+
+    @staticmethod
+    def _parse_broadcast_markets(broadcasts_data: list) -> dict[str, str]:
+        """Broadcast name → market ('national'/'home'/'away') from the
+        scoreboard payload — data-driven feed discrimination for
+        team-branded/regional channels ('Brewers.TV' → away, #343). The
+        summary format carries no market and is skipped.
+        """
+        markets: dict[str, str] = {}
+        for broadcast in broadcasts_data:
+            market = broadcast.get("market")
+            if not market or not isinstance(market, str):
+                continue
+            for name in broadcast.get("names") or []:
+                if name:
+                    markets[name] = market.lower()
+        return markets
 
     def _parse_broadcasts(self, broadcasts_data: list) -> list[str]:
         """Extract broadcast network names.

--- a/tests/providers/test_event_cache_roundtrip.py
+++ b/tests/providers/test_event_cache_roundtrip.py
@@ -54,14 +54,42 @@ def test_neutral_site_survives_cache_roundtrip():
     assert dict_to_event(event_to_dict(_event())).neutral_site is False
 
 
+def test_broadcast_markets_survive_cache_roundtrip():
+    markets = {"MLB.TV": "national", "Brewers.TV": "away", "Marquee Sports Network": "home"}
+    back = dict_to_event(event_to_dict(_event(broadcast_markets=markets)))
+    assert back.broadcast_markets == markets
+    assert dict_to_event(event_to_dict(_event())).broadcast_markets == {}
+
+
 def test_pre_upgrade_cache_entries_deserialize():
     """Entries written before these fields existed must still load."""
     data = event_to_dict(_event())
     for key in (
         "neutral_site", "game_recap", "game_event_note", "soccer_match_note",
         "game_preview", "series_summary", "home_last_five", "away_last_five",
+        "broadcast_markets",
     ):
         data.pop(key)
     back = dict_to_event(data)
     assert back.neutral_site is False
     assert back.game_event_note == ""
+    assert back.broadcast_markets == {}
+
+
+def test_parse_broadcast_markets_from_scoreboard_payload():
+    """ESPN scoreboard broadcasts[] → name→market mapping (#343). The
+    summary format (media.shortName, no market) contributes nothing."""
+    from teamarr.providers.espn.provider import ESPNProvider
+
+    payload = [
+        {"market": "national", "names": ["MLB.TV"]},
+        {"market": "away", "names": ["Brewers.TV"]},
+        {"market": "home", "names": ["Marquee Sports Network", "MARQ+"]},
+        {"media": {"shortName": "NBC"}},  # summary format: no market
+    ]
+    assert ESPNProvider._parse_broadcast_markets(payload) == {
+        "MLB.TV": "national",
+        "Brewers.TV": "away",
+        "Marquee Sports Network": "home",
+        "MARQ+": "home",
+    }

--- a/tests/test_feed_separation.py
+++ b/tests/test_feed_separation.py
@@ -251,6 +251,79 @@ class TestDetectTeamInStreamName:
         )
         assert result == home_team
 
+    def test_team_branded_channel_token(self, home_team, away_team):
+        """'Yankees.TV' is a team-specific feed even with no feed keyword (#343)."""
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        result = EventGroupProcessor._detect_team_in_stream_name(
+            "mlb 04: yankees @ orioles (yankees.tv)", home_team, away_team
+        )
+        assert result == away_team
+
+
+# ===========================================================================
+# Broadcast-market feed detection (#343)
+# ===========================================================================
+
+
+class TestDetectFeedFromBroadcastMarkets:
+    """_detect_feed_from_broadcast_markets() maps ESPN broadcasts[].market
+    names found in the stream name to that side's team."""
+
+    @pytest.fixture
+    def event(self):
+        @dataclass
+        class MockEvent:
+            home_team: object
+            away_team: object
+            broadcast_markets: dict
+
+        return MockEvent(
+            home_team=MockTeam(
+                id="1", provider="espn", name="Chicago Cubs", short_name="Cubs",
+                abbreviation="CHC", league="mlb", sport="baseball",
+            ),
+            away_team=MockTeam(
+                id="2", provider="espn", name="Milwaukee Brewers", short_name="Brewers",
+                abbreviation="MIL", league="mlb", sport="baseball",
+            ),
+            broadcast_markets={
+                "MLB.TV": "national",
+                "Brewers.TV": "away",
+                "Marquee Sports Network": "home",
+            },
+        )
+
+    def _detect(self, stream_name, event):
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        return EventGroupProcessor._detect_feed_from_broadcast_markets(
+            stream_name.lower(), event
+        )
+
+    def test_away_market_name_matches(self, event):
+        """The #343 report: 'Brewers.TV' resolves to the away feed."""
+        assert self._detect("MLB 04: MIL @ CHC (Brewers.TV)", event) == event.away_team
+
+    def test_home_market_name_matches(self, event):
+        """Regional networks with no team token resolve via market too."""
+        assert self._detect("MIL @ CHC Marquee Sports Network", event) == event.home_team
+
+    def test_national_market_never_makes_a_feed(self, event):
+        assert self._detect("MIL @ CHC MLB.TV", event) is None
+
+    def test_both_sides_matching_is_ambiguous(self, event):
+        assert self._detect("Brewers.TV / Marquee Sports Network combo", event) is None
+
+    def test_no_broadcast_data(self, event):
+        event.broadcast_markets = {}
+        assert self._detect("MIL @ CHC (Brewers.TV)", event) is None
+
+    def test_short_names_skipped(self, event):
+        """Names under 3 chars are skipped (false-positive guard)."""
+        event.broadcast_markets = {"TV": "away"}
+        assert self._detect("some tv stream", event) is None
+
 
 # ===========================================================================
 # Feed label generation


### PR DESCRIPTION
Fixes #343 (lands on dev; issue closes at release per workflow).

## Problem
Feed discrimination was HOME/AWAY-**term** based, with a team-name fallback that only matched strict feed contexts (`(Brewers)`, `Brewers Feed`, `Brewers Home`). So:
- `Brewers.TV` never registered as the Brewers (away) feed — stream-priority rules couldn't order it.
- Regional networks with no team token at all (`YES`, `Marquee Sports Network`) could never resolve.

## Fix (three pieces, per the triage design on #343)
1. **Ingest** — ESPN `broadcasts[].market` becomes `Event.broadcast_markets` (name → national/home/away), serialized through the event cache round-trip (the #366 lesson).
2. **Matcher** — new resolution stage in `_resolve_feed_teams`, between the explicit term hint and the team-name scan: a stream name matching a home/away-market broadcast name resolves to that side's team. `national` names never make a team feed; a stream matching both sides is ambiguous and stays a normal channel; names under 3 chars are skipped.
3. **Team-name loosening** — the feed-context patterns now accept the team-branded channel token (`Brewers.TV`), covering feeds ESPN doesn't list; the existing opposing-team-after guard still prevents matchup-title false positives.

Precedence: explicit HOME/AWAY term → broadcast market → team-name context. Once `feed_team` resolves, the existing `team_feed` stream-ordering rules work with no further changes.

## Tests
- `_parse_broadcast_markets` scoreboard payload (summary format contributes nothing)
- Cache round-trip incl. pre-upgrade entries
- Market detection: away name (the exact #343 report), regional home name, national ignored, both-sides ambiguity, short-name guard, no data
- Team-branded token `(yankees.tv)` → away feed

1604 passed; ruff clean; frontend build OK.

Thanks @FractalBoy for the report and the `broadcasts[].market` find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)