### PR TITLE
fix: fuzzy broadcast-name matching for feed detection (#343)

### DIFF
--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -32,7 +32,7 @@ When multiple IPTV providers carry separate home and away broadcast feeds for th
 ### How It Works
 
 1. **Literal token detection** — stream names containing terms like "HOME" or "AWAY" are detected before team matching. The token is stripped so it doesn't interfere with team-name parsing.
-2. **Broadcast-market detection** — the stream name is matched against the event's actual broadcast listings from the provider (ESPN reports each network's market: national, home, or away). This is how team-branded channels ("Brewers.TV") and regional networks that don't carry the team's name at all ("YES", "Marquee Sports Network") resolve to the right feed. Always on; national networks never count as a team feed.
+2. **Broadcast-market detection** — the stream name is matched against the event's actual broadcast listings from the provider (ESPN reports each network's market: national, home, or away). This is how team-branded channels ("Brewers.TV") and regional networks that don't carry the team's name at all ("YES", "Marquee Sports Network") resolve to the right feed. Matching tolerates the usual stream-name drift — punctuation and casing ("BREWERS TV"), run-together forms ("BrewersTV"), and abbreviated words ("Bally Sports WI" for "Bally Sports Wisconsin"). Always on; national networks never count as a team feed.
 3. **Team-name detection** — if enabled, stream names are scanned for team names in a feed context (e.g., "Orioles Feed", "Orioles.TV") and matched against the event's home and away teams.
 4. **Channel discrimination** — streams resolved to different teams get separate channels, even for the same event. Unlabeled streams go to their own channel as usual.
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -437,23 +437,80 @@ class StreamMatching:
         return matched_streams
 
     @staticmethod
+    def _broadcast_name_in_stream(name_norm: str, stream_norm: str) -> bool:
+        """Fuzzy-tolerant presence check for a normalized broadcast name in
+        a normalized stream name (#343). Stream names rarely quote the ESPN
+        listing verbatim, so three tiers:
+
+        1. Exact normalized phrase (word-boundary) — punctuation/case
+           variants ('Brewers.TV' ↔ 'BREWERS TV'); the ONLY tier for short
+           single-token names ('YES'), which fuzzier tiers would over-match.
+        2. Collapsed substring (≥5 chars) — run-together forms ('BrewersTV').
+        3. Token window for multi-word names — each name token must match
+           the aligned stream token exactly, by prefix ('WI' ↔ 'Wisconsin'),
+           or fuzzily (rapidfuzz ratio ≥ 80 for tokens ≥ 4 chars): covers
+           abbreviated/near-miss forms ('Bally Sports WI').
+        """
+        import re
+
+        if not name_norm:
+            return False
+        if re.search(rf"\b{re.escape(name_norm)}\b", stream_norm):
+            return True
+        collapsed = name_norm.replace(" ", "")
+        if len(collapsed) >= 5 and collapsed in stream_norm.replace(" ", ""):
+            return True
+
+        name_tokens = name_norm.split()
+        if len(name_tokens) < 2:
+            return False
+        stream_tokens = stream_norm.split()
+        n = len(name_tokens)
+        return any(
+            all(
+                StreamMatching._broadcast_tokens_match(nt, st)
+                for nt, st in zip(name_tokens, stream_tokens[i : i + n], strict=True)
+            )
+            for i in range(len(stream_tokens) - n + 1)
+        )
+
+    @staticmethod
+    def _broadcast_tokens_match(a: str, b: str) -> bool:
+        """Single-token equivalence for the broadcast token window."""
+        from rapidfuzz import fuzz
+
+        if a == b:
+            return True
+        if len(a) >= 2 and len(b) >= 2 and (a.startswith(b) or b.startswith(a)):
+            return True
+        return len(a) >= 4 and len(b) >= 4 and fuzz.ratio(a, b) >= 80
+
+    @staticmethod
     def _detect_feed_from_broadcast_markets(stream_name_lower: str, event):
         """Match the stream name against the event's home/away-market
         broadcast names (ESPN broadcasts[].market, #343).
 
-        'national' names never make a team feed; a stream matching BOTH
-        sides' names is ambiguous and stays a normal channel. Names shorter
-        than 3 characters are skipped (false-positive guard, same threshold
-        as team abbreviations).
+        Matching is fuzzy-tolerant (see _broadcast_name_in_stream) since
+        stream names rarely quote the listing verbatim. 'national' names
+        never make a team feed; a stream matching BOTH sides' names is
+        ambiguous and stays a normal channel. Names shorter than 3
+        characters are skipped (false-positive guard, same threshold as
+        team abbreviations).
         """
-        import re
+        from teamarr.utilities.fuzzy_match import normalize_text
 
         markets = getattr(event, "broadcast_markets", None) or {}
+        if not markets:
+            return None
+        stream_norm = normalize_text(stream_name_lower)
         matched_sides: set[str] = set()
         for name, market in markets.items():
-            if market not in ("home", "away") or len(name) < 3:
+            if market not in ("home", "away"):
                 continue
