### PR TITLE
Anchor EPG racing matches to the programme's broadcast instant

### DIFF
--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -727,7 +727,9 @@ class StreamMatcher:
         if classified.category == StreamCategory.EVENT_CARD:
             return [self._match_event_card(classified, stream_id, target_date)]
         if classified.category == StreamCategory.RACING_EVENT:
-            return [self._match_racing_event(classified, stream_id, target_date)]
+            return [self._match_racing_event(
+                classified, stream_id, target_date, anchor_dt=anchor_dt
+            )]
         if classified.category == StreamCategory.TENNIS_MATCH:
             return self._match_tennis_event(classified, stream_id, target_date)
         if classified.category == StreamCategory.TEAM_ONLY:
@@ -830,6 +832,25 @@ class StreamMatcher:
                 )
                 continue
 
+            # Same text-evidence gate as the racing fallback, applied to the
+            # PRIMARY classification too: in a racing-dominant group
+            # _get_dominant_event_type() returns "event" directly, so this
+            # classify_stream call already defaults arbitrary EPG titles
+            # (documentaries, movies) to RACING_EVENT with no series name in
+            # the text — the fallback's gate never even runs for these groups
+            # since primary_outcomes already "succeeds". Without this check,
+            # any program on any linear channel resolved into a racing-only
+            # group can bind to "the one race happening this weekend" by date
+            # coverage alone.
+            if classified.category == StreamCategory.RACING_EVENT and not (
+                has_racing_text_evidence(epg_input)
+            ):
+                logger.debug(
+                    "[EPG_MATCH] racing programme skipped, no series name in text: %s",
+                    epg_input[:60],
+                )
+                continue
+
             # TEAM_ONLY gate: skip team routing when disabled, but allow the
             # racing fallback to run if racing leagues are present. A race title
             # like "F1 | Monaco Grand Prix" classifies TEAM_ONLY in a mixed
@@ -862,7 +883,9 @@ class StreamMatcher:
 
             # Racing fallback for mixed groups (see _try_racing_fallback).
             if not matched_pairs and classified.category != StreamCategory.RACING_EVENT:
-                fallback = self._try_racing_fallback(epg_input, stream_id, target_date)
+                fallback = self._try_racing_fallback(
+                    epg_input, stream_id, target_date, anchor_dt=program.start_dt
+                )
                 if fallback is not None:
                     matched_pairs.append(fallback)
 
@@ -1058,8 +1081,13 @@ class StreamMatcher:
         classified: ClassifiedStream,
         stream_id: int,
         target_date: date,
+        anchor_dt: "datetime | None" = None,
     ) -> MatchOutcome:
-        """Match a racing stream (F1, NASCAR, IndyCar, MotoGP, ...)."""
+        """Match a racing stream (F1, NASCAR, IndyCar, MotoGP, ...).
+
+        anchor_dt (EPG path only): the program's broadcast instant — candidate
+        events are gated to those with a session actually airing near it.
+        """
         # Find the racing leagues in our search leagues. The "event" type is
         # shared with tennis/golf, so exclude leagues whose sport is known to
         # be something else (unknown sport = legacy racing behavior).
@@ -1112,6 +1140,8 @@ class StreamMatcher:
                 stream_id=stream_id,
                 generation=self._generation,
                 user_tz=self._user_tz,
+                anchor_dt=anchor_dt,
+                sport_durations=self._sport_durations,
             )
             if outcome.is_matched:
                 return outcome
@@ -1129,6 +1159,7 @@ class StreamMatcher:
         text: str,
         stream_id: int,
         target_date: date,
