### PR TITLE
feat: league_is/sport_is value-matched conditions (#370 part 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 
 **Template Engine** (`teamarr/templates/`):
 - 259 variables in `variables/` (20 categories)
-- 29 condition evaluators in `conditions.py`
+- 31 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`
 

--- a/docs/guide/epg/conditions.md
+++ b/docs/guide/epg/conditions.md
@@ -192,6 +192,20 @@ when it isn't published yet — the pattern the starter templates ship with:
 {"condition": "opponent_name_contains", "condition_value": "Rival", "priority": 20, "template": "🔥 Rivalry game! {team_name} vs {opponent}"}
 ```
 
+### League / Sport
+
+| Condition | Value | Description |
+|-----------|-------|-------------|
+| `league_is` | League code(s), comma-separated | Event's league matches one of the given codes (case-insensitive), e.g. `cfb` or `cfb,nfl` |
+| `sport_is` | Sport code(s), comma-separated | Event's sport matches one of the given codes (case-insensitive), e.g. `football,basketball` |
+
+Available to both team and event templates — one template can branch its description by league or sport instead of needing a separate template variant per league.
+
+**Example:**
+```json
+{"condition": "league_is", "condition_value": "cfb", "priority": 15, "template": "College football: {away_team} at {home_team}"}
+```
+
 ---
 
 ## Default Descriptions
@@ -255,3 +269,5 @@ Here's a complete set of conditions for a college football team template:
 | `is_national_broadcast` | No | National TV games |
 | `has_odds` | No | Including betting lines |
 | `opponent_name_contains` | Yes (search text) | Rivalry or specific opponent |
+| `league_is` | Yes (league codes) | Branching one template by league |
+| `sport_is` | Yes (sport codes) | Branching one template by sport |

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -17,6 +17,6 @@ Internal design documentation for Teamarr's backend systems.
 | [Dispatcharr Integration](dispatcharr-layer) | HTTP client, managers, OperationResult pattern, self-healing sync |
 | [Detection Keyword Service](detection-keywords) | Stream classification patterns, sport/league hints, multi-sport hints |
 | [Database](database) | SQLite schema, settings, channel numbering, database modules |
-| [Template Engine](template-engine) | 259 variables, 29 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
+| [Template Engine](template-engine) | 259 variables, 31 conditions, suffix rules, art-URL reconstruction, resolution pipeline |
 | [Gracenote Template Design](gracenote-template-design) | Gracenote-modeled best-in-class template design, data sources, scoping, fallback |
 | [Database Migrations](migrations) | Checkpoint + incremental migration system, schema versioning |

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -8,7 +8,7 @@ docs_version: "2.3.1"
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 29 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 259 variables across 20 categories, 31 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
@@ -221,7 +221,7 @@ optimistic layer while the debounced server render is in flight.
 | File | Purpose |
 |------|---------|
 | `templates/resolver.py` | Variable resolution pipeline |
-| `templates/conditions.py` | 29 condition evaluators |
+| `templates/conditions.py` | 31 condition evaluators |
 | `templates/context.py` | Context dataclasses (Odds, GameContext, TemplateContext) |
 | `templates/context_builder.py` | Build TemplateContext from Event + Team |
 | `templates/variables/` | 20 category modules with 240 variable definitions |

--- a/teamarr/api/routes/variables.py
+++ b/teamarr/api/routes/variables.py
@@ -364,6 +364,26 @@ def get_conditions(template_type: str = "team"):
         },
     ]
 
