### PR TITLE
feat: match league All-Star games in event EPG (#433)

### DIFF
--- a/docs/guide/matching/index.md
+++ b/docs/guide/matching/index.md
@@ -110,6 +110,15 @@ Separators have no **Target Value** — the field is hidden on this tab.
 {: .note }
 Live-broadcast prefixes such as `DIRECTO`, `EN DIRECTO`, `EN VIVO`, `AO VIVO`, `DIRETTA`, and `DIREKT` are stripped automatically during matching, so a stream like `DIRECTO España - Inglaterra` is read as `España - Inglaterra`. You don't need to configure these.
 
+## All-Star Games
+
+League All-Star exhibitions (the MLB All-Star Game, the MLS All-Star Game, and others) are matched automatically — there's nothing to configure. Providers name these streams generically, like `MLB All-Star Game`, which carries no real matchup. Teamarr recognizes the **"All-Star"** keyword together with a **league hint** and resolves the stream to that league's single All-Star event for the day.
+
+This works without hardcoding the teams, so it keeps working as the yearly opponent changes (for example, the MLS All-Stars face a different side each summer). It relies on the data provider listing both sides of the game as All-Star squads — the case for MLB and MLS. Leagues whose provider names the sides differently (divisions or captain-picked teams) aren't recognized this way.
+
+{: .note }
+An All-Star stream still needs **Stream Name** matching enabled on its source, and the league must be one the event group subscribes to.
+
 ## Keyword Fields
 
 All keyword tabs (Event Type, League Hints, Sport Hints, Separators) share the same create/edit form:

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -29,6 +29,7 @@ class StreamCategory(Enum):
     RACING_EVENT = "racing_event"  # Racing race weekends (F1, NASCAR, etc.)
     TENNIS_MATCH = "tennis_match"  # Tennis matches ("Wimbledon: Zheng vs Norrie")
     TEAM_ONLY = "team_only"  # Single-team branded stream (e.g., "NHL | Toronto Maple Leafs")
+    ALL_STAR = "all_star"  # League All-Star exhibition (e.g., "MLB All-Star Game")
     PLACEHOLDER = "placeholder"  # No event info, skip
 
 
@@ -1697,6 +1698,36 @@ def _classify_team_vs_team(ctx: _ClassifyContext) -> ClassifiedStream | None:
     )
 
 
