### PR TITLE
perf: EPG generation loop speedups — parallel fetches, negative caching, sync diff-loop fixes (#392)

### DIFF
--- a/docs/reference/deployment/configuration.md
+++ b/docs/reference/deployment/configuration.md
@@ -19,6 +19,7 @@ Teamarr is configured via environment variables in your `docker-compose.yml` fil
 | `LOG_FORMAT` | `text` | Log format: `text` or `json` (for log aggregation systems like ELK, Loki, Splunk) |
 | `LOG_DIR` | auto-detected | Override log directory path. See [Log Directory Detection](#log-directory-detection). |
 | `SKIP_CACHE_REFRESH` | `false` | Skip team/league cache refresh on startup. Set to `true`, `yes`, or `1`. Useful for faster restarts during development. |
+| `EPG_INDEX_FETCH_WORKERS` | `10` | Parallel workers for fetching Dispatcharr EPG programs during EPG matching. Lower it if your Dispatcharr instance struggles with concurrent requests. |
 
 ## ESPN API Settings
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -645,26 +645,48 @@ class StreamMatching:
         if not matched_streams:
             return matched_streams
 
+        # Refresh each unique event once, in parallel. The service coalesces
+        # repeated refreshes of the same event within a run (single-flight in
+        # get_event), so this is safe across threads — the dedupe here just
+        # avoids queueing redundant no-op calls.
+        from concurrent.futures import ThreadPoolExecutor
+
+        unique_events = {}
+        for match in matched_streams:
+            event = match.get("event")
+            if event:
+                unique_events.setdefault((event.league, event.id), event)
+
+        refreshed_by_key = {}
+        if unique_events:
+            workers = min(10, len(unique_events))
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                for key, refreshed in zip(
+                    unique_events.keys(),
+                    executor.map(
+                        self._service.refresh_event_status, unique_events.values()
+                    ),
+                    strict=True,
+                ):
+                    old = unique_events[key]
+                    old_status = old.status.state if old.status else "N/A"
+                    new_status = refreshed.status.state if refreshed.status else "N/A"
+                    if old_status != new_status:
+                        logger.debug(
+                            "[ENRICH] event=%s status changed: %s → %s",
+                            old.id,
+                            old_status,
+                            new_status,
+                        )
+                    refreshed_by_key[key] = refreshed
+
         enriched = []
         for match in matched_streams:
             event = match.get("event")
             if event:
-                old_status = event.status.state if event.status else "N/A"
-                # Refresh event status from provider. The service coalesces
-                # repeated refreshes of the same event within a run, so an event
-                # matched to many channels triggers a single provider fetch.
-                refreshed = self._service.refresh_event_status(event)
-                new_status = refreshed.status.state if refreshed.status else "N/A"
-                if old_status != new_status:
-                    logger.debug(
-                        "[ENRICH] event=%s status changed: %s → %s",
-                        event.id,
-                        old_status,
-                        new_status,
-                    )
                 # Preserve all keys (including segment info for UFC)
                 enriched_match = dict(match)
-                enriched_match["event"] = refreshed
+                enriched_match["event"] = refreshed_by_key[(event.league, event.id)]
                 enriched.append(enriched_match)
             else:
                 enriched.append(match)

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -6,6 +6,7 @@ the sibling mixin modules; this module owns orchestration and shared state.
 """
 
 import logging
+import time
 from collections.abc import Callable
 from datetime import date, datetime
 from sqlite3 import Connection
@@ -114,6 +115,31 @@ class EventGroupProcessor(
         # This avoids redundant API/cache lookups when multiple groups search the same leagues
         # while ensuring groups that need fresh API data can still get it
         self._shared_events: dict[str, tuple[list[Event], bool]] = {}
+
+        # Per-run consolidation state (this processor lives for one run):
+        # one lifecycle service shared by all groups, and once-per-run flags for
+        # work that used to repeat per group (scheduled deletions, the initial
+        # channel-number reassign pass).
+        self._lifecycle_service = None
+        self._deletions_processed = False
+        self._initial_reassign_done = False
+
+    def _get_lifecycle_service(self):
+        """Lifecycle service shared across all groups in this run.
+
+        The Dispatcharr channel cache is class-level (shared per URL), so
+        per-group construction never bought cache freshness — it only repeated
+        settings reads and the external-occupied computation ~160 times per run.
+        """
+        if self._lifecycle_service is None:
+            self._lifecycle_service = create_lifecycle_service(
+                self._db_factory,
+                self._service,
+                self._dispatcharr_client,
+            )
+            # Compute external channel numbers to avoid collisions (#146)
+            self._lifecycle_service.compute_external_occupied()
+        return self._lifecycle_service
 
     def _resolve_subscription_leagues(
         self, conn: Connection, group: "EventEPGGroup | None" = None
@@ -257,6 +283,9 @@ class EventGroupProcessor(
         self._shared_events.clear()
         if hasattr(self, "_subscription_leagues_cache"):
             del self._subscription_leagues_cache
+        self._lifecycle_service = None
+        self._deletions_processed = False
+        self._initial_reassign_done = False
 
         with self._db_factory() as conn:
             # Sync the system-managed "Dispatcharr Channels" source group (183.9) to
@@ -361,11 +390,7 @@ class EventGroupProcessor(
             if run_enforcement:
                 enforcement_lifecycle = None
                 if self._dispatcharr_client:
-                    enforcement_lifecycle = create_lifecycle_service(
-                        db_factory=self._db_factory,
-                        sports_service=self._service,
-                        dispatcharr_client=self._dispatcharr_client,
-                    )
+                    enforcement_lifecycle = self._get_lifecycle_service()
                 all_group_ids = [g.id for g in groups]
                 batch_result.enforcement = self._run_enforcement(
                     conn,
@@ -605,6 +630,17 @@ class EventGroupProcessor(
         # create_run always returns a ProcessingRun with its DB id populated.
         assert stats_run.id is not None
 
+        # Per-phase wall time for this group, persisted to the run stats so
+        # slow groups can be diagnosed without log archaeology.
+        phases: dict[str, float] = {}
+        _phase_start = time.time()
+
+        def _mark(phase: str) -> None:
+            nonlocal _phase_start
+            now = time.time()
+            phases[phase] = round(phases.get(phase, 0.0) + (now - _phase_start), 2)
+            _phase_start = now
+
         try:
             # Clear any previously stored XMLTV for this group so that if
             # processing crashes or produces zero matches, stale rendered
@@ -615,6 +651,7 @@ class EventGroupProcessor(
             streams = self._fetch_streams(group)
             result.streams_fetched = len(streams)
             stats_run.streams_fetched = len(streams)
+            _mark("fetch")
 
             if not streams:
                 result.errors.append("No streams found for group")
@@ -671,6 +708,7 @@ class EventGroupProcessor(
                 status_callback=status_callback,
                 resolved_leagues=effective_leagues,
             )
+            _mark("match")
             # Coverage = distinct streams; volume = total matched results (EPG/TEAM_ONLY
             # fan one stream out to many results, which is why the old result-count
             # numerator pushed match rate over 100%).
@@ -719,6 +757,7 @@ class EventGroupProcessor(
             # Enrich ALL matched events with fresh status from provider
             # This ensures lifecycle filtering uses current final status
             matched_streams = self._enrich_matched_events(matched_streams)
+            _mark("enrich")
 
             # Build event lookup BEFORE team filtering (for cleanup of existing channels)
             # Use segment-aware event_id to match channel.event_id storage
@@ -764,6 +803,7 @@ class EventGroupProcessor(
                 lifecycle_result = self._process_channels(
                     matched_streams, group, conn, current_streams=current_streams
                 )
+                _mark("channels")
                 result.channels_created = len(lifecycle_result.created)
                 result.channels_existing = len(lifecycle_result.existing)
                 result.channels_skipped = len(lifecycle_result.skipped)
@@ -826,8 +866,10 @@ class EventGroupProcessor(
                 # Step 6: Store XMLTV for this group (in database)
                 # Always store, even if empty - this clears stale XMLTV when no events match
                 self._store_group_xmltv(conn, group.id, xmltv_content or "")
+                _mark("xmltv")
 
             # Mark run as completed successfully
+            stats_run.extra_metrics["phase_timings"] = phases
             stats_run.complete(status="completed")
 
             # Update group's processing stats
@@ -854,6 +896,7 @@ class EventGroupProcessor(
         except Exception as e:
             logger.exception(f"Error processing group {group.name}")
             result.errors.append(str(e))
+            stats_run.extra_metrics["phase_timings"] = phases
             stats_run.complete(status="failed", error=str(e))
 
         # Save stats run
@@ -886,14 +929,7 @@ class EventGroupProcessor(
         """
         from teamarr.consumers.lifecycle import StreamProcessResult
 
-        lifecycle_service = create_lifecycle_service(
-            self._db_factory,
-            self._service,  # Required for template resolution
-            self._dispatcharr_client,
-        )
-
-        # Compute external channel numbers to avoid collisions (#146)
-        lifecycle_service.compute_external_occupied()
+        lifecycle_service = self._get_lifecycle_service()
 
         # Build group config dict
         # Per-group profiles/channel groups removed — now resolved from
@@ -915,37 +951,48 @@ class EventGroupProcessor(
 
         combined_result = StreamProcessResult()
 
+        from teamarr.database.channel_numbers import (
+            is_sticky_mode,
+            reassign_all_channels,
+        )
+
         # v59: Global channel reassignment before processing
         # Ensures all channels have correct numbers based on global mode.
-        # Skipped in sticky (gap/strict) modes — those defer all placement to the
-        # single end-of-run pass in generation, which is the only one that pushes
+        # Runs once per run (not per group — each group's post-pass already
+        # left numbers correct for the next group). Skipped in sticky
+        # (gap/strict) modes — those defer all placement to the single
+        # end-of-run pass in generation, which is the only one that pushes
         # to Dispatcharr (see is_sticky_mode).
-        try:
-            from teamarr.database.channel_numbers import (
-                is_sticky_mode,
-                reassign_all_channels,
-            )
-            with lifecycle_service._db_factory() as conn:
-                if not is_sticky_mode(conn):
-                    reassign_result = reassign_all_channels(
-                        conn, external_occupied=lifecycle_service._external_occupied
-                    )
-                    if reassign_result.get("channels_moved"):
-                        logger.info(
-                            "[EVENT_EPG] Pre-process reassignment: %d channels moved",
-                            reassign_result["channels_moved"],
+        if not self._initial_reassign_done:
+            self._initial_reassign_done = True
+            try:
+                with lifecycle_service._db_factory() as conn:
+                    if not is_sticky_mode(conn):
+                        reassign_result = reassign_all_channels(
+                            conn, external_occupied=lifecycle_service._external_occupied
                         )
-        except Exception as e:
-            logger.debug("[EVENT_EPG] Error in global reassignment: %s", e)
+                        if reassign_result.get("channels_moved"):
+                            logger.info(
+                                "[EVENT_EPG] Pre-process reassignment: %d channels moved",
+                                reassign_result["channels_moved"],
+                            )
+            except Exception as e:
+                logger.debug("[EVENT_EPG] Error in global reassignment: %s", e)
 
         # V1 Parity Step 1: Process scheduled deletions first
-        try:
-            deletion_result = lifecycle_service.process_scheduled_deletions()
-            combined_result.merge(deletion_result)
-            if deletion_result.deleted:
-                logger.info("[EVENT_EPG] Deleted %d expired channels", len(deletion_result.deleted))
-        except Exception as e:
-            logger.debug("[EVENT_EPG] Error processing scheduled deletions: %s", e)
+        # Once per run — expired channels don't reappear between groups, so the
+        # per-group repetition was ~160 identical sweeps per generation.
+        if not self._deletions_processed:
+            self._deletions_processed = True
+            try:
+                deletion_result = lifecycle_service.process_scheduled_deletions()
+                combined_result.merge(deletion_result)
+                if deletion_result.deleted:
+                    logger.info(
+                        "[EVENT_EPG] Deleted %d expired channels", len(deletion_result.deleted)
+                    )
+            except Exception as e:
+                logger.debug("[EVENT_EPG] Error processing scheduled deletions: %s", e)
 
         # V1 Parity Step 2: Cleanup deleted/missing/changed streams
         if current_streams is not None:
@@ -966,20 +1013,23 @@ class EventGroupProcessor(
         )
         combined_result.merge(process_result)
 
-        # v59: Post-process global reassignment (skipped in sticky modes — see above)
-        try:
-            with lifecycle_service._db_factory() as conn:
-                if not is_sticky_mode(conn):
-                    reassign_result = reassign_all_channels(
-                        conn, external_occupied=lifecycle_service._external_occupied
-                    )
-                    if reassign_result.get("channels_moved"):
-                        logger.info(
-                            "[EVENT_EPG] Post-process reassignment: %d channels moved",
-                            reassign_result["channels_moved"],
+        # v59: Post-process global reassignment (skipped in sticky modes — see
+        # above). Only needed when this group actually changed the channel set;
+        # a no-op group leaves numbering exactly as the last pass did.
+        if combined_result.created or combined_result.deleted:
+            try:
+                with lifecycle_service._db_factory() as conn:
+                    if not is_sticky_mode(conn):
+                        reassign_result = reassign_all_channels(
+                            conn, external_occupied=lifecycle_service._external_occupied
                         )
-        except Exception as e:
-            logger.debug("[EVENT_EPG] Error reassigning channel numbers: %s", e)
+                        if reassign_result.get("channels_moved"):
+                            logger.info(
+                                "[EVENT_EPG] Post-process reassignment: %d channels moved",
+                                reassign_result["channels_moved"],
+                            )
+            except Exception as e:
+                logger.debug("[EVENT_EPG] Error reassigning channel numbers: %s", e)
 
         return combined_result
 

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -78,6 +78,23 @@ class GenerationResult:
     # For stats run tracking
     run_id: int | None = None
 
+    # Wall-clock seconds per generation phase (persisted to run stats so any
+    # two runs — local or live — can be compared phase-by-phase).
+    phase_timings: dict = field(default_factory=dict)
+
+
+class _PhaseTimer:
+    """Records elapsed wall time between phase marks."""
+
+    def __init__(self, timings: dict):
+        self._timings = timings
+        self._last = time.time()
+
+    def mark(self, phase: str) -> None:
+        now = time.time()
+        self._timings[phase] = round(self._timings.get(phase, 0.0) + (now - self._last), 2)
+        self._last = now
+
 
 # Type alias for progress callback
 # (phase: str, percent: int, message: str, current: int, total: int, item_name: str) -> None
@@ -245,11 +262,14 @@ def run_full_generation(
             dispatcharr_settings = get_dispatcharr_settings(conn)
             display_settings = get_display_settings(conn)
 
+        timer = _PhaseTimer(result.phase_timings)
+
         # Step 1: Refresh M3U accounts (0-5%)
         check_cancelled()
         update_progress("init", 3, "Refreshing M3U accounts...")
         if dispatcharr_client:
             result.m3u_refresh = _refresh_m3u_accounts(db_factory, dispatcharr_client)
+        timer.mark("m3u_refresh")
 
         # Step 2: Process all teams (5-50%) - 45% budget
         check_cancelled()
@@ -275,6 +295,7 @@ def run_full_generation(
         team_result = process_all_teams(db_factory=db_factory, progress_callback=team_progress)
         result.teams_processed = team_result.teams_processed
         result.teams_programmes = team_result.total_programmes
+        timer.mark("teams")
 
         # Transition message - teams done, starting groups
         logger.info("[GENERATION] Sending transition message: teams -> groups")
@@ -339,6 +360,7 @@ def run_full_generation(
         result.groups_processed = group_result.groups_processed
         result.groups_programmes = group_result.total_programmes
         result.programmes_total = result.teams_programmes + result.groups_programmes
+        timer.mark("groups")
 
         # Step 3b: Global channel reassignment (if enabled)
         check_cancelled()
@@ -346,6 +368,7 @@ def run_full_generation(
             db_factory, dispatcharr_client, update_progress,
             external_occupied=external_occupied,
         )
+        timer.mark("channel_reassign")
 
         # Step 3b: Apply stream ordering rules to all channels (93-95%)
         check_cancelled()
@@ -353,6 +376,7 @@ def run_full_generation(
         result.stream_ordering = _apply_stream_ordering(
             db_factory, dispatcharr_client, update_progress
         )
+        timer.mark("stream_ordering")
 
         # Step 4: Merge and save XMLTV (95-96%)
         check_cancelled()
@@ -381,6 +405,7 @@ def run_full_generation(
             logger.info(
                 "[GENERATION] EPG written to %s (%s bytes)", output_path, f"{result.file_size:,}"
             )
+        timer.mark("xmltv_save")
 
         # Create lifecycle service once for steps 5-6
         # Reuse shared_service to maintain cache warmth
@@ -418,6 +443,7 @@ def run_full_generation(
             result.epg_association = lifecycle_service.associate_epg_with_channels(
                 dispatcharr_settings.epg_id
             )
+        timer.mark("dispatcharr_epg_refresh")
 
         # Step 5b: Emby Live TV guide refresh
         check_cancelled()
@@ -606,6 +632,7 @@ def run_full_generation(
                 "[CHANNELSDVR] Refresh failed (non-blocking): %s", e
             )
             result.channelsdvr_refresh = {"success": False, "error": str(e)}
+        timer.mark("media_server_refresh")
 
         # Step 6: Process scheduled deletions (98-99%)
         check_cancelled()
@@ -623,6 +650,7 @@ def run_full_generation(
         except Exception as e:
             logger.warning("[GENERATION] Scheduled deletions failed: %s", e)
             result.deletions = {"error": str(e)}
+        timer.mark("deletions")
 
         # Step 7: Run reconciliation + cleanup (99-100%)
         check_cancelled()
@@ -639,6 +667,7 @@ def run_full_generation(
         except Exception as e:
             logger.warning("[RECONCILE] Failed: %s", e)
             result.reconciliation = {"error": str(e)}
+        timer.mark("reconciliation")
 
         # Step 7b: Stale source-group detection (lylt.1) — flag enabled groups
         # whose Dispatcharr M3U source channel-group no longer exists.
@@ -652,6 +681,7 @@ def run_full_generation(
             _run_stream_audit(db_factory, dispatcharr_client)
         except Exception as e:
             logger.warning("[STREAM_AUDIT] Post-generation audit failed: %s", e)
+        timer.mark("stream_audit")
 
         # Cleanup (history, old runs, unused logos — part of step 7)
         check_cancelled()
@@ -659,6 +689,8 @@ def run_full_generation(
         cleanup_results = _run_cleanup_tasks(db_factory, dispatcharr_client, update_progress)
         result.cleanup = cleanup_results["history"]
         result.logo_cleanup = cleanup_results["logos"]
+        timer.mark("cleanup")
+        logger.info("[GENERATION] Phase timings (s): %s", result.phase_timings)
 
         # Update and save stats run
         _finalize_stats_run(
@@ -1190,6 +1222,11 @@ def _finalize_stats_run(
 
     stats_run.extra_metrics["provider_calls"] = call_metrics.snapshot()
     stats_run.extra_metrics["provider_calls_total"] = call_metrics.total()
+
+    # Per-phase wall time so run-to-run comparisons (and perf regressions)
+    # are visible in the run summary instead of requiring log archaeology.
+    if result.phase_timings:
+        stats_run.extra_metrics["phase_timings"] = dict(result.phase_timings)
 
     with db_factory() as conn:
         active_channels = get_all_managed_channels(conn, include_deleted=False)

--- a/teamarr/consumers/lifecycle/_host.py
+++ b/teamarr/consumers/lifecycle/_host.py
@@ -42,6 +42,7 @@ class _LifecycleHost:
         _timezone: str
         _exception_keywords: list | None
         _pending_profile_changes: dict[int, dict[str, set[int]]]
+        _all_profile_ids_cache: set[int] | None
         _dispatcharr_failure_count: int
         _stream_drift_fix_count: int
 

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -531,6 +531,7 @@ class ChannelCreator(_LifecycleHost):
                 group_config=group_config,
                 template=template,
                 segment=segment,
+                stream_windowed=attach_at is not None,
             )
             result.merge(settings_result)
             return result
@@ -687,6 +688,7 @@ class ChannelCreator(_LifecycleHost):
             group_config=group_config,
             template=template,
             segment=segment,
+            stream_windowed=attach_at is not None,
         )
         result.merge(settings_result)
 

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -197,6 +197,10 @@ class ChannelLifecycleService(
         # Computed lazily via compute_external_occupied() and cached for the run
         self._external_occupied: set[int] | None = None
 
+        # Full channel-profile id catalog, fetched lazily once per run for the
+        # ALL-profiles ([0]) sentinel comparison in _sync_channel_profiles.
+        self._all_profile_ids_cache: set[int] | None = None
+
         # Dynamic group/profile resolver
         self._dynamic_resolver = DynamicResolver()
 
@@ -298,6 +302,7 @@ class ChannelLifecycleService(
             self._logo_manager.clear_cache()
         self._exception_keywords = None
         self._pending_profile_changes = {}
+        self._all_profile_ids_cache = None
         self._dispatcharr_failure_count = 0
         self._stream_drift_fix_count = 0
 
@@ -466,8 +471,14 @@ class ChannelLifecycleService(
         return fallback_template
 
     def _parse_profile_ids(self, raw: Any) -> list[int]:
-        """Parse channel profile IDs from various formats."""
-        if not raw:
+        """Parse channel profile IDs from various formats.
+
+        0 is a meaningful value (Dispatcharr's ALL-profiles sentinel), so the
+        filter must be None/empty-aware, not truthiness — `if x` dropped the
+        stored [0], making the DB read back as [] and re-PATCHing every channel
+        every run (perpetual "profiles: all profiles" sync).
+        """
+        if raw is None or raw == "":
             return []
         if isinstance(raw, str):
             try:
@@ -475,5 +486,5 @@ class ChannelLifecycleService(
             except json.JSONDecodeError:
                 return []
         if isinstance(raw, list):
-            return [int(x) for x in raw if x]
+            return [int(x) for x in raw if x is not None and x != ""]
         return []

--- a/teamarr/consumers/lifecycle/syncer.py
+++ b/teamarr/consumers/lifecycle/syncer.py
@@ -35,8 +35,14 @@ class ChannelSyncer(_LifecycleHost):
         group_config: dict,
         template: dict | None,
         segment: str | None = None,
+        stream_windowed: bool = False,
     ) -> StreamProcessResult:
         """Sync channel settings from group/template to Dispatcharr.
+
+        stream_windowed: True when the stream is time-windowed (EPG-matched,
+        attach_at set). Windowed membership is owned by the window sync in
+        stream ordering — the drift-add here must not fight it (an out-of-window
+        stream is correctly absent from Dispatcharr, not drift).
 
         V1 Parity: Syncs all 9 channel properties:
         | Source              | Dispatcharr Field    | Handling                    |
@@ -150,8 +156,12 @@ class ChannelSyncer(_LifecycleHost):
                 changes_made.append(f"channel_group_id: {old_group_id} → {new_group_id}")
 
             # 4. Check streams (M3U ID sync) - V1 parity
+            # Skipped for time-windowed streams: their membership flips with the
+            # attach/detach window (owned by the ordering-phase window sync), so
+            # "missing from Dispatcharr" is the CORRECT closed-window state — the
+            # old unconditional re-add fought the window sync every run.
             stream_id = stream.get("id") if stream else None
-            if stream_id:
+            if stream_id and not stream_windowed:
                 # streams is already tuple[int, ...] of stream IDs
                 ch_streams = current_channel.streams
                 current_stream_ids = list(ch_streams) if ch_streams else []
@@ -271,6 +281,27 @@ class ChannelSyncer(_LifecycleHost):
 
         return result
 
+    def _all_profile_ids(self) -> set[int] | None:
+        """Full channel-profile id catalog, fetched once per run.
+
+        Used to interpret Dispatcharr's ALL-profiles sentinel ([0]) against the
+        concrete id list its reads return. None = catalog unavailable (treat as
+        unverifiable rather than churning PATCHes).
+        """
+        if self._all_profile_ids_cache is not None:
+            return self._all_profile_ids_cache
+        if not self._channel_manager:
+            return None
+        try:
+            ids = {p.id for p in self._channel_manager.list_profiles()}
+        except Exception as e:
+            logger.debug("[LIFECYCLE] Profile catalog fetch failed: %s", e)
+            return None
+        if not ids:
+            return None
+        self._all_profile_ids_cache = ids
+        return self._all_profile_ids_cache
+
     def _sync_channel_profiles(
         self,
         conn: Connection,
@@ -335,6 +366,22 @@ class ChannelSyncer(_LifecycleHost):
             dispatcharr_profile_ids is None  # API didn't include field — can't check
             or sorted(effective_profile_ids) == sorted(dispatcharr_profile_ids)
         )
+        if (
+            not dispatcharr_in_sync
+            and effective_profile_ids == [0]
+            and dispatcharr_profile_ids
+        ):
+            # [0] is Dispatcharr's ALL-profiles sentinel on WRITE, but reads
+            # return the expanded concrete id list — a literal comparison always
+            # mismatches and re-PATCHed every channel every run (diff loop).
+            # In-sync for the sentinel means "member of every profile". An EMPTY
+            # Dispatcharr list stays drift (dropped from all profiles — the
+            # self-healing case) and is pushed without needing the catalog.
+            all_ids = self._all_profile_ids()
+            dispatcharr_in_sync = (
+                all_ids is None  # catalog unavailable — can't check, don't churn
+                or set(dispatcharr_profile_ids) >= all_ids
+            )
 
         if db_in_sync and dispatcharr_in_sync:
             return

--- a/teamarr/consumers/matching/epg_index.py
+++ b/teamarr/consumers/matching/epg_index.py
@@ -16,12 +16,19 @@ and categories is the matcher's job (teamarrv2-183.4).
 """
 
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 
 from teamarr.dispatcharr.managers.epg import EPGManager
 from teamarr.dispatcharr.types import DispatcharrProgram
 
 logger = logging.getLogger(__name__)
+
+# Parallel workers for the per-tvg_id program fetch. Dispatcharr is local and
+# httpx.Client is thread-safe (M3UManager.refresh_multiple already fans out
+# over the same client), so a moderate fan-out is safe.
+FETCH_WORKERS = int(os.environ.get("EPG_INDEX_FETCH_WORKERS", 10))
 
 
 def _iso_z(dt: datetime) -> str:
@@ -89,16 +96,22 @@ class EPGProgramIndex:
             )
             return cls({})
 
+        fetch_started = datetime.now(UTC)
         start_iso = _iso_z(window_start)
         end_iso = _iso_z(window_end)
 
-        by_tvg: dict[str, list[DispatcharrProgram]] = {}
-        total = 0
+        # Invert the resolution map: several stream tvg_ids can resolve to the
+        # same EPG-source tvg_id (mirrors of one linear channel), so fetch each
+        # distinct program tvg_id once and fan the result back out.
+        streams_by_program: dict[str, list[str]] = {}
         for stream_tvg, program_tvg in tvg_id_resolution.items():
             if not stream_tvg or not program_tvg:
                 continue
+            streams_by_program.setdefault(program_tvg, []).append(stream_tvg)
+
+        def fetch(program_tvg: str) -> tuple[str, list[DispatcharrProgram]]:
             # One call per resolved EPG-source tvg_id (the endpoint does not
-            # support multi-value tvg_id). Key the result by the stream tvg_id.
+            # support multi-value tvg_id).
             programs = epg_manager.search_programs(
                 tvg_id=program_tvg,
                 start_before=end_iso,
@@ -107,17 +120,32 @@ class EPGProgramIndex:
             )
             if exclude_teamarr:
                 programs = [p for p in programs if not p.is_teamarr]
-            if not programs:
-                continue
             programs.sort(key=lambda p: p.start_time or "")
-            by_tvg[stream_tvg] = programs
-            total += len(programs)
+            return program_tvg, programs
+
+        by_tvg: dict[str, list[DispatcharrProgram]] = {}
+        total = 0
+        if streams_by_program:
+            workers = min(FETCH_WORKERS, len(streams_by_program))
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                for program_tvg, programs in executor.map(
+                    fetch, streams_by_program.keys()
+                ):
+                    if not programs:
+                        continue
+                    # Key the result by the stream tvg_id(s) for matcher lookup.
+                    for stream_tvg in streams_by_program[program_tvg]:
+                        by_tvg[stream_tvg] = programs
+                        total += len(programs)
 
         logger.info(
-            "[EPG-INDEX] Indexed %d programs across %d/%d tvg_ids (window %s..%s)",
+            "[EPG-INDEX] Indexed %d programs across %d/%d tvg_ids "
+            "(%d fetches in %.1fs, window %s..%s)",
             total,
             len(by_tvg),
             len(tvg_id_resolution),
+            len(streams_by_program),
+            (datetime.now(UTC) - fetch_started).total_seconds(),
             start_iso,
             end_iso,
         )

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -367,6 +367,13 @@ class StreamMatcher:
         # for streams carrying a tvg_id. None = no EPG matching (default).
         self._epg_index = epg_index
 
+        # Per-run memo of EPG-title match plans keyed by tvg_id. Many streams
+        # share one guide channel (726 streams / 89 tvg_ids on a typical
+        # channel-source group), and the classify+route work depends only on
+        # the tvg_id's program timeline — not the stream — so compute it once
+        # and materialize per-stream results from the shared plan.
+        self._epg_plan_by_tvg: dict[str, list[tuple[MatchOutcome, ClassifiedStream]]] = {}
+
     def match_all(
         self,
         streams: list[dict],
@@ -722,24 +729,53 @@ class StreamMatcher:
     ) -> list[MatchedStreamResult]:
         """Match a stream to events via its EPG program titles (epic 183.4).
 
-        Walks every program on the stream's guide channel (from the injected
-        EPGProgramIndex), feeds each program's title+sub_title through the SAME
-        classify_stream -> TeamMatcher pipeline used for stream names, and emits
-        one matched result per program (a linear channel legitimately matches
-        MANY events/day). Each result carries the program's broadcast window for
+        The heavy classify+route work over the guide channel's program timeline
+        depends only on the tvg_id, so it is computed once per tvg_id per run
+        (_compute_epg_plan) and shared by every stream carrying that tvg_id —
+        mirrors of one linear channel would otherwise re-match the identical
+        program list once per stream. Per-stream results are materialized from
+        the shared plan. Only MATCHED outcomes are returned — non-games
+        self-reject in the pipeline.
+        """
+        plan = self._epg_plan_by_tvg.get(tvg_id)
+        if plan is None:
+            plan = self._compute_epg_plan(tvg_id, target_date, stream_id, stream_name)
+            self._epg_plan_by_tvg[tvg_id] = plan
+        return [
+            self._outcome_to_result(
+                outcome=outcome,
+                stream_id=stream_id,
+                stream_name=stream_name,
+                classified=classified,
+            )
+            for outcome, classified in plan
+        ]
+
+    def _compute_epg_plan(
+        self,
+        tvg_id: str,
+        target_date: date,
+        stream_id: int,
+        stream_name: str,
+    ) -> "list[tuple[MatchOutcome, ClassifiedStream]]":
+        """Match a guide channel's program timeline to events, once per tvg_id.
+
+        Walks every program on the tvg_id (from the injected EPGProgramIndex),
+        feeds each program's title+sub_title through the SAME classify_stream ->
+        TeamMatcher pipeline used for stream names, and keeps the best outcome
+        per matched event (a linear channel legitimately matches MANY
+        events/day). Each outcome carries the program's broadcast window for
         the lifecycle layer.
 
-        Cross-run caching comes for free: TeamMatcher caches on
-        (group_id, stream_id, input_string), so each distinct program title is
-        memoized without a separate fingerprint layer. Only MATCHED outcomes are
-        returned — non-games self-reject in the pipeline.
+        stream_id/stream_name are the first carrier of this tvg_id — used only
+        for the sub-matchers' cache keys and log context.
         """
         # Keyed by matched event id so that when several programs match the SAME
         # event (e.g. a pre-game block + the game itself both pass the anchor
         # gate), we keep only the one whose start is nearest the event — the live
         # broadcast — giving a deterministic, correctly-anchored window (bead
         # t5e). Different events on the same channel keep distinct keys.
-        best_by_event: dict[str | None, tuple[float, MatchedStreamResult]] = {}
+        best_by_event: dict[str | None, tuple[float, MatchOutcome, ClassifiedStream]] = {}
         league_event_type = self._get_dominant_event_type()
 
         # Full sorted timeline for this tvg_id. A linear channel legitimately
@@ -843,29 +879,21 @@ class StreamMatcher:
                 # Keep the nearest-to-event program per event (live over pre-game).
                 prev = best_by_event.get(ev_id)
                 if prev is None or skew_s < prev[0]:
-                    best_by_event[ev_id] = (
-                        skew_s,
-                        self._outcome_to_result(
-                            outcome=outcome,
-                            stream_id=stream_id,
-                            stream_name=stream_name,
-                            classified=eff_classified,
-                        ),
-                    )
+                    best_by_event[ev_id] = (skew_s, outcome, eff_classified)
 
-        results = [r for _, r in best_by_event.values()]
+        plan = [(o, c) for _, o, c in best_by_event.values()]
         if programs:
             logger.info(
-                "[EPG_MATCH] tvg=%s stream='%s': %d program(s), %d attempted, "
+                "[EPG_MATCH] tvg=%s (via stream '%s'): %d program(s), %d attempted, "
                 "%d non-event skipped, %d event(s) matched",
                 tvg_id,
                 stream_name[:32],
                 len(programs),
                 attempted,
                 skipped_non_event,
-                len(results),
+                len(plan),
             )
-        return results
+        return plan
 
     def _reconcile_epg(
         self,

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -30,6 +30,7 @@ from teamarr.database.provider_cache import (
 from teamarr.database.team_cache import get_team_identity
 from teamarr.providers import ProviderRegistry
 from teamarr.utilities.cache import (
+    CACHE_TTL_NEGATIVE,
     CACHE_TTL_SCHEDULE,
     CACHE_TTL_SINGLE_EVENT,
     CACHE_TTL_TEAM_INFO,
@@ -58,6 +59,13 @@ REFRESH_COALESCE_TTL = 300  # seconds
 # fails (e.g. ESPN 404) falls through to another serial provider call —
 # hundreds of live 404s per run for a single event.
 _EVENT_NOT_FOUND = {"__event_not_found__": True}
+
+# Negative-cache marker for get_team / get_team_stats. Lookups that return
+# nothing (off-season teams, leagues without records) were never cached, so
+# every generation run repeated the same failing provider calls — a steady
+# ~250+ `espn:teams` calls per hourly run. Cached with CACHE_TTL_NEGATIVE so
+# a team that comes back into season is picked up within a few hours.
+_NOT_FOUND = {"__not_found__": True}
 
 # Sentinel distinguishing "no usable cache entry" from a legitimately cached
 # empty result (e.g. a league with no games that day, cached as []). A distinct
@@ -426,6 +434,9 @@ class SportsDataService:
         # Check cache (deserialize from dict)
         cached = self._cache.get(cache_key)
         if cached is not None:
+            if cached == _NOT_FOUND:
+                logger.debug("[CACHE_HIT] %s (negative)", cache_key)
+                return None
             if _team_dict_is_stale(cached):
                 logger.debug(
                     "[CACHE_STALE] %s — team data missing short_name, re-fetching",
@@ -447,6 +458,7 @@ class SportsDataService:
                     # Serialize to dict before caching
                     self._cache.set(cache_key, team_to_dict(team), CACHE_TTL_TEAM_INFO)
                     return team
+        self._cache.set(cache_key, _NOT_FOUND, CACHE_TTL_NEGATIVE)
         return None
 
     def get_event(self, event_id: str, league: str) -> Event | None:
@@ -672,6 +684,9 @@ class SportsDataService:
         # Check cache (deserialize from dict)
         cached = self._cache.get(cache_key)
         if cached is not None:
+            if cached == _NOT_FOUND:
+                logger.debug("[CACHE_HIT] %s (negative)", cache_key)
+                return None
             logger.debug("[CACHE_HIT] %s", cache_key)
             try:
                 return dict_to_stats(cached)
@@ -686,6 +701,7 @@ class SportsDataService:
                     # Serialize to dict before caching
                     self._cache.set(cache_key, stats_to_dict(stats), CACHE_TTL_TEAM_STATS)
                     return stats
+        self._cache.set(cache_key, _NOT_FOUND, CACHE_TTL_NEGATIVE)
         return None
 
     # Cache management

--- a/teamarr/utilities/cache.py
+++ b/teamarr/utilities/cache.py
@@ -516,6 +516,7 @@ CACHE_TTL_SCHEDULE = 8 * 60 * 60  # 8 hours - team schedules rarely change
 CACHE_TTL_EVENTS = 8 * 60 * 60  # 8 hours - scoreboard (league events list)
 CACHE_TTL_SINGLE_EVENT = 30 * 60  # 30 minutes - individual event (scores, odds)
 CACHE_TTL_TEAM_INFO = 24 * 60 * 60  # 24 hours - static team data
+CACHE_TTL_NEGATIVE = 4 * 60 * 60  # 4 hours - provider returned nothing (off-season etc.)
 
 
 def make_cache_key(*parts: str) -> str:

--- a/tests/epg/test_epg_program_index.py
+++ b/tests/epg/test_epg_program_index.py
@@ -64,6 +64,36 @@ def test_build_fetches_by_resolved_tvg_and_keys_by_stream_tvg():
     assert set(idx.tvg_ids()) == {"FoxSports1.us", "ESPN.us"}
 
 
+def test_build_dedupes_fetches_for_shared_program_tvg():
+    """Streams resolving to the SAME EPG-source tvg_id share one fetch."""
+    mgr = _epg_mgr()
+    base = datetime(2026, 6, 1, 18, tzinfo=UTC)
+    mgr.search_programs.side_effect = lambda tvg_id, **kw: [
+        _prog(1, tvg_id, base, base + timedelta(hours=3))
+    ]
+
+    idx = EPGProgramIndex.build(
+        mgr,
+        # Two mirror streams of one linear channel + one distinct channel.
+        tvg_id_resolution={
+            "FS1-East.us": "82547",
+            "FS1-West.us": "82547",
+            "ESPN.us": "12345",
+        },
+        window_start=base,
+        window_end=base + timedelta(days=1),
+    )
+
+    # One call per DISTINCT resolved id, not per stream tvg_id.
+    assert mgr.search_programs.call_count == 2
+    called = {c.kwargs["tvg_id"] for c in mgr.search_programs.call_args_list}
+    assert called == {"82547", "12345"}
+    # But the index still answers for every stream tvg_id.
+    assert set(idx.tvg_ids()) == {"FS1-East.us", "FS1-West.us", "ESPN.us"}
+    assert len(idx.programs_for("FS1-East.us")) == 1
+    assert len(idx.programs_for("FS1-West.us")) == 1
+
+
 def test_build_excludes_teamarr_programs():
     mgr = _epg_mgr()
     base = datetime(2026, 6, 1, 18, tzinfo=UTC)

--- a/tests/lifecycle/test_dispatcharr_sync_reliability.py
+++ b/tests/lifecycle/test_dispatcharr_sync_reliability.py
@@ -294,10 +294,8 @@ class TestProfileSelfHealing:
     def test_no_false_positive_when_in_sync(self):
         """DB and Dispatcharr both match expected — no update needed.
 
-        Uses profile ID 1 (not 0) because _parse_profile_ids filters falsy
-        values with ``if x``, so 0 gets dropped.  Also sets a non-None
-        default_channel_profile_ids so the dynamic resolver runs
-        (None causes a [0] fallback, bypassing the resolver entirely).
+        Sets a non-None default_channel_profile_ids so the dynamic resolver
+        runs (None causes a [0] fallback, bypassing the resolver entirely).
         """
         cm = MagicMock()
         service = _make_service(channel_manager=cm)
@@ -331,6 +329,57 @@ class TestProfileSelfHealing:
         cm.update_channel.assert_not_called()
         mock_update_db.assert_not_called()
         assert len(changes_made) == 0
+
+    def test_all_profiles_sentinel_parses_stably(self):
+        """_parse_profile_ids must keep 0 (the ALL-profiles sentinel).
+
+        The old ``if x`` filter dropped 0, so a stored "[0]" read back as []
+        and every channel re-PATCHed "all profiles" on every run.
+        """
+        service = _make_service(channel_manager=MagicMock())
+        assert service._parse_profile_ids("[0]") == [0]
+        assert service._parse_profile_ids([0]) == [0]
+        assert service._parse_profile_ids(None) == []
+        assert service._parse_profile_ids("") == []
+
+    def test_all_profiles_sentinel_no_repatch_when_expanded(self):
+        """Dispatcharr expands [0] to the concrete profile list on read.
+
+        DB stores [0]; Dispatcharr returns [1] (member of the only profile).
+        That IS in sync for the sentinel — no PATCH, no history churn.
+        """
+        cm = MagicMock()
+        profile = MagicMock()
+        profile.id = 1
+        cm.list_profiles.return_value = [profile]
+        service = _make_service(channel_manager=cm)
+
+        existing = FakeManagedChannel(channel_profile_ids="[0]")
+        dispatcharr_ch = _make_dispatcharr_channel(channel_profile_ids=[1])
+
+        changes_made = []
+        mock_settings = MagicMock()
+        mock_settings.default_channel_profile_ids = None
+
+        with (
+            patch("teamarr.database.channels.update_managed_channel") as mock_update_db,
+            patch(
+                "teamarr.database.settings.get_dispatcharr_settings",
+                return_value=mock_settings,
+            ),
+        ):
+            service._sync_channel_profiles(
+                conn=MagicMock(),
+                existing=existing,
+                event_sport="football",
+                event_league="nfl",
+                changes_made=changes_made,
+                current_channel=dispatcharr_ch,
+            )
+
+        cm.update_channel.assert_not_called()
+        mock_update_db.assert_not_called()
+        assert changes_made == []
 
 
 # =============================================================================

--- a/tests/providers/test_team_negative_cache.py
+++ b/tests/providers/test_team_negative_cache.py
@@ -1,0 +1,79 @@
+"""get_team / get_team_stats negative-cache provider misses.
+
+Lookups that return nothing (off-season teams, leagues without records) were
+never cached, so every generation run repeated the same failing provider
+calls — a steady ~250+ `espn:teams` calls per hourly run. Both now store a
+negative marker with CACHE_TTL_NEGATIVE so repeats within the window are
+served from cache, while successful fetches keep their normal TTLs.
+"""
+
+from unittest.mock import MagicMock
+
+from teamarr.core.types import Team, TeamStats
+from teamarr.services.sports_data import SportsDataService
+from teamarr.utilities.cache import CACHE_TTL_NEGATIVE
+from tests.fakes import FakeCache
+
+
+def _service(team=None, stats=None):
+    provider = MagicMock()
+    provider.supports_league.return_value = True
+    provider.get_team.return_value = team
+    provider.get_team_stats.return_value = stats
+    service = SportsDataService(providers=[provider])
+    service._cache = FakeCache()
+    return service, provider
+
+
+def _make_team() -> Team:
+    return Team(
+        id="8",
+        provider="espn",
+        name="Detroit Pistons",
+        short_name="Pistons",
+        abbreviation="DET",
+        league="nba",
+        sport="Basketball",
+    )
+
+
+class TestGetTeamNegativeCache:
+    def test_provider_miss_fetches_once_within_window(self):
+        service, provider = _service(team=None)
+        for _ in range(3):
+            assert service.get_team("8", "nba") is None
+        assert provider.get_team.call_count == 1
+
+    def test_negative_entry_uses_negative_ttl(self):
+        service, _ = _service(team=None)
+        service.get_team("8", "nba")
+        _, value, ttl = service._cache.set_calls[-1]
+        assert value.get("__not_found__")
+        assert ttl == CACHE_TTL_NEGATIVE
+
+    def test_successful_fetch_still_cached_normally(self):
+        service, provider = _service(team=_make_team())
+        assert service.get_team("8", "nba") is not None
+        assert service.get_team("8", "nba") is not None
+        assert provider.get_team.call_count == 1
+
+
+class TestGetTeamStatsNegativeCache:
+    def test_provider_miss_fetches_once_within_window(self):
+        service, provider = _service(stats=None)
+        for _ in range(3):
+            assert service.get_team_stats("8", "nba") is None
+        assert provider.get_team_stats.call_count == 1
+
+    def test_negative_entry_uses_negative_ttl(self):
+        service, _ = _service(stats=None)
+        service.get_team_stats("8", "nba")
+        _, value, ttl = service._cache.set_calls[-1]
+        assert value.get("__not_found__")
+        assert ttl == CACHE_TTL_NEGATIVE
+
+    def test_successful_fetch_still_cached_normally(self):
+        service, provider = _service(stats=TeamStats(record="10-5", wins=10, losses=5))
+        assert service.get_team_stats("8", "nba") is not None
+        assert service.get_team_stats("8", "nba") is not None
+        assert provider.get_team_stats.call_count == 1


### PR DESCRIPTION
Closes-when-released #392 · bead `teamarrv2-44ey`

## What

Seven targeted fixes to the full-generation hot path, found via new per-phase instrumentation + cProfile against live-mirror data:

**Round 1 — fetch/call volume**
- `EPGProgramIndex.build`: dedupe fetches by resolved EPG-source tvg_id (mirror streams shared one guide channel but each fetched it) and fan out over a thread pool (`EPG_INDEX_FETCH_WORKERS`, default 10; documented in configuration.md). 92 serial round-trips → 3.2s parallel.
- `_enrich_matched_events`: refresh each unique event once, in parallel (was serial per matched stream; `refresh_event_status` is already single-flight + coalesced).
- `get_team` / `get_team_stats`: negative-cache provider misses (`CACHE_TTL_NEGATIVE`, 4h) — kills a steady ~250–300 repeated `espn:teams` calls per hourly run.
- `EventGroupProcessor`: one lifecycle service per run (the Dispatcharr channel cache is class-level; per-group construction bought nothing), scheduled deletions once per run (was 161×), pre-reassign once per run, post-reassign only when a group changed the channel set (was 2× per group ≈ 322 full scans/run).

**Round 2 — per-run sync churn (profiler findings)**
- `StreamMatcher`: memoize the EPG-title match plan per tvg_id — 726 channel-source streams share 89 guide channels; the classify+route pass ran once per stream (~8× redundant). Now computed once per tvg_id, per-stream results materialized from the shared plan.
- **Bug:** `_parse_profile_ids` filtered with `if x`, dropping the `0` ALL-profiles sentinel — every channel's stored `[0]` read back as `[]` and re-PATCHed "profiles: all profiles" every run (2,907 history rows / 3h on live data). Fixed the parse; also compare Dispatcharr's expanded concrete profile list against the profile catalog when effective is the sentinel (reads never return `[0]`); an empty Dispatcharr list stays drift (self-healing preserved, covered by existing test).
- `_sync_channel_settings`: skip the stream drift-add for time-windowed (EPG-matched) streams — an out-of-window stream is correctly absent from Dispatcharr; the re-add fought the ordering-phase window sync every run.

**Instrumentation**
- Per-phase wall times on full runs and per-group runs (`extra_metrics.phase_timings`), fetch timing on the `[EPG-INDEX]` log line — regressions now show in run stats instead of requiring log archaeology.

## Measured (live-mirror data, warm hourly runs)

| Metric | Before | After |
|---|---|---|
| Full generation run | ~278–542s | **~244s** |
| Channel-source group ("Dispatcharr Channels", 726 streams) | 103–228s | **48s** (fetch 15 / match 15 / enrich 0.2 / channels 15) |
| Provider HTTP calls per run | 746–912 | **~417** |
| Dispatcharr PATCHes (channel-source group) | 1,019 | ~200 (remaining are genuine attach/detach window flips) |
| Profile-sync history churn | ~650 rows/run | **0** |

## Tests

- 1,621 passing (`pytest tests/ -v`), ruff clean, frontend build green.
- New: EPG-index fetch-dedupe test; negative-cache tests for team/stats (mirroring `test_event_negative_cache.py`); regression tests for the `[0]` sentinel parse and no-repatch-when-expanded behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bqfTnGE8jY8ojmqKvYM7G