### PR TITLE
Fix WEC never matching + scope racing session fan-out by stream-name session labels

### DIFF
--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -1116,6 +1116,13 @@ def has_racing_text_evidence(text: str) -> bool:
 # naming them blocks cross-series binding entirely.
 _RACING_SERIES_SIGNATURES: "tuple[tuple[Pattern[str], tuple[str, ...]], ...]" = (
     (re.compile(r"\b(?:formula\s*1|f1)\b", re.IGNORECASE), ("f1",)),
+    # F2/F3/Formula E run as support series on F1 weekends at the SAME venue,
+    # so an unscoped "Formula 2 - Monaco - Sprint Race" stream shares venue
+    # tokens with the one configured F1 event covering that date — the exact
+    # cross-series shape this table exists to block, at a much higher
+    # collision rate (every F1 weekend). No corresponding league exists in
+    # schema.sql, so like supercross below this maps to a blocking sentinel.
+    (re.compile(r"\b(?:formula\s*[23e]|f[23])\b", re.IGNORECASE), ("formula-feeder",)),
     (
         re.compile(r"\bnascar\b", re.IGNORECASE),
         ("nascar-cup", "nascar-xfinity", "nascar-truck"),

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -1107,6 +1107,45 @@ def has_racing_text_evidence(text: str) -> bool:
     return bool(text) and RACING_TEXT_EVIDENCE.search(text) is not None
 
 
+# Per-series text signatures, for scoping a racing stream to the league(s)
+# whose series it explicitly names. Values are the league codes the series
+# can belong to (NASCAR is an umbrella over three leagues). Deliberately a
+# subset of RACING_TEXT_EVIDENCE: generic evidence like "grand prix" names
+# racing but not a series, and stays unscoped. Series with no corresponding
+# league (supercross/motocross) map to a code no group will ever include, so
+# naming them blocks cross-series binding entirely.
+_RACING_SERIES_SIGNATURES: "tuple[tuple[Pattern[str], tuple[str, ...]], ...]" = (
+    (re.compile(r"\b(?:formula\s*1|f1)\b", re.IGNORECASE), ("f1",)),
+    (
+        re.compile(r"\bnascar\b", re.IGNORECASE),
+        ("nascar-cup", "nascar-xfinity", "nascar-truck"),
+    ),
+    (re.compile(r"\b(?:indycar|indy\s*(?:500|nxt))\b", re.IGNORECASE), ("indycar",)),
+    (re.compile(r"\b(?:motogp|moto\s*[23])\b", re.IGNORECASE), ("motogp",)),
+    (re.compile(r"\bimsa\b", re.IGNORECASE), ("imsa",)),
+    (re.compile(r"\b(?:wec|world\s+endurance)\b", re.IGNORECASE), ("wec",)),
+    (re.compile(r"\b(?:supercross|motocross)\b", re.IGNORECASE), ("supercross",)),
+)
+
+
+def detect_racing_series_leagues(text: str) -> "tuple[str, ...] | None":
+    """League codes for the racing series the text explicitly names.
+
+    Returns None when no specific series is named (e.g. a bare "Monaco
+    Grand Prix") — callers must treat that as "unscoped", not "not racing".
+    A stream naming a specific series must only match events from that
+    series' league(s): a MotoGP stream must not date-bind to the one IMSA
+    event covering the weekend just because motogp isn't configured.
+    """
+    if not text:
+        return None
+    hits: list[str] = []
+    for pattern, leagues in _RACING_SERIES_SIGNATURES:
+        if pattern.search(text):
+            hits.extend(leagues)
+    return tuple(hits) or None
+
+
 # Known tennis league codes — mirror of the sport='tennis' leagues in
 # schema.sql (this module is pure text classification, no DB access).
 _TENNIS_LEAGUE_HINTS: frozenset[str] = frozenset({"atp", "wta"})

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -1096,7 +1096,7 @@ def is_racing(
 RACING_TEXT_EVIDENCE: Pattern[str] = re.compile(
     r"\b(?:"
     r"formula\s*[123e]|f1|nascar|indycar|indy\s*(?:500|nxt)|"
-    r"motogp|moto\s*[23]|grand\s+prix|imsa|supercross|motocross"
+    r"motogp|moto\s*[23]|grand\s+prix|imsa|supercross|motocross|wec|world\s+endurance"
     r")\b",
     re.IGNORECASE,
 )

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -597,6 +597,22 @@ class StreamMatcher:
         # This handles streams that passed filtering but still can't be classified
         # (e.g., no separator found, no custom regex match).
         if classified.category == StreamCategory.PLACEHOLDER:
+            # A racing stream with a timestamp but no separator ("US (Peacock
+            # 031) | IMSA CTMP Grand Prix (2026-07-12 14:00:00)") classifies
+            # PLACEHOLDER — a date/time was extracted, so _classify_team_only
+            # refuses it and nothing else fits. Give the racing fallback a
+            # chance before writing it off as unclassifiable (same gate as
+            # the TEAM_ONLY path below).
+            if self._name_match_enabled:
+                fallback = self._try_racing_fallback(stream_name, stream_id, target_date)
+                if fallback is not None:
+                    outcome, racing_classified = fallback
+                    return [self._outcome_to_result(
+                        outcome=outcome,
+                        stream_id=stream_id,
+                        stream_name=stream_name,
+                        classified=racing_classified,
+                    )]
             return [MatchedStreamResult(
                 stream_name=stream_name,
                 stream_id=stream_id,

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -32,6 +32,7 @@ from teamarr.consumers.matching.classifier import (
     CustomRegexConfig,
     StreamCategory,
     classify_stream,
+    detect_racing_series_leagues,
     has_racing_text_evidence,
 )
 from teamarr.consumers.matching.constants import MATCH_WINDOW_DAYS
@@ -1048,6 +1049,29 @@ class StreamMatcher:
                 stream_id=stream_id,
                 detail="No racing leagues configured",
             )
+
+        # Series scoping: when the stream text explicitly names a series
+        # (MotoGP, NASCAR, ...), only that series' league(s) are eligible.
+        # Without this, a stream for an unconfigured series carries racing
+        # text evidence, reaches the racing matcher, and date-binds to
+        # whatever configured series races that weekend ("MotoGP - Grand
+        # Prix of Germany" direct-matched IMSA's Chevrolet Grand Prix via
+        # the shared "Grand Prix" tokens). Generic racing text (a bare
+        # "Monaco Grand Prix") names no series and stays unscoped.
+        named_leagues = detect_racing_series_leagues(classified.normalized.original)
+        if named_leagues:
+            scoped = [lg for lg in racing_leagues if lg in named_leagues]
+            if not scoped:
+                return MatchOutcome.failed(
+                    reason=FailedReason.NO_RACING_MATCH,
+                    stream_name=classified.normalized.original,
+                    stream_id=stream_id,
+                    detail=(
+                        "Stream names a racing series with no configured league "
+                        f"({', '.join(named_leagues)})"
+                    ),
+                )
+            racing_leagues = scoped
 
         # Try each racing league
         outcome = None

--- a/teamarr/consumers/racing_segments.py
+++ b/teamarr/consumers/racing_segments.py
@@ -3,7 +3,16 @@
 Expands racing events (F1, NASCAR, IndyCar, MotoGP, ...) into session-based
 channels (Practice 1, Practice 2, Qualifying, Race, ...). Each matched racing
 stream is expanded into one channel entry per session in `event.sessions`,
-using ESPN-provided session start times for exact EPG timing.
+using ESPN-provided session start times for exact EPG timing — UNLESS the
+stream's own name clearly names one specific session (e.g. "Free Practice
+3"), in which case it's scoped to just that session instead of fanning out
+across the whole weekend (see _session_category_from_stream_name).
+
+Practice sessions are excluded from that whole-weekend fan-out (they're only
+included when a stream's name specifically names one): providers frequently
+don't carry a dedicated practice feed at all, and a generic linear stream
+landing on a Practice channel is more likely to produce a channel with
+nothing actually airing yet than a legitimate live source.
 
 NASCAR-style single-session events (a single "race" session) degenerate to
 one segment via the same code path - no special-casing required.
@@ -16,6 +25,18 @@ from datetime import datetime, timedelta
 from teamarr.core.types import Event
 
 logger = logging.getLogger(__name__)
+
+# Session-label regexes (looser than the providers.tsdb.racing parser's:
+# its _FREE_PRACTICE_RE requires a digit and literal "free practice"/"fp",
+# and would miss stream labels like "Practice 2").
+_FREE_PRACTICE_RE = re.compile(r"^(?:free\s*practice|practice|fp)\s*(\d*)$", re.IGNORECASE)
+_QUALIFYING_RE = re.compile(
+    r"^(?:hyperpole\s+)?qualifying(?:\s*[-–]\s*(.+))?$", re.IGNORECASE
+)
+_HYPERPOLE_RE = re.compile(
+    r"^hyperpole\s*(\d*)\s*(?:[-–]\s*(.+))?$", re.IGNORECASE
+)
+_PROLOGUE_RE = re.compile(r"prologue", re.IGNORECASE)
 
 # Canonical session order, earliest to latest within a race weekend.
 SESSION_ORDER = [
@@ -115,6 +136,146 @@ def _session_duration_hours(
     return SESSION_DURATION_HOURS.get(session_code, 1.0)
 
 
+# Session labels that don't need a regex (either fully generic words that
+# would be too risky to substring-match anywhere in a stream name, or short
+# fixed phrases the tsdb parser's regexes don't cover on their own).
+_EXACT_SESSION_LABELS = {
+    "race": "race",
+    "feature race": "race",
+    "sprint": "sprint",
+    "sprint race": "sprint",
+    "sprint qualifying": "sprint_qualifying",
+    "warm up": "warmup",
+    "warmup": "warmup",
+}
+
+# Fallback for labels shaped "<Series/event description> <SessionType>"
+# (session type as a TRAILING word, not the whole label) — e.g. NASCAR/TSN+
+# streams named "NASCAR Cup Series Qualifying" or "2026 NASCAR ORAP Series
+# Qualifying", where the tsdb-style anchored regexes above (which require
+# the label to BE the session type) don't match. Anchored at the end of the
+# label (not a bare substring search), so "Pre-Race Show" still counts as
+# naming the race but "Racecourse Network" or similar would not accidentally
+# trail-match "race" mid-word.
+_TRAILING_FP_RE = re.compile(r"(?:free\s*practice|practice|fp)\s*(\d)\s*$", re.IGNORECASE)
+_TRAILING_SPRINT_QUALIFYING_RE = re.compile(r"\bsprint\s*qualifying\s*$", re.IGNORECASE)
+_TRAILING_HYPERPOLE_RE = re.compile(r"\bhyperpole\s*$", re.IGNORECASE)
+_TRAILING_WARMUP_RE = re.compile(r"\bwarm[\s-]?up\s*$", re.IGNORECASE)
+_TRAILING_QUALIFYING_RE = re.compile(r"\bqualifying\s*$", re.IGNORECASE)
+_TRAILING_SPRINT_RACE_RE = re.compile(r"\bsprint\s*race\s*$", re.IGNORECASE)
+_TRAILING_RACE_RE = re.compile(r"\brace\s*$", re.IGNORECASE)
+_TRAILING_SPRINT_RE = re.compile(r"\bsprint\s*$", re.IGNORECASE)
+
+
+def _session_category_from_trailing_keyword(label: str) -> str | None:
+    """Session category for a label ending in a session-type WORD.
+
+    Checked in specificity order so e.g. "Sprint Qualifying" resolves to
+    sprint_qualifying rather than the bare "qualifying" suffix match.
+    """
+    if m := _TRAILING_FP_RE.search(label):
+        return f"fp{m.group(1)}"
+    if _TRAILING_SPRINT_QUALIFYING_RE.search(label):
+        return "sprint_qualifying"
+    if _TRAILING_HYPERPOLE_RE.search(label):
+        return "hyperpole"
+    if _TRAILING_WARMUP_RE.search(label):
+        return "warmup"
+    if _TRAILING_QUALIFYING_RE.search(label):
+        return "qualifying"
+    if _TRAILING_SPRINT_RACE_RE.search(label):
+        return "sprint"
+    if _TRAILING_RACE_RE.search(label):
+        return "race"
+    if _TRAILING_SPRINT_RE.search(label):
+        return "sprint"
+    return None
+
+
+def _isolate_stream_session_label(stream_name: str) -> str:
+    """Best-effort isolation of a session-label field from a stream name.
+
+    Provider-tagged racing streams are commonly shaped like
+    "<provider tag> | <Session Label>: <description> (<timestamp>)" (e.g.
+    "AU (STAN 36) | Free Practice 3: 6 Hours of Sao Paulo WEC 2026 (...)").
+    Taking the segment after the last "|" and before the first ":" isolates
+    just the label field, so keyword detection runs against a narrow,
+    structured slice instead of the whole noisy name — "Race" only counts as
+    a session label when it more or less stands alone, not when it's merely
+    a substring of some unrelated branding text.
+    """
+    segment = stream_name.rsplit("|", 1)[-1] if "|" in stream_name else stream_name
+    return segment.split(":", 1)[0].strip()
+
+
+def _session_category_from_stream_name(stream_name: str) -> str | None:
+    """Best-effort session-type CATEGORY from a stream's own name.
+
+    Reuses the same anchored regexes the TSDB parser uses to classify
+    session labels (inlined above), applied to the
+    isolated label field instead of a full TSDB event name. Returns a
+    CATEGORY, not necessarily an exact `RacingSession.code` — a bare
+    "Qualifying" can't disambiguate "qualifying_hypercar" from
+    "qualifying_lmgt3", so it maps to a category that covers every session
+    of that type via `_session_in_category` below, rather than guessing
+    wrong and excluding one.
+
+    Returns None when the label doesn't clearly encode a session type
+    (the common case for a linear/whole-weekend channel's own name, e.g.
+    "HBO UK 065"), so callers can fall back to their existing full
+    session fan-out — this function is deliberately conservative to avoid
+    false negatives (a real session-specific stream getting excluded from
+    the one session channel it actually belongs on).
+    """
+    label = _isolate_stream_session_label(stream_name)
+    if not label:
+        return None
+    if category := _EXACT_SESSION_LABELS.get(label.lower()):
+        return category
+    if m := _FREE_PRACTICE_RE.match(label):
+        return f"fp{m.group(1)}" if m.group(1) else "practice"
+    if _QUALIFYING_RE.match(label):
+        return "qualifying"
+    if _HYPERPOLE_RE.match(label):
+        return "hyperpole"
+    if _PROLOGUE_RE.search(label):
+        return "prologue"
+    # Fallback: the label isn't ENTIRELY a session type, but ENDS in one —
+    # e.g. NASCAR/TSN+'s "NASCAR Cup Series Qualifying" or "2026 NASCAR ORAP
+    # Series Qualifying", vs. tsdb/STAN's convention of the label being just
+    # "Qualifying" on its own (handled above).
+    return _session_category_from_trailing_keyword(label)
+
+
+def _session_in_category(session_code: str, category: str) -> bool:
+    """True if `session_code` belongs to the coarse `category`.
+
+    Numbered practice sessions (fp1/fp2/fp3) must match exactly — a stream
+    labeled "Free Practice 3" names ONE specific session, not every
+    practice session. Everything else matches the category itself or any
+    class-suffixed variant (category="qualifying" covers both
+    "qualifying_hypercar" and "qualifying_lmgt3").
+
+    A bare "qualifying" category also covers hyperpole sessions: WEC's
+    Hyperpole is itself a qualifying-shootout round, and providers rarely
+    label it distinctly from regular qualifying — a stream generically
+    labeled "Qualifying" is a real candidate for a Hyperpole session too,
+    not just an exact-name "qualifying_*" one.
+    """
+    if category.startswith("fp"):
+        return session_code == category
+    if category == "qualifying" and (
+        session_code == "hyperpole" or session_code.startswith("hyperpole_")
+    ):
+        return True
+    return session_code == category or session_code.startswith(f"{category}_")
+
+
+def _is_practice_session(session_code: str) -> bool:
+    """True for practice-type sessions (fp1/fp2/fp3, or an unnumbered "practice")."""
+    return session_code.startswith("fp") or session_code == "practice"
+
+
 def is_racing_event(event: Event | None) -> bool:
     """Check if event is a racing event with session data to expand."""
     if not event:
@@ -187,6 +348,30 @@ def expand_racing_segments(
 
         expanded_streams += 1
         sessions = sorted(event.sessions, key=lambda s: s.start_time)
+
+        # Scope to a single session (or session category) when the stream's
+        # own name clearly names one — e.g. a dedicated "Free Practice 3"
+        # feed must not also show up as the Qualifying/Race channel's
+        # source. A stream whose name carries no such hint (a linear
+        # channel's own branding, e.g. "HBO UK 065") keeps the full
+        # fan-out, unchanged from before — EXCEPT practice sessions, which
+        # are dropped from that fan-out rather than kept (see below).
+        stream_name = match.get("stream", {}).get("name") or ""
+        if category := _session_category_from_stream_name(stream_name):
+            scoped = [s for s in sessions if _session_in_category(s.code, category)]
+            if scoped:
+                sessions = scoped
+        else:
+            # Providers frequently don't carry a dedicated practice feed at
+            # all (coverage often starts at qualifying), so a generic
+            # whole-weekend stream landing on a Practice channel is more
+            # likely to produce a channel with nothing actually airing yet
+            # than a legitimate live source. Only include a practice
+            # session when the stream's own name specifically named it
+            # (handled by the scoping above); otherwise skip practice
+            # sessions in the full fan-out — better no channel than one
+            # that's dead air until qualifying starts.
+            sessions = [s for s in sessions if not _is_practice_session(s.code)]
 
         for session in sessions:
             start_time = session.start_time

--- a/teamarr/consumers/racing_segments.py
+++ b/teamarr/consumers/racing_segments.py
@@ -154,10 +154,10 @@ _EXACT_SESSION_LABELS = {
 # streams named "NASCAR Cup Series Qualifying" or "2026 NASCAR ORAP Series
 # Qualifying", where the tsdb-style anchored regexes above (which require
 # the label to BE the session type) don't match. Anchored at the end of the
-# label (not a bare substring search), so "Pre-Race Show" still counts as
-# naming the race but "Racecourse Network" or similar would not accidentally
-# trail-match "race" mid-word.
-_TRAILING_FP_RE = re.compile(r"(?:free\s*practice|practice|fp)\s*(\d)\s*$", re.IGNORECASE)
+# label (not a bare substring search), so "Pre-Race" still counts as naming
+# the race, while "Pre-Race Show" (doesn't end in the keyword) and
+# "Racecourse Network" (keyword mid-word, not at the end) do not.
+_TRAILING_FP_RE = re.compile(r"\b(?:free\s*practice|practice|fp)\s*(\d?)\s*$", re.IGNORECASE)
 _TRAILING_SPRINT_QUALIFYING_RE = re.compile(r"\bsprint\s*qualifying\s*$", re.IGNORECASE)
 _TRAILING_HYPERPOLE_RE = re.compile(r"\bhyperpole\s*$", re.IGNORECASE)
 _TRAILING_WARMUP_RE = re.compile(r"\bwarm[\s-]?up\s*$", re.IGNORECASE)
@@ -174,7 +174,10 @@ def _session_category_from_trailing_keyword(label: str) -> str | None:
     sprint_qualifying rather than the bare "qualifying" suffix match.
     """
     if m := _TRAILING_FP_RE.search(label):
-        return f"fp{m.group(1)}"
+        # NASCAR emits an unnumbered "practice" session code, and TSN+ labels
+        # the feed "<Series> Practice" with no digit — same mapping as
+        # _FREE_PRACTICE_RE's bare-"Practice" case.
+        return f"fp{m.group(1)}" if m.group(1) else "practice"
     if _TRAILING_SPRINT_QUALIFYING_RE.search(label):
         return "sprint_qualifying"
     if _TRAILING_HYPERPOLE_RE.search(label):

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 from teamarr.consumers.matching.classifier import (
     StreamCategory,
     classify_stream,
+    detect_racing_series_leagues,
     has_racing_text_evidence,
 )
 from teamarr.consumers.matching.racing_matcher import RacingMatchContext, RacingMatcher
@@ -403,6 +404,103 @@ def test_stream_name_racing_fallback_on_team_only_gate(monkeypatch):
     assert len(out) == 1
     assert out[0].is_matched
     assert captured["classified"].category == StreamCategory.RACING_EVENT
+
+
+# ---------------------------------------------------------------------------
+# Series scoping: a stream naming a specific series must only match that
+# series' league(s) — and match nothing when that series isn't configured.
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRacingSeriesLeagues:
+    def test_motogp(self):
+        assert detect_racing_series_leagues(
+            "CA (SN+ 017) | MotoGP _ Grand Prix of Germany (2026-07-12 07:15:00)"
+        ) == ("motogp",)
+
+    def test_nascar_umbrella(self):
+        assert detect_racing_series_leagues("NASCAR Cup Series at San Diego") == (
+            "nascar-cup", "nascar-xfinity", "nascar-truck",
+        )
+
+    def test_wec(self):
+        assert detect_racing_series_leagues("FIA WEC | ROUND 5") == ("wec",)
+        assert detect_racing_series_leagues("World Endurance Championship") == ("wec",)
+
+    def test_generic_grand_prix_is_unscoped(self):
+        # "grand prix" is racing evidence but names no series — must stay
+        # unscoped so a bare "Monaco Grand Prix" stream can still match F1.
+        assert detect_racing_series_leagues("Monaco Grand Prix") is None
+
+    def test_empty(self):
+        assert detect_racing_series_leagues("") is None
+        assert detect_racing_series_leagues("ESPN 2 (US)") is None
+
+
+def test_racing_series_scoping_blocks_unconfigured_series(monkeypatch):
+    # Live false-match regression: two "MotoGP - Grand Prix of Germany"
+    # streams direct-matched IMSA's "Chevrolet Grand Prix" — the only racing
+    # event covering the date — because motogp isn't a configured league and
+    # the shared "Grand Prix" tokens cleared the single-event sanity bar. A
+    # stream naming an unconfigured series must match nothing.
+    m = _mixed_matcher()  # racing league available: f1 only
+    _failed_route(monkeypatch, m)
+    racing_called = []
+    monkeypatch.setattr(
+        m._racing_matcher, "match",
+        lambda **kw: racing_called.append(kw["league"]) or _racing_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_single(
+        1, "CA (SN+ 017) | MotoGP _ Grand Prix of Germany (2026-07-12 07:15:00)",
+        date(2026, 7, 12),
+    )
+    assert not racing_called  # f1 must never be attempted
+    assert not out[0].matched
+
+
+def test_racing_series_scoping_restricts_to_named_league(monkeypatch):
+    # A stream naming IMSA in a group with several racing leagues must only
+    # try imsa — not fan out across f1 too. (Racing dominates this group, so
+    # the stream classifies RACING_EVENT on the primary pass and reaches
+    # _match_racing_event through the real route.)
+    from tests.fakes import make_stream_matcher
+
+    m = make_stream_matcher(
+        leagues=("nfl", "f1", "imsa"),
+        league_event_types={"nfl": "team_vs_team", "f1": "event", "imsa": "event"},
+        league_sports={"nfl": "football", "f1": "racing", "imsa": "racing"},
+    )
+    racing_called = []
+    monkeypatch.setattr(
+        m._racing_matcher, "match",
+        lambda **kw: racing_called.append(kw["league"]) or _racing_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_single(
+        1, "US (Peacock 031) | IMSA CTMP Grand Prix (2026-07-12 14:00:00)", date(2026, 7, 12)
+    )
+    assert racing_called == ["imsa"]
+    assert out[0].is_matched
+
+
+def test_racing_generic_name_stays_unscoped(monkeypatch):
+    # No series named ("Monaco Grand Prix") → all racing leagues remain
+    # eligible, preserving pre-scoping behavior.
+    m = _mixed_matcher()
+    _failed_route(monkeypatch, m)
+    racing_called = []
+    monkeypatch.setattr(
+        m._racing_matcher, "match",
+        lambda **kw: racing_called.append(kw["league"]) or _racing_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_single(1, "Monaco Grand Prix (2026-06-01 13:00:00)", date(2026, 6, 1))
+    assert racing_called == ["f1"]
+    assert out[0].is_matched
 
 
 # ---------------------------------------------------------------------------

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -7,15 +7,24 @@ regression-prone path (cf. #157): a team-sport stream that leaks into a
 racing-dominant group must NOT be hijacked as a race.
 """
 
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
-from teamarr.consumers.matching.classifier import StreamCategory, classify_stream
+from teamarr.consumers.matching.classifier import (
+    StreamCategory,
+    classify_stream,
+    has_racing_text_evidence,
+)
 from teamarr.consumers.matching.racing_matcher import RacingMatchContext, RacingMatcher
 from teamarr.consumers.racing_segments import (
+    _is_practice_session,
+    _isolate_stream_session_label,
     _parse_duration_from_name,
+    _session_category_from_stream_name,
     _session_duration_hours,
+    _session_in_category,
+    expand_racing_segments,
 )
 from teamarr.services.detection_keywords import DetectionKeywordService
 
@@ -351,3 +360,224 @@ def test_stream_name_racing_fallback_on_team_only_gate(monkeypatch):
     assert len(out) == 1
     assert out[0].is_matched
     assert captured["classified"].category == StreamCategory.RACING_EVENT
+
+
+# ---------------------------------------------------------------------------
+# Racing text evidence: WEC
+# ---------------------------------------------------------------------------
+
+
+def test_wec_stream_names_carry_racing_text_evidence():
+    # WEC had no signature in RACING_TEXT_EVIDENCE at all, so genuine WEC
+    # streams could never pass the mixed-group racing fallback gate in
+    # matcher.py — WEC simply never matched.
+    assert has_racing_text_evidence("WEC | Qualifying: 6 Hours of Sao Paulo")
+    assert has_racing_text_evidence("FIA World Endurance Championship - Race")
+    assert has_racing_text_evidence("FIA WEC Sao Paulo")
+    assert not has_racing_text_evidence("Random Movie Channel")
+
+
+# ---------------------------------------------------------------------------
+# Session scoping: a stream whose NAME names a specific session must only
+# produce that session's channel entry, not fan out across the weekend (and
+# conversely, a generic stream name must not be narrowed away from sessions
+# it should still cover).
+# ---------------------------------------------------------------------------
+
+
+def _wec_sessions():
+    base = datetime(2026, 7, 11, 9, tzinfo=UTC)
+    return [
+        SimpleNamespace(code="fp1", name="Free Practice 1", start_time=base),
+        SimpleNamespace(code="fp2", name="Free Practice 2", start_time=base + timedelta(hours=4)),
+        SimpleNamespace(code="fp3", name="Free Practice 3", start_time=base + timedelta(hours=8)),
+        SimpleNamespace(
+            code="qualifying_lmgt3", name="Qualifying - LMGT3",
+            start_time=base + timedelta(hours=12),
+        ),
+        SimpleNamespace(
+            code="hyperpole_lmgt3", name="Hyperpole - LMGT3",
+            start_time=base + timedelta(hours=12, minutes=30),
+        ),
+        SimpleNamespace(
+            code="qualifying_hypercar", name="Qualifying - Hypercar",
+            start_time=base + timedelta(hours=13),
+        ),
+        SimpleNamespace(
+            code="hyperpole_hypercar", name="Hyperpole - Hypercar",
+            start_time=base + timedelta(hours=13, minutes=30),
+        ),
+        SimpleNamespace(code="race", name="Race", start_time=base + timedelta(days=1)),
+    ]
+
+
+def _wec_event(sessions=None):
+    sessions = sessions if sessions is not None else _wec_sessions()
+    return SimpleNamespace(
+        sport="racing",
+        league="wec",
+        name="6 Hours of São Paulo",
+        sessions=sessions,
+    )
+
+
+def test_isolate_stream_session_label():
+    label = _isolate_stream_session_label(
+        "AU (STAN 36) | Free Practice 3: 6 Hours of Sao Paulo WEC 2026 (2026-07-11 23:00:44)"
+    )
+    assert label == "Free Practice 3"
+
+
+def test_isolate_stream_session_label_no_delimiters():
+    assert _isolate_stream_session_label("HBO UK 065") == "HBO UK 065"
+
+
+class TestSessionCategoryFromStreamName:
+    def test_numbered_free_practice(self):
+        assert _session_category_from_stream_name(
+            "AU (STAN 36) | Free Practice 3: 6 Hours of Sao Paulo WEC 2026 (2026-07-11 23:00:44)"
+        ) == "fp3"
+
+    def test_bare_qualifying(self):
+        assert _session_category_from_stream_name(
+            "AU (STAN 39) | Qualifying: 6 Hours of Sao Paulo WEC 2026 (2026-07-12 03:20:29)"
+        ) == "qualifying"
+
+    def test_bare_race(self):
+        name = "AU (STAN) | Race: 6 Hours of Sao Paulo"
+        assert _session_category_from_stream_name(name) == "race"
+
+    def test_generic_channel_name_has_no_hint(self):
+        # Linear/whole-weekend channel names must not trip narrowing.
+        name = "HBO UK 065|  6 HOURS OF SAO PAULO - FIA WEC | Round 5 | 6 Hours of Sao Paulo (2026-07-11 13:00:00)"  # noqa: E501
+        assert _session_category_from_stream_name(name) is None
+
+    def test_race_as_substring_of_unrelated_branding_has_no_hint(self):
+        # "race" must only count as a label when it (near enough) stands
+        # alone — not as a substring of generic branding text.
+        assert _session_category_from_stream_name("Sky | Race Week Live: WEC coverage") is None
+
+    def test_plain_channel_name_has_no_hint(self):
+        assert _session_category_from_stream_name("ESPN 2 (US)") is None
+
+    def test_trailing_qualifying_keyword(self):
+        # NASCAR/TSN+ convention: session type as a trailing word in the
+        # label, not the whole label (unlike tsdb/STAN's bare "Qualifying").
+        assert _session_category_from_stream_name(
+            "CA (TSN+ 021) | NASCAR Cup Series Qualifying: Quaker State 400 (2026-07-11 16:30:00)"
+        ) == "qualifying"
+        assert _session_category_from_stream_name(
+            "CA (TSN+ 015) | 2026 NASCAR ORAP Series Qualifying: Focused Health 250 (2026-07-11 11:00:00)"  # noqa: E501
+        ) == "qualifying"
+
+    def test_no_trailing_keyword_has_no_hint(self):
+        # A label ending in descriptive text (not a session word) must not
+        # trip the trailing fallback.
+        assert _session_category_from_stream_name(
+            "2026 NASCAR CRAFTSMAN Truck Series: LiUNA 150 (2026-07-11 13:00:00)"
+        ) is None
+        assert _session_category_from_stream_name(
+            "CA (TSN+ 036) | NASCAR Cup Series On_Board Camera: Quaker State 400 (2026-07-12 19:00:00)"  # noqa: E501
+        ) is None
+
+
+class TestSessionInCategory:
+    def test_numbered_fp_matches_exactly(self):
+        assert _session_in_category("fp3", "fp3")
+        assert not _session_in_category("fp1", "fp3")
+
+    def test_qualifying_category_covers_class_suffixed_sessions(self):
+        assert _session_in_category("qualifying_lmgt3", "qualifying")
+        assert _session_in_category("qualifying_hypercar", "qualifying")
+        assert not _session_in_category("fp1", "qualifying")
+
+    def test_qualifying_category_also_covers_hyperpole(self):
+        # WEC's Hyperpole is itself a qualifying shootout, and providers
+        # rarely label it distinctly — a bare "Qualifying" stream is a real
+        # candidate for a Hyperpole session too.
+        assert _session_in_category("hyperpole_lmgt3", "qualifying")
+        assert _session_in_category("hyperpole_hypercar", "qualifying")
+        assert _session_in_category("hyperpole", "qualifying")
+        # But a stream explicitly labeled "Hyperpole" stays scoped to
+        # hyperpole sessions only — narrowing is not symmetric.
+        assert not _session_in_category("qualifying_lmgt3", "hyperpole")
+
+
+class TestIsPracticeSession:
+    def test_numbered_fp_codes(self):
+        assert _is_practice_session("fp1")
+        assert _is_practice_session("fp2")
+        assert _is_practice_session("fp3")
+
+    def test_bare_practice_code(self):
+        assert _is_practice_session("practice")
+
+    def test_non_practice_codes(self):
+        assert not _is_practice_session("qualifying")
+        assert not _is_practice_session("race")
+        assert not _is_practice_session("hyperpole_lmgt3")
+        assert not _is_practice_session("sprint")
+
+
+def test_expand_racing_segments_scopes_dedicated_fp3_stream():
+    matched = [{"stream": {"id": 1, "name": "AU (STAN) | Free Practice 3: 6 Hours of Sao Paulo"},
+                "event": _wec_event()}]
+    out = expand_racing_segments(matched)
+    assert [m["segment"] for m in out] == ["fp3"]
+
+
+def test_expand_racing_segments_scopes_bare_qualifying_to_both_classes_and_hyperpole():
+    matched = [{"stream": {"id": 1, "name": "AU (STAN) | Qualifying: 6 Hours of Sao Paulo"},
+                "event": _wec_event()}]
+    out = expand_racing_segments(matched)
+    assert {m["segment"] for m in out} == {
+        "qualifying_lmgt3", "qualifying_hypercar", "hyperpole_lmgt3", "hyperpole_hypercar",
+    }
+
+
+def test_expand_racing_segments_keeps_full_fanout_for_generic_channel_name_excluding_practice():
+    # A generic/linear channel name still fans out across everything EXCEPT
+    # practice — providers rarely carry a dedicated practice feed, so a
+    # whole-weekend stream landing on a Practice channel is more likely to
+    # be dead air than a real source; better no channel than that.
+    matched = [{
+        "stream": {"id": 1, "name": "HBO UK 065|  6 HOURS OF SAO PAULO - FIA WEC | Round 5"},
+        "event": _wec_event(),
+    }]
+    out = expand_racing_segments(matched)
+    assert {m["segment"] for m in out} == {
+        "qualifying_lmgt3", "hyperpole_lmgt3", "qualifying_hypercar", "hyperpole_hypercar",
+        "race",
+    }
+
+
+def test_expand_racing_segments_still_scopes_dedicated_practice_stream():
+    # The exception: a stream whose name specifically names a practice
+    # session still gets that session's channel.
+    matched = [{"stream": {"id": 1, "name": "AU (STAN) | Free Practice 2: 6 Hours of Sao Paulo"},
+                "event": _wec_event()}]
+    out = expand_racing_segments(matched)
+    assert [m["segment"] for m in out] == ["fp2"]
+
+
+def test_expand_racing_segments_falls_back_when_no_session_of_the_category_exists():
+    # Defensive: a hint that doesn't match anything in THIS event's sessions
+    # must not silently produce zero segments for a real matched stream.
+    sessions = [s for s in _wec_sessions() if s.code != "fp3"]
+    matched = [{"stream": {"id": 1, "name": "AU (STAN) | Free Practice 3: 6 Hours of Sao Paulo"},
+                "event": _wec_event(sessions)}]
+    out = expand_racing_segments(matched)
+    assert len(out) == len(sessions)
+
+
+def test_expand_racing_segments_produces_no_channel_when_only_practice_exists():
+    # A single-session (practice-only) event matched by a generic stream:
+    # rather than land the stream on a Practice channel with nothing airing
+    # yet, no segment — and so no channel — should be produced at all.
+    sessions = [
+        SimpleNamespace(code="practice", name="Practice",
+                        start_time=datetime(2026, 7, 11, 9, tzinfo=UTC)),
+    ]
+    matched = [{"stream": {"id": 1, "name": "TSN+ 016"}, "event": _wec_event(sessions)}]
+    out = expand_racing_segments(matched)
+    assert out == []

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -513,6 +513,22 @@ class TestSessionCategoryFromStreamName:
             "CA (TSN+ 015) | 2026 NASCAR ORAP Series Qualifying: Focused Health 250 (2026-07-11 11:00:00)"  # noqa: E501
         ) == "qualifying"
 
+    def test_trailing_unnumbered_practice_keyword(self):
+        # NASCAR emits an unnumbered "practice" session code and TSN+ labels
+        # the feed "<Series> Practice" (no digit) — this must scope to the
+        # practice category, not fall into the generic fan-out where the
+        # practice exclusion would drop it (the exact inversion: a dedicated
+        # practice feed landing on Qualifying/Race but not Practice).
+        assert _session_category_from_stream_name(
+            "CA (TSN+ 021) | NASCAR Cup Series Practice: Quaker State 400 (2026-07-11 14:30:00)"
+        ) == "practice"
+
+    def test_trailing_practice_requires_word_boundary(self):
+        # "...practice" as a word-suffix must not match ("Malpractice").
+        assert _session_category_from_stream_name(
+            "US | Malpractice: Medical Drama Marathon (2026-07-11 20:00:00)"
+        ) is None
+
     def test_no_trailing_keyword_has_no_hint(self):
         # A label ending in descriptive text (not a session word) must not
         # trip the trailing fallback.
@@ -601,6 +617,24 @@ def test_expand_racing_segments_still_scopes_dedicated_practice_stream():
                 "event": _wec_event()}]
     out = expand_racing_segments(matched)
     assert [m["segment"] for m in out] == ["fp2"]
+
+
+def test_expand_racing_segments_scopes_unnumbered_trailing_practice_stream():
+    # NASCAR-style weekend: an unnumbered "practice" session plus qualifying
+    # and race. A TSN+ "<Series> Practice" feed must land on the practice
+    # channel only.
+    base = datetime(2026, 7, 11, 9, tzinfo=UTC)
+    sessions = [
+        SimpleNamespace(code="practice", name="Practice", start_time=base),
+        SimpleNamespace(code="qualifying", name="Qualifying", start_time=base + timedelta(hours=3)),
+        SimpleNamespace(code="race", name="Race", start_time=base + timedelta(days=1)),
+    ]
+    matched = [{
+        "stream": {"id": 1, "name": "CA (TSN+ 021) | NASCAR Cup Series Practice: Quaker State 400"},
+        "event": _wec_event(sessions),
+    }]
+    out = expand_racing_segments(matched)
+    assert [m["segment"] for m in out] == ["practice"]
 
 
 def test_expand_racing_segments_falls_back_when_no_session_of_the_category_exists():

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -427,6 +427,17 @@ class TestDetectRacingSeriesLeagues:
         assert detect_racing_series_leagues("FIA WEC | ROUND 5") == ("wec",)
         assert detect_racing_series_leagues("World Endurance Championship") == ("wec",)
 
+    def test_formula_feeder_series_block_and_do_not_scope_to_f1(self):
+        # F2/F3/Formula E have no league in schema.sql but run on F1 weekends
+        # at the same venue — they must map to the blocking sentinel, and the
+        # F1 pattern must not also fire on the same text.
+        assert detect_racing_series_leagues("Formula 2 - Monaco - Sprint Race") == (
+            "formula-feeder",
+        )
+        assert detect_racing_series_leagues("F3: Feature Race") == ("formula-feeder",)
+        assert detect_racing_series_leagues("Formula E - Berlin ePrix") == ("formula-feeder",)
+        assert detect_racing_series_leagues("F1 | Monaco Grand Prix") == ("f1",)
+
     def test_generic_grand_prix_is_unscoped(self):
         # "grand prix" is racing evidence but names no series — must stay
         # unscoped so a bare "Monaco Grand Prix" stream can still match F1.
@@ -455,6 +466,26 @@ def test_racing_series_scoping_blocks_unconfigured_series(monkeypatch):
     out = m._match_single(
         1, "CA (SN+ 017) | MotoGP _ Grand Prix of Germany (2026-07-12 07:15:00)",
         date(2026, 7, 12),
+    )
+    assert not racing_called  # f1 must never be attempted
+    assert not out[0].matched
+
+
+def test_racing_series_scoping_blocks_f2_from_binding_to_f1(monkeypatch):
+    # F2 races on the F1 weekend at the same venue: an "F2 Sprint Race"
+    # stream must not bind to the configured F1 event via shared venue
+    # tokens and date coverage.
+    m = _mixed_matcher()  # racing league available: f1 only
+    _failed_route(monkeypatch, m)
+    racing_called = []
+    monkeypatch.setattr(
+        m._racing_matcher, "match",
+        lambda **kw: racing_called.append(kw["league"]) or _racing_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_single(
+        1, "Formula 2 | Monaco | Sprint Race (2026-06-01 09:30:00)", date(2026, 6, 1)
     )
     assert not racing_called  # f1 must never be attempted
     assert not out[0].matched

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -342,6 +342,49 @@ def test_stream_name_racing_fallback_gated_by_name_match(monkeypatch):
     assert not out[0].is_matched
 
 
+def test_stream_name_racing_fallback_on_placeholder_gate(monkeypatch):
+    # A timestamped racing stream with no separator ("US (Peacock 031) | IMSA
+    # CTMP Grand Prix (2026-07-12 14:00:00)") classifies PLACEHOLDER in a
+    # team-dominant group: the date/time extraction disqualifies TEAM_ONLY
+    # and nothing else fits. It must reach the racing fallback instead of
+    # being dropped as "unclassifiable".
+    m = _mixed_matcher()
+    monkeypatch.setattr(m, "_match_racing_event", lambda classified, sid, td: _racing_outcome())
+    captured = {}
+
+    def capture(outcome, *, stream_id, stream_name, classified):
+        captured["classified"] = classified
+        return outcome
+
+    monkeypatch.setattr(m, "_outcome_to_result", capture)
+
+    out = m._match_single(
+        1, "US (Peacock 031) | IMSA CTMP Grand Prix (2026-07-12 14:00:00)", date(2026, 7, 12)
+    )
+    assert len(out) == 1
+    assert out[0].is_matched
+    assert captured["classified"].category == StreamCategory.RACING_EVENT
+
+
+def test_placeholder_without_racing_evidence_stays_unclassifiable(monkeypatch):
+    # A timestamped stream with NO racing series name still short-circuits as
+    # unclassifiable — the fallback must not turn every dated filler stream
+    # into a racing-match attempt.
+    m = _mixed_matcher()
+    racing_called = []
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda *a, **kw: racing_called.append(1) or _racing_outcome(),
+    )
+
+    out = m._match_single(
+        1, "US (Peacock 054) | Premier League Darts (2026-07-12 19:00:00)", date(2026, 7, 12)
+    )
+    assert not racing_called
+    assert not out[0].matched
+    assert out[0].exclusion_reason == "unclassifiable"
+
+
 def test_stream_name_racing_fallback_on_team_only_gate(monkeypatch):
     # Team matching OFF: a TEAM_ONLY-classified racing stream ("F1 | Monaco
     # Grand Prix") must reach the fallback instead of being dropped with


### PR DESCRIPTION
## Summary

Two related racing-matching fixes, found while running WEC and NASCAR event groups in production:

### 1. WEC streams never match (`classifier.py`)

`RACING_TEXT_EVIDENCE` has no signature for the FIA World Endurance Championship, so genuine WEC streams (`FIA WEC | ROUND 5 | 6 HOURS OF SAO PAULO | ...`, `WEC | Qualifying: ...`) can never pass the `has_racing_text_evidence` gate on the mixed-group racing fallback in `matcher.py`. The result is that WEC events systematically produce **zero** stream matches regardless of what the provider carries — `wec` is in `_RACING_LEAGUE_HINTS` and the schema, but no text can ever prove it. Fix: add `wec|world\s+endurance` to the regex.

### 2. Racing session fan-out ignores session labels in stream names (`racing_segments.py`)

`expand_racing_segments` fans every matched racing stream out into a channel entry for *every* session in the event. In practice that means a dedicated "Free Practice 3" feed also shows up as a source on the Qualifying and Race channels, and "NASCAR Cup Series Qualifying" streams land on the Race channel.

This PR scopes the fan-out when the stream's own name clearly names one session:

- **Label-is-session-type** convention (STAN/tsdb style): `AU (STAN 36) | Free Practice 3: 6 Hours of Sao Paulo WEC 2026 (...)` → fp3 only.
- **Label-ends-in-session-type** convention (TSN+ style): `CA (TSN+ 021) | NASCAR Cup Series Qualifying: Quaker State 400 (...)` → qualifying only. Trailing-keyword matching is end-anchored, so branding like "Race Week Live" doesn't false-positive.
- A bare **"Qualifying"** label also covers WEC **Hyperpole** sessions (Hyperpole is a qualifying shootout; providers rarely label it distinctly). The reverse is not true — an explicit "Hyperpole" stream stays scoped to hyperpole sessions.
- Detection is deliberately conservative: a name with no recognizable session label (generic linear channels like `TNT Sports 4 HD`) keeps the previous full fan-out, and a label that matches no session in *this* event's session list falls back to the full fan-out rather than silently producing nothing.

It also **excludes practice sessions from the generic-stream fan-out** (still produced when a stream specifically names one): providers frequently don't carry dedicated practice feeds at all, so a whole-weekend stream landing on a Practice channel tends to be dead air until qualifying starts — better no channel than that. If this is too opinionated a default for teamarr, this part is cleanly separable; happy to drop or gate it behind a setting.

The session-label regexes are defined locally rather than imported from `providers.tsdb.racing`: that parser's `_FREE_PRACTICE_RE` requires a digit and the literal "free practice"/"fp" forms, so it would miss stream labels like "Practice 2".

### 3. PLACEHOLDER streams never reach the racing fallback (`matcher.py`)

A racing stream carrying a timestamp but no team separator (`US (Peacock 031) | IMSA CTMP Grand Prix (2026-07-12 14:00:00)`) classifies PLACEHOLDER in a team-dominant group — the extracted date/time disqualifies `_classify_team_only`, and nothing else fits. `_match_single` then returned `"unclassifiable"` at step 2, **before** the #349 racing fallback was consulted, so a stream the fallback would happily match (series name present, single covering event, fuzzy 66 vs. threshold 50) was dropped instead. Fixed by routing the PLACEHOLDER branch through `_try_racing_fallback` first, under the same `name_match_enabled` gate as the TEAM_ONLY path; timestamped streams *without* racing text evidence still short-circuit as unclassifiable.

### 4. Cross-series date-binding: streams for unconfigured series match whatever races that weekend (`matcher.py`, `classifier.py`)

Found live right after fix 3 landed: two "MotoGP - Grand Prix of Germany" streams direct-matched IMSA's "Chevrolet Grand Prix". MotoGP isn't a configured league, so the IMSA event was the only racing event covering the date, and the shared "Grand Prix" tokens cleared the single-event sanity bar — the text-evidence gate can't reject it because MotoGP *is* racing text. Fixed with per-series signature patterns (`detect_racing_series_leagues`, a scoping subset of `RACING_TEXT_EVIDENCE`): when a stream explicitly names a series, `_match_racing_event` only tries that series' league(s), and fails outright when none are configured. Generic racing text (a bare "Monaco Grand Prix") names no series and stays unscoped, preserving existing behavior.

## Testing

- 35 new tests across the four fixes covering label isolation, both label conventions, hyperpole/qualifying coverage, practice exclusion, the no-matching-session fallback, and the WEC text-evidence regression.
- Full suite: **1665 passed** on this branch.
- Both fixes verified live against a production Dispatcharr + teamarr:dev install during a WEC race weekend (6 Hours of São Paulo) and a NASCAR triple-header weekend: WEC streams matched only after fix 1, and per-session streams stopped attaching to the wrong session channels with fix 2.

Closes-when-released #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168e49DmKeWX9cDEyDk6xuF