+        anchor_dt: "datetime | None" = None,
     ) -> "tuple[MatchOutcome, ClassifiedStream] | None":
         """Racing fallback for mixed groups (#349): re-classify as racing and retry.
 
@@ -1167,7 +1198,9 @@ class StreamMatcher:
         if racing_classified.category != StreamCategory.RACING_EVENT:
             return None
 
-        outcome = self._match_racing_event(racing_classified, stream_id, target_date)
+        outcome = self._match_racing_event(
+            racing_classified, stream_id, target_date, anchor_dt=anchor_dt
+        )
         if not outcome.is_matched:
             return None
         return outcome, racing_classified

--- a/teamarr/consumers/matching/racing_matcher.py
+++ b/teamarr/consumers/matching/racing_matcher.py
@@ -16,7 +16,7 @@ Matching strategy:
 
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from rapidfuzz import fuzz
@@ -28,6 +28,7 @@ from teamarr.consumers.matching.result import (
     MatchMethod,
     MatchOutcome,
 )
+from teamarr.consumers.racing_segments import get_session_times
 from teamarr.consumers.stream_match_cache import StreamMatchCache, event_to_cache_data
 from teamarr.core.types import Event
 from teamarr.services.sports_data import SportsDataService
@@ -43,6 +44,16 @@ RACING_MATCH_THRESHOLD = 70
 # (e.g. cycling/other-sport streams misclassified as racing events).
 SINGLE_EVENT_SANITY_THRESHOLD = 50
 
+# EPG path only: how far a program's broadcast instant may sit from a
+# session's [start, end] window and still count as covering that session.
+# Date coverage alone is not enough for EPG titles: a program whose text
+# merely NAMES racing (e.g. the animated movie "Grand Prix of Europe" airing
+# on a kids' channel, or a filler/stub "Coming up:" blurb) can otherwise bind
+# to "the one race covering this date" regardless of what hour it airs — a
+# program landing hours away from every real session is not a broadcast of
+# that event.
+RACING_ANCHOR_TOLERANCE_SECONDS = 90 * 60
+
 
 @dataclass
 class RacingMatchContext:
@@ -55,6 +66,8 @@ class RacingMatchContext:
     generation: int
     user_tz: ZoneInfo
     classified: ClassifiedStream
+    anchor_dt: "datetime | None" = None
+    sport_durations: "dict[str, float] | None" = None
 
 
 class RacingMatcher:
@@ -83,6 +96,8 @@ class RacingMatcher:
         stream_id: int,
         generation: int,
         user_tz: ZoneInfo,
+        anchor_dt: "datetime | None" = None,
+        sport_durations: "dict[str, float] | None" = None,
     ) -> MatchOutcome:
         """Match a racing stream to a provider event.
 
@@ -119,6 +134,8 @@ class RacingMatcher:
             generation=generation,
             user_tz=user_tz,
             classified=classified,
+            anchor_dt=anchor_dt,
+            sport_durations=sport_durations,
         )
 
         # Check cache first
@@ -153,6 +170,21 @@ class RacingMatcher:
                 detail=f"No {league} events covering {ctx.target_date}",
             )
 
+        # EPG path only: further gate to events with a session actually airing
+        # near the program's broadcast instant, not just sharing a date.
+        if anchor_dt is not None:
+            window_events = [
+                e for e in window_events
+                if self._covers_instant(e, anchor_dt, sport_durations)
+            ]
+            if not window_events:
+                return MatchOutcome.failed(
+                    FailedReason.NO_RACING_MATCH,
+                    stream_name=ctx.stream_name,
+                    stream_id=stream_id,
+                    detail=f"No {league} session airing near {anchor_dt.isoformat()}",
+                )
+
         result = self._match_to_event(ctx, window_events, league)
 
         # Cache successful matches
@@ -173,6 +205,35 @@ class RacingMatcher:
         session_dates = {s.start_time.astimezone(user_tz).date() for s in event.sessions}
         session_dates.add(event.start_time.astimezone(user_tz).date())
         return target_date in session_dates
+
+    def _covers_instant(
+        self,
+        event: Event,
+        anchor_dt: "datetime",
+        sport_durations: "dict[str, float] | None",
+    ) -> bool:
+        """True if some session of ``event`` is actually airing near ``anchor_dt``.
+
+        Unlike `_covers_date` (calendar-date granularity, used for the plain
+        stream-name path where the whole weekend is a legitimate match target),
+        this checks each session's real [start, end] window (padded by
+        RACING_ANCHOR_TOLERANCE_SECONDS) — the EPG path needs this tighter
+        bound because a program merely NAMING racing (a movie with "Grand
+        Prix" in the title, a filler/stub blurb) would otherwise bind to any
+        session of the week's only covering event regardless of how many
+        hours away it actually airs.
+        """
+        if not event.sessions:
+            return abs((event.start_time - anchor_dt).total_seconds()) <= (
+                RACING_ANCHOR_TOLERANCE_SECONDS
+            )
+
+        tolerance = timedelta(seconds=RACING_ANCHOR_TOLERANCE_SECONDS)
+        for session in event.sessions:
+            start, end = get_session_times(event, session.code, sport_durations)
+            if start - tolerance <= anchor_dt <= end + tolerance:
+                return True
+        return False
 
     def _check_cache(self, ctx: RacingMatchContext) -> MatchOutcome | None:
         """Check cache for existing match."""
