### PR TITLE
feat: pin live events' #1 stream on re-gen, append new streams below (#232)

### DIFF
--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -69,6 +69,12 @@ Both **Stream Type** (team streams) and **Home/Away Feed** rules let you pick sp
 
 Teamarr builds a name-matching pattern from your selected teams' names and abbreviations, then looks for feed indicators in the stream name — a matchup (`vs`, `at`, `@`), a side (`home`/`away`), a camera label (`cam 01`/`cam 02`), or a `(Team feed)` marker. A stream like `Cubs vs Pirates (Home)` is recognized as the Pirates' home feed. Generic streams with no feed markers (for example a plain `Pirates vs Cubs` with no side) are left for other rules to handle. Because detection relies on the stream name, results depend on your provider's naming conventions.
 
+## Live events keep their #1 stream
+
+While an event is airing, scheduled generation runs won't displace the channel's top stream — the one a viewer is most likely watching. Rule changes still take effect in the background (priorities are recomputed and stored), and new streams that match mid-event are added **below** the current #1, but the top slot itself stays put until the event ends. The first run after the event restores full rule ordering.
+
+A **manually triggered** generation run bypasses this pin — that's your escape hatch if the pinned stream is the wrong one: fix your rules (or remove the bad stream) and hit Generate.
+
 ## Why is a stream ordered this way?
 
 On the **Channels** page, click a stream's priority number to open a popover that explains its ordering against your current rules: the hard **band** it landed in (and which Priority rule, if any, set it), plus each **Scoring** contribution with its points. If the stored number was computed under rules you've since changed, the popover marks it stale so you know a regeneration will re-rank it.

--- a/teamarr/api/routes/epg.py
+++ b/teamarr/api/routes/epg.py
@@ -122,6 +122,7 @@ def generate_epg(
             db_factory=get_db,
             dispatcharr_client=dispatcharr_client,
             progress_callback=progress_callback,
+            manual=True,
         )
 
         if not result.success:
@@ -294,6 +295,7 @@ def generate_epg_stream():
                 db_factory=get_db,
                 dispatcharr_client=dispatcharr_client,
                 progress_callback=progress_callback,
