### PR TITLE
fix: drop zombie league codes on subscription save + surface stale slugs (#408)

### DIFF
--- a/docs/guide/subscriptions.md
+++ b/docs/guide/subscriptions.md
@@ -35,6 +35,10 @@ Subscribe to as many or as few leagues as you like — there is no cost to a bro
 {: .note }
 > **Unsubscribing cleans up after itself.** When you uncheck a league, the next generation run deletes the channels it created for that league — you no longer have to wipe all channels to apply the change. The source group can stay enabled; only the dropped league's channels are removed.
 
+### Stale leagues
+
+Provider discovery lists change over time, so a subscribed league can disappear from Teamarr's league cache while still sitting in your subscription. These show up in an amber **Stale leagues** box on the Sports tile — remove them with the × and save, or just save: unrecognized codes are dropped automatically (and logged) whenever the subscription is saved, so they can't silently waste provider calls on every generation run.
+
 ## Soccer modes
 
 Soccer is special because there are hundreds of leagues. Rather than checking each one, you choose a **mode**:

--- a/frontend/src/components/GlobalDefaults.tsx
+++ b/frontend/src/components/GlobalDefaults.tsx
@@ -21,6 +21,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { LeaguePicker } from "@/components/LeaguePicker"
+import { SelectedBadges } from "@/components/ui/selected-badges"
 import { SoccerModeSelector, type SoccerMode } from "@/components/SoccerModeSelector"
 import { TeamPicker } from "@/components/TeamPicker"
 import { useSubscription, useUpdateSubscription } from "@/hooks/useSubscription"
@@ -35,26 +36,36 @@ import type { SoccerFollowedTeam } from "@/api/types"
 import type { TeamFilterSettings } from "@/api/settings"
 
 /**
- * Split subscribed league slugs into soccer vs non-soccer. Module-level so the
- * render-time seeding block below stays simple enough for the React Compiler
- * (a .find() lambda combined with a method call inside that block defeats its
- * memoization analysis).
+ * Split subscribed league slugs into soccer / non-soccer / stale. Module-level
+ * so the render-time seeding block below stays simple enough for the React
+ * Compiler (a .find() lambda combined with a method call inside that block
+ * defeats its memoization analysis).
+ *
+ * Stale (#408): a slug the league cache no longer knows. Provider discovery
+ * lists churn, so subscribed slugs can outlive the cache — the cache-driven
+ * pickers never render them, making them undeselectable "zombies" that still
+ * cost provider calls every generation run. They're surfaced as removable
+ * badges instead. When the league list hasn't loaded yet there's no basis to
+ * judge, so everything unknown stays in the non-soccer bucket as before.
  */
 function splitSubscribedLeagues(
   slugs: string[],
   allLeagues: { slug: string; sport?: string | null }[],
-): { soccer: string[]; nonSoccer: string[] } {
+): { soccer: string[]; nonSoccer: string[]; stale: string[] } {
   const soccer: string[] = []
   const nonSoccer: string[] = []
+  const stale: string[] = []
   for (const slug of slugs) {
     const league = allLeagues.find((l) => l.slug === slug)
-    if (league?.sport?.toLowerCase() === "soccer") {
+    if (!league && allLeagues.length > 0) {
+      stale.push(slug)
+    } else if (league?.sport?.toLowerCase() === "soccer") {
       soccer.push(slug)
     } else {
       nonSoccer.push(slug)
     }
   }
-  return { soccer, nonSoccer }
+  return { soccer, nonSoccer, stale }
 }
 
 export function GlobalDefaults({
@@ -93,6 +104,7 @@ export function GlobalDefaults({
   const [nonSoccerLeagues, setNonSoccerLeagues] = useState<string[]>([])
   const [soccerMode, setSoccerMode] = useState<SoccerMode>(null)
   const [soccerLeagues, setSoccerLeagues] = useState<string[]>([])
+  const [staleLeagues, setStaleLeagues] = useState<string[]>([])
   const [followedTeams, setFollowedTeams] = useState<SoccerFollowedTeam[]>([])
   const [hasLocalChanges, setHasLocalChanges] = useState(false)
 
@@ -120,11 +132,12 @@ export function GlobalDefaults({
   ) {
     setSyncedSubscription({ subscription, leaguesData })
 
-    // Split leagues into soccer vs non-soccer
-    const { soccer, nonSoccer } = splitSubscribedLeagues(subscription.leagues, allLeagues)
+    // Split leagues into soccer vs non-soccer vs stale
+    const { soccer, nonSoccer, stale } = splitSubscribedLeagues(subscription.leagues, allLeagues)
 
     setNonSoccerLeagues(nonSoccer)
     setSoccerLeagues(soccer)
+    setStaleLeagues(stale)
     setSoccerMode(subscription.soccer_mode as SoccerMode)
     setFollowedTeams(subscription.soccer_followed_teams || [])
     setHasLocalChanges(false)
@@ -143,6 +156,12 @@ export function GlobalDefaults({
     () => [...nonSoccerLeagues, ...soccerLeagues],
     [nonSoccerLeagues, soccerLeagues]
   )
+
+  // Remove a stale (cache-unknown) slug from the pending subscription
+  const handleRemoveStale = useCallback((slug: string) => {
+    setStaleLeagues((prev) => prev.filter((s) => s !== slug))
+    setHasLocalChanges(true)
+  }, [])
 
   // Handle non-soccer league change
   const handleNonSoccerChange = useCallback((leagues: string[]) => {
@@ -168,9 +187,12 @@ export function GlobalDefaults({
     setHasLocalChanges(true)
   }, [])
 
-  // Save subscription to server
+  // Save subscription to server. Stale slugs the user hasn't removed ride
+  // along unchanged — the backend validates against its league universe and
+  // logs+drops anything unknown (#408), so a save from here never silently
+  // grows the list back.
   const handleSave = useCallback(() => {
-    const combinedLeagues = [...nonSoccerLeagues, ...soccerLeagues]
+    const combinedLeagues = [...nonSoccerLeagues, ...soccerLeagues, ...staleLeagues]
     updateMutation.mutate(
       {
         leagues: combinedLeagues,
@@ -187,7 +209,7 @@ export function GlobalDefaults({
         },
       }
     )
-  }, [nonSoccerLeagues, soccerLeagues, soccerMode, followedTeams, updateMutation])
+  }, [nonSoccerLeagues, soccerLeagues, staleLeagues, soccerMode, followedTeams, updateMutation])
 
   // Save team filter
   const handleSaveTeamFilter = useCallback(() => {
@@ -245,6 +267,23 @@ export function GlobalDefaults({
             showSelectedBadges={true}
             maxBadges={10}
           />
+          {staleLeagues.length > 0 && (
+            <div className="space-y-1.5 rounded-md border border-amber-500/40 bg-amber-500/5 p-3">
+              <Label className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                Stale leagues
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                These subscribed leagues are no longer recognized (removed from
+                provider discovery). They can't be shown in the pickers and are
+                dropped on save.
+              </p>
+              <SelectedBadges
+                items={staleLeagues.map((slug) => ({ key: slug, label: slug }))}
+                maxBadges={20}
+                onRemove={handleRemoveStale}
+              />
+            </div>
+          )}
           <div className="flex justify-end pt-2">
             <SaveButton
               onClick={handleSave}

--- a/teamarr/database/subscription.py
+++ b/teamarr/database/subscription.py
@@ -157,6 +157,39 @@ def get_subscribed_league_codes(conn: Connection) -> set[str]:
     return codes
 
 
+def _drop_unknown_league_codes(conn: Connection, codes: list[str]) -> list[str]:
+    """Drop codes not present in the leagues ∪ league_cache universe (#408).
+
+    ESPN's discovery list churns (leagues drop out while their data endpoints
+    keep working), so slugs can outlive the cache and become invisible zombies:
+    the UI's cache-driven pickers never render them, yet every generation run
+    still fetches events for them. Validating on save keeps the persisted list
+    inside the known universe; drops are logged, never silent.
+
+    When league_cache is empty (fresh install, mid cache-refresh — the refresh
+    deletes and repopulates the table) there is no universe to judge against,
+    so validation is skipped rather than wrongly purging the whole list.
+    """
+    cache_rows = conn.execute("SELECT DISTINCT league_slug FROM league_cache").fetchall()
+    if not cache_rows:
+        return codes
+    known = {row[0].lower() for row in cache_rows}
+    known.update(
+        row[0].lower()
+        for row in conn.execute("SELECT league_code FROM leagues").fetchall()
+    )
+    kept = [c for c in codes if c and c.lower() in known]
+    dropped = [c for c in codes if c and c.lower() not in known]
+    if dropped:
+        logger.warning(
+            "[SUBSCRIPTION] Dropped %d unknown league code(s) on save "
+            "(not in leagues/league_cache): %s",
+            len(dropped),
+            ", ".join(sorted(dropped)),
+        )
+    return kept
+
+
 def update_subscription(
     conn: Connection,
     leagues: list[str] | None | EllipsisType = ...,
@@ -180,6 +213,8 @@ def update_subscription(
     params = []
 
     if leagues is not ...:
+        if leagues:
+            leagues = _drop_unknown_league_codes(conn, leagues)
         updates.append("leagues = ?")
         params.append(json.dumps(leagues) if leagues is not None else "[]")
 

--- a/tests/subscriptions/test_sports_subscription.py
+++ b/tests/subscriptions/test_sports_subscription.py
@@ -33,6 +33,19 @@ def _create_subscription_schema(conn):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL
         );
+
+        -- Known-league universe for save-time validation (#408). league_cache
+        -- left empty by default so validation is skipped unless a test seeds it.
+        CREATE TABLE IF NOT EXISTS leagues (
+            league_code TEXT PRIMARY KEY
+        );
+
+        CREATE TABLE IF NOT EXISTS league_cache (
+            league_slug TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            sport TEXT NOT NULL,
+            PRIMARY KEY (league_slug, provider)
+        );
     """)
     conn.commit()
 
@@ -71,6 +84,44 @@ class TestSubscriptionCRUD:
         update_subscription(db, leagues=["nhl", "nba", "nfl"])
         sub = get_subscription(db)
         assert sorted(sub.leagues) == ["nba", "nfl", "nhl"]
+
+    def test_update_leagues_drops_unknown_codes(self, db):
+        """Zombie slugs absent from leagues ∪ league_cache are dropped on save (#408)."""
+        from teamarr.database.subscription import get_subscription, update_subscription
+
+        db.execute(
+            "INSERT INTO league_cache (league_slug, provider, sport) VALUES "
+            "('nhl', 'espn', 'hockey'), ('eng.1', 'espn', 'soccer')"
+        )
+        db.execute("INSERT INTO leagues (league_code) VALUES ('sui.1')")
+        db.commit()
+
+        update_subscription(
+            db, leagues=["nhl", "eng.1", "sui.1", "bra.carioca.groupa", "afc.challenge_cup"]
+        )
+        sub = get_subscription(db)
+        assert sorted(sub.leagues) == ["eng.1", "nhl", "sui.1"]
+
+    def test_update_leagues_validation_is_case_insensitive(self, db):
+        from teamarr.database.subscription import get_subscription, update_subscription
+
+        db.execute(
+            "INSERT INTO league_cache (league_slug, provider, sport) "
+            "VALUES ('nhl', 'espn', 'hockey')"
+        )
+        db.commit()
+
+        update_subscription(db, leagues=["NHL"])
+        sub = get_subscription(db)
+        assert sub.leagues == ["NHL"]
+
+    def test_update_leagues_skips_validation_when_cache_empty(self, db):
+        """Empty league_cache (fresh install / mid-refresh) must not purge the list."""
+        from teamarr.database.subscription import get_subscription, update_subscription
+
+        update_subscription(db, leagues=["nhl", "bra.carioca.groupa"])
+        sub = get_subscription(db)
+        assert sorted(sub.leagues) == ["bra.carioca.groupa", "nhl"]
 
     def test_update_soccer_mode(self, db):
         from teamarr.database.subscription import get_subscription, update_subscription


### PR DESCRIPTION
Closes-when-released #408. Bead: `teamarrv2-r2yn`.

## Problem

`sports_subscription.leagues` accumulates slugs the league cache no longer knows (observed live: 4 stale ESPN slugs surviving every save for months). The UI's cache-driven bucketing makes them invisible — they can't be rendered, so they can't be deselected — and every generation run fetches events for them (4 leagues × 11 dates of wasted provider calls per group-batch in the observed case).

Root cause of the churn validated today: ESPN's soccer discovery list simply changes membership over time (e.g. `bra.carioca.groupa` still serves data at its direct endpoint but is no longer listed; the old "250 cap" theory is disproven — `limit≤1000` is honored and the full list is 220). Any list-driven cache sheds leagues eventually, so the subscription must tolerate unknown slugs.

## Fix (a+b from the bead — never silently mutate a user list without surfacing it)

- **Backend:** `update_subscription` validates codes against the `leagues` ∪ `league_cache` union; unknowns are logged and dropped on save. Skipped entirely when `league_cache` is empty (fresh install / mid cache-refresh deletes+repopulates the table) so a transient empty cache can't purge the list. Custom leagues are safe: `insert_custom_league` runs before `_auto_subscribe`, so the code is already in `leagues` when validation runs.
- **Frontend:** `splitSubscribedLeagues` gains a `stale` bucket — cache-unknown slugs render as removable badges in an amber "Stale leagues" box on the Sports tile (reuses `SelectedBadges`) instead of hiding in the non-soccer bucket. Stale slugs the user doesn't remove still ride in the save payload; the backend net catches them.

## Verification

- 3 new tests: unknown codes dropped, case-insensitive matching, empty-cache skip. Existing subscription tests unchanged (fixture gained the two universe tables, empty by default).
- Live UI verified via Playwright against the dev instance with an injected fake zombie slug: amber box + badge render, × removes it and arms Save, box disappears when empty. (DB restored to byte-identical state after.)
- Docs: "Stale leagues" subsection added to `docs/guide/subscriptions.md`.

## Gates

- `ruff check` clean · `pytest` 1705 passed · `npm run build` green