+# Word-bounded "All-Star" / "All Star" / "Allstar" (singular or plural) token.
+_ALL_STAR_RE = re.compile(r"\ball[\s\-]?stars?\b", re.IGNORECASE)
+
+
+def _classify_all_star(ctx: _ClassifyContext) -> ClassifiedStream | None:
+    """Step 3.5: League All-Star exhibition games (MLB, MLS, ...).
+
+    ESPN carries All-Star games inside the normal league scoreboard as two
+    pseudo-teams (e.g. "American All-Stars"/"National All-Stars" for MLB,
+    "MLS All-Stars"/"Liga MX All-Stars" for MLS). Streams that carry them are
+    named generically ("MLB All-Star Game") and would otherwise fall through to
+    TEAM_ONLY with a nonsense team ("All-Star Game"), never matching the event.
+
+    When an "All-Star" token is present *and* a league hint pins the league,
+    route to the All-Star matcher, which resolves the stream to the single
+    All-Star event in that league — name-agnostic, so the yearly-varying
+    opponent (Liga MX this year, someone else next) needs no hardcoding.
+
+    Ordered before TEAM_VS_TEAM so a hinted "MLS All-Stars vs Liga MX
+    All-Stars" routes here rather than yielding a partial team extraction.
+    A league hint is required, so an unhinted "American All-Stars vs National
+    All-Stars" still falls through to the normal team-vs-team path.
+    """
+    if not ctx.league_hint:
+        return None
+    if not _ALL_STAR_RE.search(ctx.text):
+        return None
+    return ctx.make(StreamCategory.ALL_STAR)
+
+
 def _classify_team_only(ctx: _ClassifyContext) -> ClassifiedStream | None:
     """Step 4.5: Check for single-team stream (TEAM_ONLY).
 
@@ -1722,6 +1753,7 @@ _CLASSIFY_STEPS = (
     _classify_racing_event,
     _classify_tennis_match,
     _classify_teams_custom_regex,
+    _classify_all_star,
     _classify_team_vs_team,
     _classify_team_only,
 )

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -664,6 +664,7 @@ class StreamMatcher:
             StreamCategory.EVENT_CARD,
             StreamCategory.RACING_EVENT,
             StreamCategory.TENNIS_MATCH,
+            StreamCategory.ALL_STAR,
         ):
             return [MatchedStreamResult(
                 stream_name=stream_name,
@@ -734,6 +735,8 @@ class StreamMatcher:
             return self._match_tennis_event(classified, stream_id, target_date)
         if classified.category == StreamCategory.TEAM_ONLY:
             return self._match_team_only(classified, stream_id, target_date, anchor_dt=anchor_dt)
+        if classified.category == StreamCategory.ALL_STAR:
+            return self._match_all_star(classified, stream_id, target_date, anchor_dt=anchor_dt)
         # TEAM_VS_TEAM
         return [
             self._match_team_vs_team(classified, stream_id, target_date, anchor_dt=anchor_dt)
@@ -1021,6 +1024,35 @@ class StreamMatcher:
                 pass
 
         return self._team_matcher.match_team_only(
+            classified=classified,
+            enabled_leagues=list(self._include_leagues),
+            target_date=target_date,
+            group_id=self._group_id,
+            stream_id=stream_id,
+            generation=self._generation,
+            user_tz=self._user_tz,
+            sport_durations=self._sport_durations,
+            prefetched_events=self._prefetched_events,
+            stream_tz=stream_tz,
+            anchor_dt=anchor_dt,
+        )
+
+    def _match_all_star(
+        self,
+        classified: ClassifiedStream,
+        stream_id: int,
+        target_date: date,
+        anchor_dt: "datetime | None" = None,
+    ) -> list[MatchOutcome]:
+        """Match a league All-Star stream to that league's All-Star event."""
+        stream_tz = self._stream_tz
+        if classified.normalized.extracted_tz:
+            try:
+                stream_tz = ZoneInfo(classified.normalized.extracted_tz)
+            except (KeyError, ValueError):
+                pass
+
+        return self._team_matcher.match_all_star(
             classified=classified,
             enabled_leagues=list(self._include_leagues),
             target_date=target_date,

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -58,6 +58,23 @@ logger = logging.getLogger(__name__)
 # no EPG stream (safe no-match) rather than a wrong-occurrence bind.
 ANCHOR_MATCH_TOLERANCE_SECONDS = 90 * 60
 
+# "All-Star(s)" token used to recognise All-Star pseudo-teams in event names.
+_ALL_STAR_TEAM_RE = re.compile(r"all[\s\-]?stars?", re.IGNORECASE)
+
+
+def _is_all_star_event(event: Event) -> bool:
+    """True when both competitors are All-Star squads.
+
+    ESPN names both sides of an All-Star game with an "All-Star(s)" token
+    ("American All-Stars"/"National All-Stars" for MLB, "MLS All-Stars"/"Liga MX
+    All-Stars" for MLS). Requiring the token on *both* sides is a precise,
+    name-agnostic signal that survives the yearly change of opponents and does
+    not misfire on a regular game against an all-star-branded club.
+    """
+    home = event.home_team.name if event.home_team else ""
+    away = event.away_team.name if event.away_team else ""
+    return bool(_ALL_STAR_TEAM_RE.search(home)) and bool(_ALL_STAR_TEAM_RE.search(away))
+
 
 def _sport_hint_matches(sport_hint: str | list[str], event_sport: str) -> bool:
     """Check if a sport hint matches an event's sport.
@@ -558,6 +575,132 @@ class TeamMatcher:
             stream_id=stream_id,
             detail=f"No event found for team '{classified.team1}'",
             parsed_team1=classified.team1,
+        )]
+
+    def match_all_star(
+        self,
+        classified: ClassifiedStream,
+        enabled_leagues: list[str],
+        target_date: date,
+        group_id: int,
+        stream_id: int,
+        generation: int,
+        user_tz: ZoneInfo,
+        sport_durations: dict[str, float] | None = None,
+        prefetched_events: dict[str, list[Event]] | None = None,
+        stream_tz: ZoneInfo | None = None,
+        anchor_dt: "datetime | None" = None,
+    ) -> list[MatchOutcome]:
+        """Match an All-Star stream (ALL_STAR) to the league's All-Star event.
+
+        ESPN serves All-Star games inside the normal league scoreboard as two
+        pseudo-teams whose names both carry an "All-Star(s)" token. We resolve
+        the classified stream to the event in the hinted league(s) whose
+        competitors are both All-Star squads (see ``_is_all_star_event``) —
+        name-agnostic, so the yearly-varying opponent needs no hardcoding.
+        There is one All-Star event per league per season, so this normally
+        returns a single outcome.
+
+        Args:
+            classified: Pre-classified stream (category must be ALL_STAR)
+            enabled_leagues: League codes subscribed for this group
+            target_date: Date to anchor the search window
+            group_id: Event group ID (unused; kept for call-site symmetry)
+            stream_id: Stream ID (for logging/outcomes)
+            generation: Cache generation counter (unused; symmetry)
+            user_tz: User timezone for the date window
+            sport_durations: Sport duration settings (unused; symmetry)
+            prefetched_events: Optional pre-fetched events by league
+            stream_tz: Timezone for interpreting stream dates (unused; symmetry)
+            anchor_dt: EPG path — gate to the live occurrence near this instant
+
+        Returns:
+            List of MatchOutcome — one per matched All-Star event, or a single
+            filtered/failed outcome if nothing matched.
+        """
+        if classified.category != StreamCategory.ALL_STAR:
+            return [MatchOutcome.filtered(
+                FilteredReason.NOT_EVENT,
+                stream_name=classified.normalized.original,
+                stream_id=stream_id,
+            )]
+
+        stream_name = classified.normalized.original
+
+        # An ALL_STAR classification always carries a league hint (enforced by
+        # the classifier); narrow to the hinted leagues this group subscribes to.
+        league_hint = classified.league_hint
+        hint_leagues = (
+            [league_hint] if isinstance(league_hint, str) else list(league_hint or [])
+        )
+        leagues_to_search = [lg for lg in hint_leagues if lg in enabled_leagues]
+        if not leagues_to_search:
+            hint_display = ", ".join(hint_leagues) if hint_leagues else "?"
+            return [MatchOutcome.filtered(
+                FilteredReason.LEAGUE_NOT_INCLUDED,
+                stream_name=stream_name,
+                stream_id=stream_id,
+                detail=f"League '{hint_display}' not in enabled leagues",
+            )]
+
+        # Narrow date window to ±2 days to minimise false positives.
+        window_days = 2
+        all_events: list[tuple[str, Event]] = []
+        if prefetched_events:
+            for league in leagues_to_search:
+                for event in prefetched_events.get(league, []):
+                    event_date = event.start_time.astimezone(user_tz).date()
+                    if abs((event_date - target_date).days) <= window_days:
+                        all_events.append((league, event))
+        else:
+            for league in leagues_to_search:
+                is_tsdb = self._service.get_provider_name(league) == "tsdb"
+                for offset in range(-window_days, window_days + 1):
+                    fetch_date = target_date + timedelta(days=offset)
+                    cache_only = is_tsdb or offset < 0
+                    events = self._service.get_events(league, fetch_date, cache_only=cache_only)
+                    for event in events:
+                        all_events.append((league, event))
+
+        matched_outcomes: list[MatchOutcome] = []
+        seen_event_ids: set[str] = set()
+        for league, event in all_events:
+            if event.id in seen_event_ids:
+                continue
+            if not _is_all_star_event(event):
+                continue
+            # EPG anchored matching (bead t5e): gate to the live occurrence near
+            # the program's broadcast instant.
+            if anchor_dt is not None:
+                anchor_skew = abs((event.start_time - anchor_dt).total_seconds())
+                if anchor_skew > ANCHOR_MATCH_TOLERANCE_SECONDS:
+                    continue
+            seen_event_ids.add(event.id)
+            logger.debug(
+                "[ALL_STAR] Matched: stream_id=%d league=%s event=%s (%s vs %s)",
+                stream_id,
+                league,
+                event.id,
+                event.away_team.name,
+                event.home_team.name,
+            )
+            matched_outcomes.append(MatchOutcome.matched(
+                MatchMethod.FUZZY,
+                event,
+                detected_league=league,
+                confidence=1.0,
+                stream_name=stream_name,
+                stream_id=stream_id,
+            ))
+
+        if matched_outcomes:
+            return matched_outcomes
+
+        return [MatchOutcome.failed(
+            FailedReason.NO_EVENT_FOUND,
+            stream_name=stream_name,
+            stream_id=stream_id,
+            detail=f"No All-Star event in window ±{window_days}d for {target_date}",
         )]
 
     # =========================================================================

--- a/tests/matching/test_all_star.py
+++ b/tests/matching/test_all_star.py
@@ -1,0 +1,159 @@
+"""All-Star game classification and matching (issue #433).
+
+ESPN carries All-Star games inside the normal league scoreboard as two
+pseudo-teams whose names both carry an "All-Star(s)" token (MLB:
+"American All-Stars"/"National All-Stars"; MLS: "MLS All-Stars"/"Liga MX
+All-Stars"). Generically-named streams ("MLB All-Star Game") must route to the
+name-agnostic All-Star matcher rather than falling through to TEAM_ONLY.
+"""
+
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
+
+from teamarr.consumers.matching.classifier import StreamCategory, classify_stream
+from teamarr.consumers.matching.result import MatchMethod
+from teamarr.consumers.matching.team_matcher import _is_all_star_event
+from teamarr.core.types import Event, EventStatus, Team
+from tests.fakes import make_team_matcher
+
+
+def _team(name: str, league: str = "mlb", sport: str = "baseball") -> Team:
+    return Team(
+        id=name,
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation="",
+        league=league,
+        sport=sport,
+    )
+
+
+def _event(
+    home: str,
+    away: str,
+    *,
+    event_id: str = "1",
+    league: str = "mlb",
+    sport: str = "baseball",
+) -> Event:
+    return Event(
+        id=event_id,
+        provider="espn",
+        name=f"{away} at {home}",
+        short_name="",
+        start_time=datetime(2026, 7, 14, 23, 0, tzinfo=UTC),
+        home_team=_team(home, league, sport),
+        away_team=_team(away, league, sport),
+        status=EventStatus(state="scheduled"),
+        league=league,
+        sport=sport,
+    )
+
+
+# --- Classification -------------------------------------------------------
+
+
+def test_generic_mlb_all_star_stream_classifies_all_star():
+    c = classify_stream("MLB All-Star Game")
+    assert c.category is StreamCategory.ALL_STAR
+    assert c.league_hint == "mlb"
+
+
+def test_generic_mls_all_star_stream_classifies_all_star():
+    c = classify_stream("MLS All-Star Game")
+    assert c.category is StreamCategory.ALL_STAR
+    assert c.league_hint == "usa.1"
+
+
+def test_hinted_all_star_matchup_routes_all_star_not_partial_team():
+    # Without the All-Star step this yields a partial team1="All-Stars".
+    c = classify_stream("MLS All-Stars vs Liga MX All-Stars")
+    assert c.category is StreamCategory.ALL_STAR
+
+
+def test_unhinted_all_star_matchup_falls_through_to_team_vs_team():
+    # No league hint → All-Star step abstains; the normal team-vs-team path
+    # still resolves it against the group's configured leagues.
+    c = classify_stream("American All-Stars vs National All-Stars")
+    assert c.category is StreamCategory.TEAM_VS_TEAM
+
+
+def test_regular_game_is_not_all_star():
+    assert classify_stream("Yankees vs Red Sox").category is StreamCategory.TEAM_VS_TEAM
+
+
+# --- Event predicate ------------------------------------------------------
+
+
+def test_is_all_star_event_true_when_both_sides_are_all_stars():
+    assert _is_all_star_event(_event("National All-Stars", "American All-Stars"))
+    assert _is_all_star_event(
+        _event("MLS All-Stars", "Liga MX All-Stars", league="usa.1", sport="soccer")
+    )
+
+
+def test_is_all_star_event_false_for_regular_game():
+    assert not _is_all_star_event(_event("New York Yankees", "Boston Red Sox"))
+
+
+def test_is_all_star_event_false_when_only_one_side_all_star():
+    assert not _is_all_star_event(
+        _event("MLS All-Stars", "LA Galaxy", league="usa.1", sport="soccer")
+    )
+
+
+# --- End-to-end matching --------------------------------------------------
+
+
+def test_match_all_star_resolves_generic_stream_to_event():
+    matcher = make_team_matcher()
+    event = _event("National All-Stars", "American All-Stars", event_id="as")
+    outcomes = matcher.match_all_star(
+        classified=classify_stream("MLB All-Star Game"),
+        enabled_leagues=["mlb"],
+        target_date=date(2026, 7, 14),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+        prefetched_events={"mlb": [event]},
+    )
+    assert len(outcomes) == 1
+    assert outcomes[0].is_matched
+    assert outcomes[0].event.id == "as"
+    assert outcomes[0].match_method is MatchMethod.FUZZY
+
+
+def test_match_all_star_ignores_regular_games_in_pool():
+    matcher = make_team_matcher()
+    regular = _event("New York Yankees", "Boston Red Sox", event_id="reg")
+    allstar = _event("National All-Stars", "American All-Stars", event_id="as")
+    outcomes = matcher.match_all_star(
+        classified=classify_stream("MLB All-Star Game"),
+        enabled_leagues=["mlb"],
+        target_date=date(2026, 7, 14),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+        prefetched_events={"mlb": [regular, allstar]},
+    )
+    assert len(outcomes) == 1
+    assert outcomes[0].event.id == "as"
+
+
+def test_match_all_star_filters_when_league_not_enabled():
+    matcher = make_team_matcher()
+    outcomes = matcher.match_all_star(
+        classified=classify_stream("MLB All-Star Game"),
+        enabled_leagues=["nba"],
+        target_date=date(2026, 7, 14),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+        prefetched_events={},
+    )
+    assert len(outcomes) == 1
+    assert not outcomes[0].is_matched

--- a/tests/matching/test_all_star.py
+++ b/tests/matching/test_all_star.py
@@ -7,14 +7,17 @@ All-Stars"). Generically-named streams ("MLB All-Star Game") must route to the
 name-agnostic All-Star matcher rather than falling through to TEAM_ONLY.
 """
 
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from teamarr.consumers.matching.classifier import StreamCategory, classify_stream
 from teamarr.consumers.matching.result import MatchMethod
 from teamarr.consumers.matching.team_matcher import _is_all_star_event
 from teamarr.core.types import Event, EventStatus, Team
-from tests.fakes import make_team_matcher
+from tests.fakes import make_stream_matcher, make_team_matcher
+
+# ESPN lists the MLB All-Star Game at 23:00 UTC on 2026-07-14.
+_ASG_START = datetime(2026, 7, 14, 23, 0, tzinfo=UTC)
 
 
 def _team(name: str, league: str = "mlb", sport: str = "baseball") -> Team:
@@ -42,7 +45,7 @@ def _event(
         provider="espn",
         name=f"{away} at {home}",
         short_name="",
-        start_time=datetime(2026, 7, 14, 23, 0, tzinfo=UTC),
+        start_time=_ASG_START,
         home_team=_team(home, league, sport),
         away_team=_team(away, league, sport),
         status=EventStatus(state="scheduled"),
@@ -157,3 +160,68 @@ def test_match_all_star_filters_when_league_not_enabled():
     )
     assert len(outcomes) == 1
     assert not outcomes[0].is_matched
+
+
+# --- EPG program-matching path (anchored) ---------------------------------
+#
+# The EPG path (_compute_epg_plan) feeds each program title through the same
+# _route_to_outcomes with anchor_dt = the program's broadcast instant. An
+# All-Star program title ("MLB All-Star Game" on FOX) must reach _match_all_star
+# and bind only to the occurrence airing near that instant.
+
+
+def _kwargs():
+    return dict(
+        enabled_leagues=["mlb"],
+        target_date=date(2026, 7, 14),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+    )
+
+
+def test_match_all_star_binds_within_anchor_window():
+    matcher = make_team_matcher()
+    event = _event("National All-Stars", "American All-Stars", event_id="as")
+    outcomes = matcher.match_all_star(
+        classified=classify_stream("MLB All-Star Game"),
+        prefetched_events={"mlb": [event]},
+        # Program slot 30 min after event start — inside the 90-min window.
+        anchor_dt=_ASG_START + timedelta(minutes=30),
+        **_kwargs(),
+    )
+    assert len(outcomes) == 1
+    assert outcomes[0].is_matched
+    assert outcomes[0].event.id == "as"
+
+
+def test_match_all_star_rejects_outside_anchor_window():
+    matcher = make_team_matcher()
+    event = _event("National All-Stars", "American All-Stars", event_id="as")
+    outcomes = matcher.match_all_star(
+        classified=classify_stream("MLB All-Star Game"),
+        prefetched_events={"mlb": [event]},
+        # Program slot 4 hours off (e.g. a next-day encore) — no live bind.
+        anchor_dt=_ASG_START + timedelta(hours=4),
+        **_kwargs(),
+    )
+    assert len(outcomes) == 1
+    assert not outcomes[0].is_matched
+
+
+def test_epg_route_reaches_all_star_matcher():
+    # Drive the real StreamMatcher routing (what the EPG plan uses) end-to-end.
+    matcher = make_stream_matcher(leagues=["mlb"])
+    matcher._prefetched_events = {
+        "mlb": [_event("National All-Stars", "American All-Stars", event_id="as")]
+    }
+    outcomes = matcher._route_to_outcomes(
+        classify_stream("MLB All-Star Game"),
+        stream_id=1,
+        target_date=date(2026, 7, 14),
+        anchor_dt=_ASG_START,
+    )
+    assert len(outcomes) == 1
+    assert outcomes[0].is_matched
+    assert outcomes[0].event.id == "as"


### PR DESCRIPTION
Closes the matching gap for league All-Star games (MLB, MLS, and any league whose provider tags both sides as All-Star squads).

## Problem

ESPN carries All-Star games inside the normal league scoreboard as two pseudo-teams:
- **MLB**: `American All-Stars` at `National All-Stars`
- **MLS**: `Liga MX All-Stars` at `MLS All-Stars`

The events were already in the event-EPG candidate pool, but realistically-named streams/programs (`MLB All-Star Game`) classified as **TEAM_ONLY** with a nonsense team (`All-Star Game`) and never matched.

## Change

- New `StreamCategory.ALL_STAR`, classified when an **All-Star** token co-occurs with a **league hint** (ordered before TEAM_VS_TEAM so a hinted `MLS All-Stars vs Liga MX All-Stars` routes here instead of yielding a partial team extraction; an *unhinted* `American All-Stars vs National All-Stars` still falls through to the normal team path).
- `TeamMatcher.match_all_star` resolves the stream to the event in the hinted league whose competitors are **both** All-Star squads (`_is_all_star_event`) — name-agnostic, so the yearly-varying opponent needs no hardcoding.
- Wired into both the stream-name path and the **EPG program-matching path** (`_route_to_outcomes`), so it inherits the broadcast-instant **anchor gate** — binds only the live occurrence.
- Gated by Stream Name matching (`name_match_enabled`) like the other name-derived categories.

## Verification against live data

Confirmed on the live Dispatcharr guide for 2026-07-14:
- Real game programs — `MLB All-Star Game`, `2026 MLB All-Star Game`, `MLB All-Star Game 2026` (and the pipe-joined title+sub-title) — all classify `ALL_STAR`/`mlb`.
- The game airs 23:00–23:30Z vs the event`&#39;`s 00:00Z start (within the 90-min anchor window); the pregame `MLB All-Star Red Carpet Show` (18:00Z) and `2026 MLB All-Star Futures Game` (07-12) fall outside it and are rejected in the EPG path.
- Live Teamarr event search confirms the MLB All-Star event is in the pool.

## Known limitation

Relies on the provider naming **both** sides as All-Star squads (true for MLB/MLS). Leagues that name the sides differently (NBA captain-picked teams, NHL divisions) aren`&#39;`t recognized this way. In the stream-name path (no anchor), a stream literally named after the pregame/Futures programme could bind to the game within the ±2-day window — niche; the EPG path`&#39;`s anchor gate is unaffected.

## Tests

14 unit tests in `tests/matching/test_all_star.py`: classification, the `_is_all_star_event` predicate, end-to-end `match_all_star`, and the EPG routing + anchor window.

## Gates
- `ruff check` clean
- `pytest` 1786 passed
- `npm run build` clean

Bead: `teamarrv2-fv78`