### PR TITLE
fix: event cache round-trip carries odds_data, combat result fields, bouts (#366)

### DIFF
--- a/teamarr/database/provider_cache.py
+++ b/teamarr/database/provider_cache.py
@@ -7,7 +7,7 @@ JSON for storage in PersistentTTLCache (SQLite-backed).
 from datetime import datetime
 
 from teamarr.core import Event, EventStatus, Team, TeamStats, Venue
-from teamarr.core.types import RacingResult, RacingSession
+from teamarr.core.types import Bout, RacingResult, RacingSession
 
 
 def event_to_dict(event: Event) -> dict:
@@ -51,9 +51,21 @@ def event_to_dict(event: Event) -> dict:
         "series_summary": event.series_summary,
         "home_last_five": event.home_last_five,
         "away_last_five": event.away_last_five,
+        # Betting odds — the has_odds condition and odds vars read this; a
+        # cache hit must not silently drop it (#366).
+        "odds_data": event.odds_data,
         # UFC-specific fields
         "segment_times": segment_times_dict,
         "main_card_start": event.main_card_start.isoformat() if event.main_card_start else None,
+        # Combat result fields — the is_knockout/is_submission/is_decision/
+        # is_finish/went_distance conditions and result vars read these (#366).
+        "bouts": [bout_to_dict(b) for b in event.bouts],
+        "fight_result_method": event.fight_result_method,
+        "finish_round": event.finish_round,
+        "finish_time": event.finish_time,
+        "weight_class": event.weight_class,
+        "fighter1_scores": event.fighter1_scores,
+        "fighter2_scores": event.fighter2_scores,
         # Racing-specific fields
         "circuit_name": event.circuit_name,
         "sessions": [racing_session_to_dict(s) for s in event.sessions],
@@ -67,6 +79,26 @@ def event_to_dict(event: Event) -> dict:
         "draw_type": event.draw_type,
         "is_major": event.is_major,
     }
+
+
+def bout_to_dict(bout: Bout) -> dict:
+    """Serialize Bout to dict."""
+    return {
+        "fighter1": bout.fighter1,
+        "fighter2": bout.fighter2,
+        "segment": bout.segment,
+        "order": bout.order,
+    }
+
+
+def dict_to_bout(data: dict) -> Bout:
+    """Deserialize dict to Bout."""
+    return Bout(
+        fighter1=data["fighter1"],
+        fighter2=data["fighter2"],
+        segment=data.get("segment", "main_card"),
+        order=data.get("order", 0),
+    )
 
 
 def racing_session_to_dict(session: RacingSession) -> dict:
@@ -164,9 +196,19 @@ def dict_to_event(data: dict) -> Event:
         series_summary=data.get("series_summary", ""),
         home_last_five=data.get("home_last_five", ""),
         away_last_five=data.get("away_last_five", ""),
+        # Betting odds (#366) — absent in pre-upgrade cache entries
+        odds_data=data.get("odds_data"),
         # UFC-specific fields
         segment_times=segment_times or {},
         main_card_start=main_card_start,
+        # Combat result fields (#366) — absent in pre-upgrade cache entries
+        bouts=[dict_to_bout(b) for b in data.get("bouts", [])],
+        fight_result_method=data.get("fight_result_method"),
+        finish_round=data.get("finish_round"),
+        finish_time=data.get("finish_time"),
+        weight_class=data.get("weight_class"),
+        fighter1_scores=data.get("fighter1_scores"),
+        fighter2_scores=data.get("fighter2_scores"),
         # Racing-specific fields
         circuit_name=data.get("circuit_name"),
         sessions=[dict_to_racing_session(s) for s in data.get("sessions", [])],

--- a/tests/providers/test_event_cache_roundtrip.py
+++ b/tests/providers/test_event_cache_roundtrip.py
@@ -61,6 +61,40 @@ def test_broadcast_markets_survive_cache_roundtrip():
     assert dict_to_event(event_to_dict(_event())).broadcast_markets == {}
 
 
+def test_odds_data_survives_cache_roundtrip():
+    odds = {"spread": "BOS -6.5", "over_under": 224.5, "provider": "ESPN BET"}
+    back = dict_to_event(event_to_dict(_event(odds_data=odds)))
+    assert back.odds_data == odds
+    assert dict_to_event(event_to_dict(_event())).odds_data is None
+
+
+def test_combat_fields_survive_cache_roundtrip():
+    from teamarr.core.types import Bout
+
+    bouts = [
+        Bout(fighter1="A. Fighter", fighter2="B. Fighter", segment="prelims", order=0),
+        Bout(fighter1="C. Champ", fighter2="D. Challenger", segment="main_card", order=1),
+    ]
+    ev = _event(
+        league="ufc", sport="mma",
+        bouts=bouts,
+        fight_result_method="ko/tko",
+        finish_round=3,
+        finish_time="3:48",
+        weight_class="Bantamweight",
+        fighter1_scores=[48, 47, 48],
+        fighter2_scores=[47, 48, 47],
+    )
+    back = dict_to_event(event_to_dict(ev))
+    assert back.bouts == bouts
+    assert back.fight_result_method == "ko/tko"
+    assert back.finish_round == 3
+    assert back.finish_time == "3:48"
+    assert back.weight_class == "Bantamweight"
+    assert back.fighter1_scores == [48, 47, 48]
+    assert back.fighter2_scores == [47, 48, 47]
+
+
 def test_pre_upgrade_cache_entries_deserialize():
     """Entries written before these fields existed must still load."""
     data = event_to_dict(_event())
@@ -68,12 +102,18 @@ def test_pre_upgrade_cache_entries_deserialize():
         "neutral_site", "game_recap", "game_event_note", "soccer_match_note",
         "game_preview", "series_summary", "home_last_five", "away_last_five",
         "broadcast_markets",
+        "odds_data", "bouts", "fight_result_method", "finish_round",
+        "finish_time", "weight_class", "fighter1_scores", "fighter2_scores",
     ):
         data.pop(key)
     back = dict_to_event(data)
     assert back.neutral_site is False
     assert back.game_event_note == ""
     assert back.broadcast_markets == {}
+    assert back.odds_data is None
+    assert back.bouts == []
+    assert back.fight_result_method is None
+    assert back.fighter1_scores is None
 
 
 def test_parse_broadcast_markets_from_scoreboard_payload():


### PR DESCRIPTION
Fixes #366 — last of the cache-serialization class found during #365.

`event_to_dict`/`dict_to_event` didn't serialize `odds_data` (the `has_odds` condition and odds vars went empty on every cache-hit read), the MMA result fields (`fight_result_method`, `finish_round`, `finish_time`, `weight_class`, judge scores — the five combat conditions flickered off within the TTL), or `bouts`. Directly undermined the new starter templates, whose description chains lean on those conditions.

- Added the fields to both functions + a `Bout` serializer pair
- Pre-upgrade cache entries deserialize absent-safe (None/[] defaults), covered in the pre-upgrade test
- Extended `tests/providers/test_event_cache_roundtrip.py` per the #365 pattern

Gates: ruff clean, 1629 passed, frontend build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)