### PR TITLE
fix: team-branded domain tokens beyond .tv — whitelisted TLDs (#343)

### DIFF
--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -33,7 +33,7 @@ When multiple IPTV providers carry separate home and away broadcast feeds for th
 
 1. **Literal token detection** — stream names containing terms like "HOME" or "AWAY" are detected before team matching. The token is stripped so it doesn't interfere with team-name parsing.
 2. **Broadcast-market detection** — the stream name is matched against the event's actual broadcast listings from the provider (ESPN reports each network's market: national, home, or away). This is how team-branded channels ("Brewers.TV") and regional networks that don't carry the team's name at all ("YES", "Marquee Sports Network") resolve to the right feed. Matching tolerates the usual stream-name drift — punctuation and casing ("BREWERS TV"), run-together forms ("BrewersTV"), and abbreviated words ("Bally Sports WI" for "Bally Sports Wisconsin"). Always on; national networks never count as a team feed.
-3. **Team-name detection** — if enabled, stream names are scanned for team names in a feed context (e.g., "Orioles Feed", "Orioles.TV") and matched against the event's home and away teams.
+3. **Team-name detection** — if enabled, stream names are scanned for team names in a feed context (e.g., "Orioles Feed", "Orioles.TV", "Orioles.US") and matched against the event's home and away teams.
 4. **Channel discrimination** — streams resolved to different teams get separate channels, even for the same event. Unlabeled streams go to their own channel as usual.
 
 ### Settings

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -530,7 +530,7 @@ class StreamMatching:
         - With feed keyword: "Penguins Feed", "Penguins Broadcast"
         - After pipe/dash at end: "Game | Penguins", "Game - Penguins"
         - With home/away: "Penguins Home", "Home Penguins"
-        - Team-branded channel token: "Penguins.TV" (#343)
+        - Team-branded channel token: "Penguins.TV", "Penguins.US" (#343)
 
         Does NOT match team names that just appear in a matchup title like
         "Penguins vs Jets" — that's a shared feed, not team-specific.
@@ -566,6 +566,12 @@ class StreamMatching:
                     # Team-branded channel token: "Brewers.TV" / "Brewers TV"
                     # / "BrewersTV" (#343)
                     rf"\b{esc}[.\s]?tv\b",
+                    # Domain-style token: "Brewers.US", "Brewers.Live". DOT
+                    # form with whitelisted TLDs only — a spaced variant
+                    # would false-positive on matchup connectors ("Brewers
+                    # vs Cubs") and an open [a-z]+ suffix on dot-separated
+                    # stream names ("MLB.Brewers.Cubs.720p").
+                    rf"\b{esc}\.(?:us|com|net|org|live|io|app|stream)\b",
                 ]
 
                 for pattern in patterns:

--- a/tests/test_feed_separation.py
+++ b/tests/test_feed_separation.py
@@ -270,6 +270,29 @@ class TestDetectTeamInStreamName:
             )
             assert result == away_team, variant
 
+    def test_team_branded_domain_suffix(self, home_team, away_team):
+        """Whitelisted domain-style tokens count: 'Yankees.US', 'Yankees.Live'."""
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        for variant in (
+            "yankees @ orioles (yankees.us)",
+            "yankees @ orioles yankees.live",
+        ):
+            result = EventGroupProcessor._detect_team_in_stream_name(
+                variant, home_team, away_team
+            )
+            assert result == away_team, variant
+
+    def test_dot_separated_stream_name_not_a_feed(self, home_team, away_team):
+        """Dot-separated provider naming ('MLB.Yankees.Orioles.720p') must not
+        read 'Yankees.Orioles' as a domain token — TLDs are whitelisted."""
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        result = EventGroupProcessor._detect_team_in_stream_name(
+            "mlb.yankees.orioles.720p", home_team, away_team
+        )
+        assert result is None
+
 
 # ===========================================================================
 # Broadcast-market feed detection (#343)


### PR DESCRIPTION
Third follow-up for #343: `Brewers.US`-style tokens now resolve as team feeds.

## Design constraint
Dot form with **whitelisted TLDs** (`us|com|net|org|live|io|app|stream`) only:
- A spaced variant would false-positive on matchup connectors — `vs` is two letters, so `Brewers vs Cubs` would instantly read as a Brewers feed.
- An open `\.[a-z]+` suffix would false-positive on dot-separated provider naming — `MLB.Brewers.Cubs.720p` would read `Brewers.Cubs` as a domain token (and the opposing-team-after guard can't catch it, because the opposing team is *inside* the match). The new test pins this case.

Tests: `.us`/`.live` variants resolve; `MLB.Yankees.Orioles.720p` stays a normal channel. 1612 passed; ruff clean; frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)