-            if re.search(rf"\b{re.escape(name.lower())}\b", stream_name_lower):
+            name_norm = normalize_text(name)
+            if len(name_norm) < 3:
+                continue
+            if StreamMatching._broadcast_name_in_stream(name_norm, stream_norm):
                 matched_sides.add(market)
 
         if matched_sides == {"home"}:
@@ -506,8 +563,9 @@ class StreamMatching:
                     rf"\b(?:feed|broadcast)[:\s]+{esc}\b",
                     rf"\b{esc}\s+(?:home|away)\b",
                     rf"\b(?:home|away)\s+{esc}\b",
-                    # Team-branded channel token: "Brewers.TV" (#343)
-                    rf"\b{esc}\.tv\b",
+                    # Team-branded channel token: "Brewers.TV" / "Brewers TV"
+                    # / "BrewersTV" (#343)
+                    rf"\b{esc}[.\s]?tv\b",
                 ]
 
                 for pattern in patterns:

--- a/tests/test_feed_separation.py
+++ b/tests/test_feed_separation.py
@@ -260,6 +260,16 @@ class TestDetectTeamInStreamName:
         )
         assert result == away_team
 
+    def test_team_branded_channel_token_variants(self, home_team, away_team):
+        """Spaced and run-together forms count too: 'Yankees TV', 'YankeesTV'."""
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        for variant in ("yankees @ orioles yankees tv", "yankees @ orioles (yankeestv)"):
+            result = EventGroupProcessor._detect_team_in_stream_name(
+                variant, home_team, away_team
+            )
+            assert result == away_team, variant
+
 
 # ===========================================================================
 # Broadcast-market feed detection (#343)
@@ -323,6 +333,32 @@ class TestDetectFeedFromBroadcastMarkets:
         """Names under 3 chars are skipped (false-positive guard)."""
         event.broadcast_markets = {"TV": "away"}
         assert self._detect("some tv stream", event) is None
+
+    # -- fuzzy tiers (#343 follow-up): streams rarely quote the listing --
+
+    def test_punctuation_variant_matches(self, event):
+        """'Brewers.TV' listed, stream says 'BREWERS TV'."""
+        assert self._detect("MLB 04: MIL @ CHC BREWERS TV", event) == event.away_team
+
+    def test_run_together_variant_matches(self, event):
+        """'Brewers.TV' listed, stream says 'BrewersTV'."""
+        assert self._detect("MLB 04: MIL @ CHC (BrewersTV)", event) == event.away_team
+
+    def test_abbreviated_multiword_name_fuzzy_matches(self, event):
+        """'Bally Sports Wisconsin' listed, stream says 'Bally Sports WI'."""
+        event.broadcast_markets = {"Bally Sports Wisconsin": "away"}
+        assert self._detect("MIL @ CHC | Bally Sports WI", event) == event.away_team
+
+    def test_short_single_token_stays_exact(self, event):
+        """'YES' must not fuzzy-match into unrelated words."""
+        event.broadcast_markets = {"YES": "home"}
+        assert self._detect("yesterday replay: MIL @ CHC", event) is None
+        assert self._detect("MIL @ CHC on YES", event) == event.home_team
+
+    def test_matchup_team_name_alone_does_not_match(self, event):
+        """'Brewers.TV' listed: a plain matchup title mentioning the Brewers
+        (no channel token) must not become a team feed."""
+        assert self._detect("Milwaukee Brewers @ Chicago Cubs", event) is None
 
 
 # ===========================================================================


### PR DESCRIPTION
Follow-up to #376 for #343: exact word-boundary matching missed the usual stream-name drift — sometimes the name matches ESPN's listing exactly, sometimes not.

## Matching tiers (`_broadcast_name_in_stream`)
1. **Exact normalized phrase** (via the shared `normalize_text`) — punctuation/case variants: `Brewers.TV` ↔ `BREWERS TV`. The ONLY tier for short single-token names (`YES`), which fuzzier tiers would over-match (`yesterday` stays unmatched).
2. **Collapsed substring** (≥5 chars) — run-together forms: `BrewersTV`.
3. **Token window** for multi-word names — each name token must match the aligned stream token exactly, by prefix (`WI` ↔ `Wisconsin`), or fuzzily (rapidfuzz `ratio ≥ 80`, tokens ≥ 4 chars): `Bally Sports WI` ↔ `Bally Sports Wisconsin`. (Tried `partial_ratio ≥ 90` first — it scores 81 on exactly this case, so the token window replaced it.)

Also: the team-branded channel token now accepts spaced/run-together forms (`Brewers TV`, `BrewersTV`). Reuses the codebase fuzzy primitives (`rapidfuzz`, `utilities.fuzzy_match.normalize_text`) rather than inventing new ones.

## Guards kept
National names never make a feed; both-sides match stays ambiguous; a plain matchup title mentioning the team ("Milwaukee Brewers @ Chicago Cubs") does not match `Brewers.TV` (no `tv` token in any tier).

## Tests
6 new cases: punctuation variant, run-together, abbreviated multi-word, short-name exactness (`yesterday` guard), matchup-title non-match, team-token variants. 1610 passed; ruff clean; frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)