@@ -196,6 +257,13 @@ class RacingMatcher:
 
         # Validate date - cached event's window must still cover target date
         if not self._covers_date(event, ctx.target_date, ctx.user_tz):
+            return None
+
+        # EPG path only: cached match must still have a session airing near
+        # this program's instant (see match()'s anchor_dt gate above).
+        if ctx.anchor_dt is not None and not self._covers_instant(
+            event, ctx.anchor_dt, ctx.sport_durations
+        ):
             return None
 
         return MatchOutcome.matched(

--- a/tests/epg/test_epg_matcher_integration.py
+++ b/tests/epg/test_epg_matcher_integration.py
@@ -263,7 +263,7 @@ def test_epg_racing_fallback_nascar_at_city(monkeypatch):
     monkeypatch.setattr(m, "_route_to_outcomes",
         lambda c, sid, td, anchor_dt=None: [MatchOutcome.failed(None)])
     monkeypatch.setattr(m, "_match_racing_event",
-        lambda classified, sid, td: _racing_matched_outcome())
+        lambda classified, sid, td, anchor_dt=None: _racing_matched_outcome())
     monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
 
     out = m._match_via_epg(100, "ESPN", "espn", date(2026, 6, 1))
@@ -290,7 +290,7 @@ def test_epg_racing_fallback_f1_team_only(monkeypatch):
     monkeypatch.setattr(
         m,
         "_match_racing_event",
-        lambda classified, sid, td: MatchOutcome.matched(
+        lambda classified, sid, td, anchor_dt=None: MatchOutcome.matched(
             MatchMethod.FUZZY, event=race_ev, confidence=0.9
         ),
     )
@@ -355,7 +355,7 @@ def test_epg_racing_fallback_uses_racing_classification_in_result(monkeypatch):
     monkeypatch.setattr(m, "_route_to_outcomes",
         lambda c, sid, td, anchor_dt=None: [MatchOutcome.failed(None)])
     monkeypatch.setattr(m, "_match_racing_event",
-        lambda classified, sid, td: _racing_matched_outcome())
+        lambda classified, sid, td, anchor_dt=None: _racing_matched_outcome())
     captured = {}
     def capture_result(outcome, *, stream_id, stream_name, classified):
         captured["category"] = classified.category
@@ -385,10 +385,78 @@ def test_epg_racing_fallback_requires_text_evidence(monkeypatch):
         lambda c, sid, td, anchor_dt=None: [MatchOutcome.failed(None)])
     racing_called = []
     monkeypatch.setattr(m, "_match_racing_event",
-        lambda classified, sid, td: racing_called.append(1) or _racing_matched_outcome())
+        lambda classified, sid, td, anchor_dt=None: (
+            racing_called.append(1) or _racing_matched_outcome()))
     monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
 
     out = m._match_via_epg(100, "US: Smithsonian Channel", "espn", date(2026, 6, 1))
 
     assert racing_called == []  # racing matcher never consulted
     assert out == []