+    # Event identity conditions (#370) — available to BOTH template types so
+    # one template can branch a register by league/sport instead of needing
+    # per-league template variants.
+    identity_conditions = [
+        {
+            "name": "league_is",
+            "description": "Event's league is one of the given codes (e.g. cfb,nfl)",
+            "requires_value": True,
+            "value_type": "string",
+            "providers": "all",
+        },
+        {
+            "name": "sport_is",
+            "description": "Event's sport is one of the given codes (e.g. football,basketball)",
+            "requires_value": True,
+            "value_type": "string",
+            "providers": "all",
+        },
+    ]
+
     # Team-only conditions (require "our team" perspective)
     team_only_conditions = [
         # Universal: works with all providers
@@ -474,11 +494,17 @@ def get_conditions(template_type: str = "team"):
 
     if template_type == "event":
         # Event templates get game-level + combat/motorsports conditions
-        conditions = summary_conditions + combat_conditions + motorsports_conditions
+        conditions = (
+            identity_conditions
+            + summary_conditions
+            + combat_conditions
+            + motorsports_conditions
+        )
     else:
         # Team templates get all conditions
         conditions = (
             team_only_conditions
+            + identity_conditions
             + common_conditions
             + summary_conditions
             + combat_conditions

--- a/teamarr/templates/conditions.py
+++ b/teamarr/templates/conditions.py
@@ -19,6 +19,8 @@ Condition Types:
 - has_event_note: Marquee/playoff note available ('NBA Finals - Game 5')
 - has_match_note: Soccer competition note available ('FIFA World Cup, Group C')
 - opponent_name_contains: Opponent name contains string
+- league_is: Event's league is one of the given codes (value = "cfb" or "cfb,nfl")
+- sport_is: Event's sport is one of the given codes (value = "football,basketball")
 
 Priority:
 - 1-99: Conditional descriptions (lower = higher priority)
@@ -411,6 +413,39 @@ class ConditionEvaluator:
             if session.code == game_ctx.card_segment:
                 return any(r.position is not None for r in session.results)
         return False
+
+    # =========================================================================
+    # Event identity conditions (#370)
+    # =========================================================================
+
+    @staticmethod
+    def _matches_any(actual: str | None, value: str | None) -> bool:
+        """Case-insensitive membership of actual in a comma-separated value list."""
+        if not value or not actual:
+            return False
+        wanted = {v.strip().lower() for v in value.split(",") if v.strip()}
+        return actual.lower() in wanted
+
+    def _eval_league_is(
+        self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
+    ) -> bool:
+        """Check if the event's league matches one of the given codes.
+
+        Value is a comma-separated list of canonical league codes
+        (e.g. "nfl" or "cfb,nfl"), case-insensitive. Lets one template
+        branch a register by league instead of needing per-league variants.
+        """
+        return self._matches_any(getattr(game_ctx.event, "league", None), value)
+
+    def _eval_sport_is(
+        self, value: str | None, ctx: TemplateContext, game_ctx: GameContext
+    ) -> bool:
+        """Check if the event's sport matches one of the given codes.
+
+        Value is a comma-separated list of sport codes
+        (e.g. "football" or "basketball,hockey"), case-insensitive.
+        """
+        return self._matches_any(getattr(game_ctx.event, "sport", None), value)
 
 
 class ConditionalDescriptionSelector:

--- a/tests/templates/test_identity_conditions.py
+++ b/tests/templates/test_identity_conditions.py
@@ -1,0 +1,81 @@
+"""league_is / sport_is value-matched conditions (#370 part 1).
+
+One template can branch its description register by league or sport instead
+of needing a per-league template variant. Values are comma-separated code
+lists, case-insensitive.
+"""
+
+from datetime import UTC, datetime
+
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.templates.conditions import ConditionEvaluator
+from teamarr.templates.context import (
+    GameContext,
+    TeamChannelContext,
+    TemplateContext,
+)
+
+
+def _event(league: str = "nba", sport: str = "basketball") -> Event:
+    team = dict(provider="espn", league=league, sport=sport)
+    return Event(
+        id="1",
+        provider="espn",
+        name="A vs B",
+        short_name="A @ B",
+        start_time=datetime(2026, 6, 17, 19, 0, tzinfo=UTC),
+        league=league,
+        sport=sport,
+        status=EventStatus(state="pre"),
+        home_team=Team(id="1", name="Home", short_name="H", abbreviation="H", **team),
+        away_team=Team(id="2", name="Away", short_name="A", abbreviation="A", **team),
+    )
+
+
+def _ctx(event: Event) -> tuple[TemplateContext, GameContext]:
+    gc = GameContext(event=event)
+    tc = TeamChannelContext(
+        team_id="1", league=event.league, sport=event.sport, team_name="Home"
+    )
+    return TemplateContext(game_context=gc, team_config=tc, team_stats=None), gc
+
+
+def test_league_is_single_code():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(league="cfb", sport="football"))
+    assert ev.evaluate("league_is", "cfb", ctx, gc) is True
+    assert ev.evaluate("league_is", "nfl", ctx, gc) is False
+
+
+def test_league_is_comma_separated_and_case_insensitive():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(league="eng.1", sport="soccer"))
+    assert ev.evaluate("league_is", "NFL, ENG.1", ctx, gc) is True
+    assert ev.evaluate("league_is", "nfl,cfb", ctx, gc) is False
+
+
+def test_sport_is_matching():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event(league="nhl", sport="hockey"))
+    assert ev.evaluate("sport_is", "hockey", ctx, gc) is True
+    assert ev.evaluate("sport_is", "Basketball,HOCKEY", ctx, gc) is True
+    assert ev.evaluate("sport_is", "football", ctx, gc) is False
+
+
+def test_missing_value_never_matches():
+    ev = ConditionEvaluator()
+    ctx, gc = _ctx(_event())
+    assert ev.evaluate("league_is", None, ctx, gc) is False
+    assert ev.evaluate("league_is", "", ctx, gc) is False
+    assert ev.evaluate("sport_is", " , ", ctx, gc) is False
+
+
+def test_conditions_exposed_to_both_template_types():
+    from teamarr.api.routes.variables import get_conditions
+
+    for template_type in ("team", "event"):
+        names = {c["name"] for c in get_conditions(template_type)["conditions"]}
+        assert {"league_is", "sport_is"} <= names
+        by_name = {c["name"]: c for c in get_conditions(template_type)["conditions"]}
+        assert by_name["league_is"]["requires_value"] is True
+        assert by_name["league_is"]["value_type"] == "string"


### PR DESCRIPTION
Part 1 of #370 (epic `teamarrv2-hehg`): value-matched league/sport conditions so one template can branch its description register by league or sport — the absence of this is what drove the 4-variant starter set.

## What's added

- **`league_is` / `sport_is` evaluators** (`templates/conditions.py`): value is a comma-separated, case-insensitive list of codes (`cfb` or `cfb,nfl`); matches against the event's own league/sport.
- **Conditions API** (`GET /variables/conditions`): exposed to BOTH team and event template types as a new identity group (`requires_value: true`, `value_type: string`). The builder UI needs no changes — the dropdown and string-value input are API-driven.
- **Docs**: new League/Sport section + summary rows in `docs/guide/epg/conditions.md`; evaluator count claims updated 29 → 31 (template-engine.md, architecture index, CLAUDE.md).

Part 2 (conditional title/subtitle rows — architectural) stays queued as `teamarrv2-hehg.2`.

## Tests

`tests/templates/test_identity_conditions.py`: single code, comma lists, case-insensitivity, empty-value never matches, API exposure to both template types. Gates: ruff clean, 1619 passed, frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)