+                manual=True,
             )
 
             if result.success:

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -105,6 +105,7 @@ def run_full_generation(
     db_factory: Callable[[], Any],
     dispatcharr_client: Any | None = None,
     progress_callback: ProgressCallback | None = None,
+    manual: bool = False,
 ) -> GenerationResult:
     """Run the complete EPG generation workflow.
 
@@ -124,6 +125,9 @@ def run_full_generation(
         db_factory: Factory function returning database connection context manager
         dispatcharr_client: Optional DispatcharrClient for Dispatcharr operations
         progress_callback: Optional callback for progress updates
+        manual: True for user-triggered runs (API endpoints); bypasses the
+            live-event #1 stream pin (#232) so a wrong pin can be corrected.
+            Scheduled runs leave this False.
 
     Returns:
         GenerationResult with all stats and sub-task results
@@ -374,7 +378,7 @@ def run_full_generation(
         check_cancelled()
         update_progress("ordering", 93, "Applying stream ordering rules...")
         result.stream_ordering = _apply_stream_ordering(
-            db_factory, dispatcharr_client, update_progress
+            db_factory, dispatcharr_client, update_progress, manual=manual
         )
         timer.mark("stream_ordering")
 
@@ -925,8 +929,17 @@ def _apply_stream_ordering(
     db_factory: Callable[[], Any],
     dispatcharr_client: Any | None,
     update_progress: Callable,
+    manual: bool = False,
 ) -> dict:
-    """Apply stream ordering rules to all managed channels."""
+    """Apply stream ordering rules to all managed channels.
+
+    ``manual`` (#232): a user-triggered run bypasses the live-event #1 pin —
+    the escape hatch when the pinned stream is wrong. Scheduled runs keep the
+    top slot of an in-window event's channel stable so a re-gen can't displace
+    the stream a viewer is currently watching; rule-truth priorities are still
+    persisted, so normal ordering resumes on the first post-event push.
+    """
+    from teamarr.consumers.lifecycle import is_channel_event_live
     from teamarr.database.channels import (
         get_all_managed_channels,
         get_channel_streams,
@@ -979,6 +992,16 @@ def _apply_stream_ordering(
                 if not streams:
                     continue
 
+                # Live-event #1 pin (#232): capture the currently-pushed top
+                # stream BEFORE priorities are recomputed, so the push below
+                # can keep it in the top slot mid-broadcast.
+                pinned_top: int | None = None
+                if not manual and is_channel_event_live(
+                    channel.event_date, channel.scheduled_delete_at
+                ):
+                    pre_order = get_ordered_stream_ids(conn, channel.id)
+                    pinned_top = pre_order[0] if pre_order else None
+
                 reordered_count = 0
                 if ordering_service:
                     for stream in streams:
@@ -1001,6 +1024,24 @@ def _apply_stream_ordering(
                     channel_mgr and channel.dispatcharr_channel_id
                 ):
                     ordered_ids = get_ordered_stream_ids(conn, channel.id)
+                    if (
+                        pinned_top is not None
+                        and ordered_ids
+                        and ordered_ids[0] != pinned_top
+                        and pinned_top in ordered_ids
+                    ):
+                        # Event is live: rule-truth priorities are in the DB,
+                        # but the push keeps the current #1 on top so the
+                        # stream being watched isn't displaced mid-broadcast.
+                        ordered_ids.remove(pinned_top)
+                        ordered_ids.insert(0, pinned_top)
+                        logger.info(
+                            "[STREAM_AUDIT] pin: ch='%s' (d_id=%s) live event — "
+                            "kept stream %d at #1 (#232)",
+                            channel.channel_name,
+                            channel.dispatcharr_channel_id,
+                            pinned_top,
+                        )
                     if has_windowed:
                         reorder_result["windows_synced"] += 1
                     logger.info(

--- a/teamarr/consumers/lifecycle/__init__.py
+++ b/teamarr/consumers/lifecycle/__init__.py
@@ -20,7 +20,7 @@ from teamarr.dispatcharr import ChannelManager, EPGManager, LogoManager
 from teamarr.dispatcharr.factory import DispatcharrConnection
 
 from .service import ChannelLifecycleService
-from .timing import ChannelLifecycleManager
+from .timing import ChannelLifecycleManager, is_channel_event_live  # noqa: F401 - re-export
 from .types import (
     ChannelCreationResult,
     CreateTiming,

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -14,7 +14,7 @@ from typing import Any
 from teamarr.core import Event
 
 from ._host import _LifecycleHost
-from .timing import compute_stream_window, is_stream_in_window
+from .timing import compute_stream_window, is_channel_event_live, is_stream_in_window
 from .types import (
     ChannelCreationResult,
     StreamProcessResult,
@@ -597,6 +597,30 @@ class ChannelCreator(_LifecycleHost):
                                 existing.id, phantoms,
                             )
                             ordered_streams = [s for s in ordered_streams if s not in phantoms]
+
+                    # Live-event #1 pin (#232): a stream that arrives while the
+                    # event is airing may out-prioritize the current top slot —
+                    # the one a viewer is watching. Slot it in right below #1
+                    # instead; rule-truth priorities stay in the DB, so normal
+                    # order resumes on the first post-event push.
+                    if (
+                        len(ordered_streams) > 1
+                        and ordered_streams[0] == stream_id
+                        and is_channel_event_live(
+                            existing.event_date, existing.scheduled_delete_at
+                        )
+                    ):
+                        ordered_streams[0], ordered_streams[1] = (
+                            ordered_streams[1],
+                            ordered_streams[0],
+                        )
+                        logger.info(
+                            "[STREAM_AUDIT] pin: ch='%s' live event — new stream %d "
+                            "slotted below current #1 %d (#232)",
+                            existing.channel_name,
+                            stream_id,
+                            ordered_streams[0],
+                        )
 
                     logger.info(
                         "[STREAM_AUDIT] consolidate add: ch='%s' (db_id=%d, d_id=%s) "

--- a/teamarr/consumers/lifecycle/timing.py
+++ b/teamarr/consumers/lifecycle/timing.py
@@ -91,6 +91,54 @@ def is_stream_in_window(
     return attach_at <= now < detach_at
 
 
+def is_channel_event_live(
+    event_date: "str | datetime | None",
+    scheduled_delete_at: "str | datetime | None",
+    now: datetime | None = None,
+) -> bool:
+    """Whether a managed channel's event is in its live window right now (#232).
+
+    Live window = ``[event_date, scheduled_delete_at]``. ``scheduled_delete_at``
+    is computed at channel creation from the sessions-aware event-end estimate
+    plus the post buffer (or 23:59 same-day), so it already IS the best
+    "broadcast over" bound we have — no duration lookup needed here. When it is
+    missing, fall back to ``event_date + 6h`` (conservative team-sport bound).
+
+    Used to pin a live channel's #1 stream against re-generation rewrites: the
+    top slot is what a viewer is watching, and re-gen runs must not displace it
+    mid-broadcast. Returns False when ``event_date`` is unknown or unparseable —
+    unknown timing must not freeze a channel forever.
+    """
+    start = _parse_channel_dt(event_date)
+    if start is None:
+        return False
+    if now is None:
+        now = datetime.now(UTC)
+    end = _parse_channel_dt(scheduled_delete_at)
+    if end is None:
+        end = start + timedelta(hours=6)
+    return start <= now <= end
+
+
+def _parse_channel_dt(value: "str | datetime | None") -> datetime | None:
+    """Parse a managed_channels timestamp (ISO string from ``.isoformat()``).
+
+    Naive values are assumed UTC — providers hand us aware UTC datetimes and
+    the creator stores them via ``.isoformat()``, so naive only appears in
+    legacy rows/tests.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value
+
+
 class ChannelLifecycleManager:
     """Manages event channel creation and deletion timing.
 

--- a/tests/epg/test_generation_helpers.py
+++ b/tests/epg/test_generation_helpers.py
@@ -149,3 +149,96 @@ def test_ordering_failure_is_captured_not_raised(db_conn):
     result = _apply_stream_ordering(broken_factory, None, _noop_progress)
     assert result["error"] == "db exploded"
     assert result["channels_reordered"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _apply_stream_ordering — live-event #1 pin (#232)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingChannelManager:
+    """Stands in for generation.ChannelManager; records update_channel pushes."""
+
+    pushes: list[tuple[int, dict]] = []
+
+    def __init__(self, client):
+        pass
+
+    def update_channel(self, channel_id, payload):
+        _RecordingChannelManager.pushes.append((channel_id, payload))
+        from types import SimpleNamespace
+
+        return SimpleNamespace(success=True)
+
+
+def _seed_live_channel(conn, *, live: bool):
+    """Channel with a rule that promotes stream 101 over the incumbent 100."""
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    start = now + timedelta(hours=(-1 if live else -10))
+    end = now + timedelta(hours=(2 if live else -7))
+    cur = conn.execute(
+        "INSERT INTO managed_channels (event_id, event_provider, tvg_id, channel_name, "
+        "dispatcharr_channel_id, event_date, scheduled_delete_at) "
+        "VALUES ('e1', 'espn', 'tvg-1', 'Test Channel', 555, ?, ?)",
+        (start.isoformat(), end.isoformat()),
+    )
+    channel_id = cur.lastrowid
+    conn.executemany(
+        """INSERT INTO managed_channel_streams
+           (managed_channel_id, dispatcharr_stream_id, stream_name, priority)
+           VALUES (?, ?, ?, ?)""",
+        [
+            (channel_id, 100, "ESPN 1080p", 0),  # incumbent #1 (tie -> added first)
+            (channel_id, 101, "ESPN 720p", 0),
+        ],
+    )
+    rules = [{"type": "regex", "value": "(?i)720p", "priority": 1}]
+    conn.execute(
+        "UPDATE settings SET stream_ordering_rules = ? WHERE id = 1", (json.dumps(rules),)
+    )
+    conn.commit()
+    return channel_id
+
+
+def _run_ordering_with_recorder(db_factory, monkeypatch, *, manual: bool):
+    import teamarr.consumers.generation as generation_mod
+
+    _RecordingChannelManager.pushes = []
+    monkeypatch.setattr(generation_mod, "ChannelManager", _RecordingChannelManager)
+    return _apply_stream_ordering(db_factory, object(), _noop_progress, manual=manual)
+
+
+def test_live_event_pin_keeps_incumbent_top(db_factory, db_conn, monkeypatch):
+    _seed_live_channel(db_conn, live=True)
+
+    result = _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    # Rule-truth priorities ARE persisted (101 promoted in the DB)...
+    rows = {
+        r["dispatcharr_stream_id"]: r["priority"]
+        for r in db_conn.execute(
+            "SELECT dispatcharr_stream_id, priority FROM managed_channel_streams"
+        ).fetchall()
+    }
+    assert rows[101] == 1
+    assert result["streams_reordered"] == 2
+    # ...but the push keeps the incumbent #1 on top mid-broadcast.
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [100, 101]})]
+
+
+def test_manual_run_bypasses_live_pin(db_factory, db_conn, monkeypatch):
+    _seed_live_channel(db_conn, live=True)
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=True)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [101, 100]})]
+
+
+def test_ended_event_gets_rule_order(db_factory, db_conn, monkeypatch):
+    _seed_live_channel(db_conn, live=False)
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [101, 100]})]

--- a/tests/lifecycle/test_live_event_pin.py
+++ b/tests/lifecycle/test_live_event_pin.py
@@ -1,0 +1,60 @@
+"""Live-event #1 stream pin (#232) — is_channel_event_live unit coverage.
+
+The pin's gate: a channel is protected while its event is airing,
+[event_date, scheduled_delete_at]. scheduled_delete_at already encodes the
+sessions-aware end estimate + post buffer, so no duration math happens here.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from teamarr.consumers.lifecycle.timing import is_channel_event_live
+
+NOW = datetime(2026, 7, 12, 20, 0, tzinfo=UTC)
+
+
+def _iso(delta_hours: float) -> str:
+    return (NOW + timedelta(hours=delta_hours)).isoformat()
+
+
+def test_live_inside_window():
+    assert is_channel_event_live(_iso(-1), _iso(+2), now=NOW) is True
+
+
+def test_not_live_before_start():
+    assert is_channel_event_live(_iso(+1), _iso(+4), now=NOW) is False
+
+
+def test_not_live_after_delete_threshold():
+    assert is_channel_event_live(_iso(-8), _iso(-1), now=NOW) is False
+
+
+def test_boundaries_inclusive():
+    assert is_channel_event_live(_iso(0), _iso(+3), now=NOW) is True
+    assert is_channel_event_live(_iso(-3), _iso(0), now=NOW) is True
+
+
+def test_no_event_date_is_never_live():
+    # Unknown timing must not freeze a channel forever.
+    assert is_channel_event_live(None, _iso(+2), now=NOW) is False
+
+
+def test_missing_delete_at_falls_back_to_six_hours():
+    assert is_channel_event_live(_iso(-2), None, now=NOW) is True
+    assert is_channel_event_live(_iso(-8), None, now=NOW) is False
+
+
+def test_naive_strings_assumed_utc():
+    naive_start = (NOW - timedelta(hours=1)).replace(tzinfo=None).isoformat()
+    naive_end = (NOW + timedelta(hours=2)).replace(tzinfo=None).isoformat()
+    assert is_channel_event_live(naive_start, naive_end, now=NOW) is True
+
+
+def test_unparseable_event_date_is_never_live():
+    assert is_channel_event_live("not-a-date", _iso(+2), now=NOW) is False
+
+
+def test_datetime_inputs_accepted():
+    assert (
+        is_channel_event_live(NOW - timedelta(hours=1), NOW + timedelta(hours=1), now=NOW)
+        is True
+    )


### PR DESCRIPTION
Closes-when-released #232. Bead: `teamarrv2-vszk`. Design agreed on the issue thread (pin-#1 + append-below, per user direction).

## Problem

Generation runs at e.g. 17:15 and 19:15; the 17:15 run sets up the channel for an 18:30 event. The 19:15 run re-processes the now-live event and rewrites its stream list — potentially displacing the stream someone is watching (reported in #232).

## Behavior

Once an event is in its live window, **scheduled** runs:
- keep the incumbent #1 stream in the top slot (both rewrite surfaces covered: the ordering pass and the consolidate-add path where a new stream out-prioritizes the top),
- still **add** newly matched streams — below #1,
- still **persist rule-truth priorities** to the DB, so the first post-event push restores full rule ordering automatically.

**Manual** runs (both API generation endpoints) bypass the pin — the escape hatch when the pinned stream is wrong. The scheduler pins by default.

## Design notes

- Live window = `[event_date, scheduled_delete_at]` — the delete threshold is computed at creation from the sessions-aware event-end estimate + post buffer, so it's already the best "broadcast over" bound (racing weekends included). Missing threshold falls back to start + 6h; unknown `event_date` never pins (a channel must not freeze forever).
- Pin applies at **push time only** — no DB priority forcing, no new state, no new setting (#406 posture: opt-out arrives if someone asks).
- EPG-match attach/detach windows, channel deletion protection, and XML generation are deliberately untouched; the pin only affects which ID leads the pushed `streams` list.

## Tests

- 9 unit tests for `is_channel_event_live` (boundaries, fallbacks, naive/aware, unparseable).
- 3 integration tests for the ordering pass with a recording ChannelManager: live pin holds incumbent on top while DB gets rule-truth, manual bypass pushes rule order, ended events push rule order.
- Creator-side pin shares the same tested gate; the swap itself is a two-element reorder.

## Gates

`ruff` clean · `pytest` 1726 passed · `npm run build` green