+
+
+# ============================================= racing: primary text gate + anchor
+
+
+def test_epg_primary_racing_requires_text_evidence_in_racing_only_group(monkeypatch):
+    # A racing-ONLY group makes _get_dominant_event_type() return "event"
+    # directly, so the PRIMARY classify_stream call in _match_via_epg already
+    # defaults an unrelated programme to RACING_EVENT — the fallback's
+    # text-evidence gate never even runs, since the primary route already
+    # "succeeds". Same false-positive class as the fallback bug, just on a
+    # different linear channel (a documentary airing during a race weekend).
+    prog = _prog(title="Nature", sub="Wolves of Yellowstone")
+    index = EPGProgramIndex({"pbs": [prog]})
+    m = _bare_matcher(index, team_streams_enabled=True, racing_leagues=("wec",))
+    racing_called = []
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda classified, sid, td, anchor_dt=None: racing_called.append(1)
+        or _racing_matched_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_via_epg(100, "PBS Affiliate", "pbs", date(2026, 6, 1))
+
+    assert racing_called == []  # racing matcher never consulted
+    assert out == []
+
+
+def test_epg_primary_racing_matches_wec_title_with_series_name(monkeypatch):
+    # The legitimate case the gate must NOT break: a genuine WEC programme
+    # (series name present) in a racing-only group should still match.
+    prog = _prog(title="WEC", sub="6 Hours of Spa - Free Practice 1")
+    index = EPGProgramIndex({"wec-chan": [prog]})
+    m = _bare_matcher(index, team_streams_enabled=True, racing_leagues=("wec",))
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda classified, sid, td, anchor_dt=None: _racing_matched_outcome(),
+    )
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_via_epg(100, "WEC Channel", "wec-chan", date(2026, 6, 1))
+
+    assert len(out) == 1
+    assert out[0].event.id == "race1"
+
+
+def test_epg_racing_receives_programme_instant_as_anchor(monkeypatch):
+    # The racing route must receive the programme's own broadcast instant as
+    # anchor_dt so RacingMatcher can reject programmes airing hours from any
+    # session (the "Grand Prix of Europe" Disney Junior false match).
+    prog = _prog(title="WEC", sub="6 Hours of Spa")
+    index = EPGProgramIndex({"wec-chan": [prog]})
+    m = _bare_matcher(index, team_streams_enabled=True, racing_leagues=("wec",))
+    seen = {}
+
+    def capture(classified, sid, td, anchor_dt=None):
+        seen["anchor_dt"] = anchor_dt
+        return _racing_matched_outcome()
+
+    monkeypatch.setattr(m, "_match_racing_event", capture)
+    monkeypatch.setattr(m, "_outcome_to_result", lambda outcome, **kw: outcome)
+
+    out = m._match_via_epg(100, "WEC Channel", "wec-chan", date(2026, 6, 1))
+
+    assert len(out) == 1
+    assert seen["anchor_dt"] == prog.start_dt

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -211,6 +211,71 @@ def test_single_event_country_passes_sanity_check():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# RacingMatcher anchor-time gating (EPG path)
+#
+# The EPG text-evidence gate only proves a programme NAMES racing — it says
+# nothing about whether the programme is actually airing it. The animated
+# movie "Grand Prix of Europe" on a kids' channel (fuzzy 75 vs "Chevrolet
+# Grand Prix") or a filler/stub "Coming up:" blurb passes that gate yet has
+# no real broadcast tied to the event. _covers_instant closes the gap by
+# requiring a session to actually be airing (within tolerance) at the
+# programme's own broadcast instant, not just somewhere in the race
+# weekend's calendar span. Stream-NAME matching passes anchor_dt=None and is
+# untouched — the whole weekend stays a legitimate match target there.
+# ---------------------------------------------------------------------------
+
+
+def _racing_session(code, start_time):
+    return SimpleNamespace(code=code, start_time=start_time)
+
+
+def _sessions_event(sessions, league="imsa", name="Chevrolet Grand Prix"):
+    return SimpleNamespace(
+        id="tsdb_imsa_2026_7",
+        name=name,
+        short_name=name,
+        circuit_name="Canadian Tire Motorsport Park",
+        venue=SimpleNamespace(country="Canada"),
+        league=league,
+        sessions=sessions,
+        start_time=sessions[0].start_time,
+    )
+
+
+def test_covers_instant_true_near_a_real_session():
+    race_start = datetime(2026, 7, 12, 18, 0, tzinfo=UTC)
+    event = _sessions_event([_racing_session("race", race_start)])
+    matcher = _matcher()
+    assert matcher._covers_instant(event, race_start, None)
+    assert matcher._covers_instant(event, race_start - timedelta(minutes=30), None)
+
+
+def test_covers_instant_false_for_programme_hours_away():
+    # Live false positive: "Grand Prix of Europe" (animated movie) airing at
+    # 03:15 on Disney Junior matched the IMSA race starting at 18:00, every
+    # hourly run, because date coverage alone was the only time check.
+    race_start = datetime(2026, 7, 12, 18, 0, tzinfo=UTC)
+    event = _sessions_event([_racing_session("race", race_start)])
+    movie_showing = datetime(2026, 7, 12, 3, 15, tzinfo=UTC)
+    matcher = _matcher()
+    assert not matcher._covers_instant(event, movie_showing, None)
+
+
+def test_covers_instant_checks_every_session_in_the_weekend():
+    # A multi-session weekend: an instant near ANY session (not just the
+    # first) counts as covered.
+    fp1 = datetime(2026, 7, 10, 9, 0, tzinfo=UTC)
+    race = datetime(2026, 7, 12, 18, 0, tzinfo=UTC)
+    event = _sessions_event(
+        [_racing_session("fp1", fp1), _racing_session("race", race)]
+    )
+    matcher = _matcher()
+    assert matcher._covers_instant(event, fp1, None)
+    assert matcher._covers_instant(event, race, None)
+    assert not matcher._covers_instant(event, fp1 + timedelta(hours=6), None)
+
+
 class TestParseDurationFromName:
     def test_digit_hours(self):
         assert _parse_duration_from_name("24 Hours of Le Mans") == 24.0
@@ -292,7 +357,10 @@ def test_stream_name_racing_fallback_in_mixed_group(monkeypatch):
     # the result carries the RACING_EVENT classification.
     m = _mixed_matcher()
     _failed_route(monkeypatch, m)
-    monkeypatch.setattr(m, "_match_racing_event", lambda classified, sid, td: _racing_outcome())
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda classified, sid, td, anchor_dt=None: _racing_outcome(),
+    )
     captured = {}
 
     def capture(outcome, *, stream_id, stream_name, classified):
@@ -350,7 +418,10 @@ def test_stream_name_racing_fallback_on_placeholder_gate(monkeypatch):
     # and nothing else fits. It must reach the racing fallback instead of
     # being dropped as "unclassifiable".
     m = _mixed_matcher()
-    monkeypatch.setattr(m, "_match_racing_event", lambda classified, sid, td: _racing_outcome())
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda classified, sid, td, anchor_dt=None: _racing_outcome(),
+    )
     captured = {}
 
     def capture(outcome, *, stream_id, stream_name, classified):
@@ -391,7 +462,10 @@ def test_stream_name_racing_fallback_on_team_only_gate(monkeypatch):
     # Grand Prix") must reach the fallback instead of being dropped with
     # team_streams_disabled (mirrors the EPG path's TEAM_ONLY bypass).
     m = _mixed_matcher(team_streams_enabled=False)
-    monkeypatch.setattr(m, "_match_racing_event", lambda classified, sid, td: _racing_outcome())
+    monkeypatch.setattr(
+        m, "_match_racing_event",
+        lambda classified, sid, td, anchor_dt=None: _racing_outcome(),
+    )
     captured = {}
 
     def capture(outcome, *, stream_id, stream_name, classified):


### PR DESCRIPTION
## Summary

EPG-driven racing matches bind by **date coverage alone**: any programme whose title carries racing text evidence and clears the fuzzy bar matches "the one race covering this date" regardless of what hour it airs.

Live false positive that motivated this: **"Grand Prix of Europe" — the animated kids' movie — airing at 03:15 on Disney Junior matched IMSA's "Chevrolet Grand Prix" (race start 18:00)** at fuzzy 75 via the shared "Grand Prix" tokens, on every hourly run. The text-evidence gate can't reject it ("grand prix" *is* racing evidence), series scoping (#394) can't either (the title names no series), and both fuzzy thresholds pass. The only thing that distinguishes a broadcast of the race from a coincidentally-titled programme is *when it airs* — which the racing matcher never looked at.

## Changes

1. **Anchor gate in `RacingMatcher`** (ported from the team/event-card EPG matching's bead-t5e anchor concept, which `_route_to_outcomes` already threads — the racing branch just dropped it): the EPG path passes the programme's start instant, and candidate events are further gated to those with a session actually airing within ±90 min of it (`_covers_instant`, using each session's real `[start, end]` from `get_session_times`). Applied to fresh matches **and cache hits**, so a stale cached bind can't outlive the gate.

2. **Text-evidence gate on the PRIMARY EPG classification path**: in a racing-dominant group `_get_dominant_event_type()` returns `"event"` directly, so the primary `classify_stream` call defaults arbitrary EPG titles (documentaries, movies) to `RACING_EVENT` — the fallback's existing gate never runs for those groups. The same check now applies before routing.

3. **The stream-NAME path is untouched by design**: all name-path call sites pass `anchor_dt=None`, and the gate only fires when an anchor is present — the whole race weekend remains a legitimate match target for named streams, so #394's placeholder fallback, series scoping, and session-label scoping behave identically (full suite re-run green to confirm).

## Testing

- 6 new tests: `_covers_instant` unit coverage (near-session pass, hours-away reject incl. the Disney Junior reproduction, multi-session weekends), the primary-path evidence gate (unrelated documentary rejected / genuine WEC title still matches), and an EPG-plumbing test asserting the programme instant reaches the racing route as `anchor_dt`.
- Full suite: **1708 passed** on this branch (rebased onto current `dev` post-#394/#407, including the `_compute_epg_plan` perf refactor).
- Live-verified on the same install as #394: the movie's 03:15 and 15:15 showings both reject (race window with tolerance is 16:30–22:15), while during-race and 30-min-pre-race instants accept; genuine Peacock IMSA streams unaffected.

Closes-when-released: happy to link an issue if you'd like one filed like #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168e49DmKeWX9cDEyDk6xuF
