### PR TITLE
chore: remove legacy 1.x upgrade support and refresh README (#446)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - 1.4.9-archive
     tags:
       - 'v*.*.*'
     paths-ignore:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/images/teamarr_electric_blue.png" alt="Teamarr — Sports Channel Management for Dispatcharr" width="420">
 </p>
 
-<p align="center"><strong>Dynamic EPG Generator for Sports Channels</strong></p>
+<p align="center"><strong>Sports Channel Management for <a href="https://github.com/Dispatcharr/Dispatcharr">Dispatcharr</a></strong></p>
 
 ## Quick Start
 
@@ -24,27 +24,12 @@ services:
 docker compose up -d
 ```
 
-## Upgrading from Legacy (1.x)
-
-**There is no automatic migration path from legacy 1.x releases** due to significant architectural changes.
-
-If you're upgrading from 1.x, you have two options:
-
-1. **Start Fresh** - Archive your old database and begin with a clean setup. The app will detect your legacy database and guide you through the process, including downloading a backup of your data.
-
-2. **Continue Using 1.x** - If you're not ready to migrate, use the archived image:
-   ```yaml
-   image: ghcr.io/pharaoh-labs/teamarr:1.4.9-archive
-   ```
-   Note: 1.x will continue to function but will not receive future updates.
-
 ## Image Tags
 
 | Tag | Description |
 |-----|-------------|
 | `latest` | Stable release |
 | `dev` | Development builds |
-| `1.4.9-archive` | Final 1.x release (no longer maintained) |
 
 ## Documentation
 

--- a/docs/reference/architecture/api-layer.md
+++ b/docs/reference/architecture/api-layer.md
@@ -45,10 +45,6 @@ The lifespan handler in `app.py` orchestrates startup in phases:
 5. **STARTING_SCHEDULER** — Background EPG cron scheduler
 6. **READY** — Fully operational
 
-V1 (Teamarr 1.x) databases are no longer supported. If a V1 database is detected on
-startup the application refuses to start with a clear error pointing the user to
-move or delete the file before retrying.
-
 ## Generation Status
 
 `generation_status.py` provides a global thread-safe state machine for EPG generation progress:

--- a/teamarr/database/MIGRATIONS.md
+++ b/teamarr/database/MIGRATIONS.md
@@ -6,7 +6,7 @@ How database schema changes work in Teamarr v2.
 
 ```
 Startup (init_db):
-  1. Verify integrity (corrupt files raise, V1 databases raise — no longer supported)
+  1. Verify integrity (corrupt files raise)
   2. Structural pre-migrations (column renames, table rebuilds) — migrations/pre.py
   3. Schema reconciliation ← compares real DB against schema.sql
   4. conn.executescript(schema.sql) ← creates missing tables, seeds data

--- a/teamarr/database/connection.py
+++ b/teamarr/database/connection.py
@@ -102,8 +102,8 @@ def init_db(db_path: Path | str | None = None) -> None:
 
     try:
         with get_db(db_path) as conn:
-            # First, verify this is a valid V2-compatible database by checking integrity
-            # and querying a core table. This catches both corruption AND V1 databases.
+            # Probe the database before touching it so corrupt files fail
+            # with a clear error instead of mid-migration.
             _verify_database_integrity(conn, path)
 
             # Structural pre-migrations (renames, table rebuilds) — these
@@ -146,55 +146,23 @@ def init_db(db_path: Path | str | None = None) -> None:
     except sqlite3.DatabaseError as e:
         if "file is not a database" in str(e):
             logger.error(
-                f"Database file '{path}' exists but is not compatible with Teamarr V2. "
-                "This usually means you're trying to use a V1 database. "
-                "V2 requires a fresh database - please either:\n"
-                "  1. Use a different data directory for V2, or\n"
-                "  2. Backup and delete the existing database file"
+                f"Database file '{path}' exists but is not a valid SQLite database. "
+                "Move or delete the file and restart Teamarr to initialize a fresh database."
             )
             raise RuntimeError(
-                f"Incompatible database file at '{path}'. "
-                "V2 is not compatible with V1 databases. "
-                "Please use a fresh data directory or delete the existing database."
+                f"Invalid database file at '{path}'. "
+                "Move or delete the file and restart Teamarr."
             ) from e
         raise
 
 
 def _verify_database_integrity(conn: sqlite3.Connection, path: Path) -> None:
-    """Verify database is valid and compatible with V2.
-
-    Catches:
-    1. Corrupt database files ("file is not a database")
-    2. V1 databases — V1 is no longer supported. The presence of V1-specific
-       tables raises immediately with instructions to delete or relocate.
+    """Probe the database so corrupt files raise a clear error up front.
 
     Raises:
-        RuntimeError: If database is a V1 database
         sqlite3.DatabaseError: If database file is corrupt
     """
-    try:
-        cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' LIMIT 100")
-        existing_tables = {row["name"] for row in cursor.fetchall()}
-    except sqlite3.DatabaseError:
-        raise
-
-    v1_indicators = {
-        "schedule_cache",
-        "league_config",
-        "h2h_cache",
-        "error_log",
-        "soccer_cache_meta",
-        "team_stats_cache",
-    }
-    v1_tables_found = v1_indicators & existing_tables
-
-    if v1_tables_found:
-        raise RuntimeError(
-            f"Database file '{path}' is a V1 (Teamarr 1.x) database "
-            f"(found V1-specific tables: {sorted(v1_tables_found)}). "
-            "V1 is no longer supported. Move or delete the database file and "
-            "restart Teamarr to initialize a fresh V2 database."
-        )
+    conn.execute("SELECT name FROM sqlite_master WHERE type='table' LIMIT 1")
 
 
 def _seed_tsdb_cache_if_needed(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
Closes nothing directly — #446 stays open until release per workflow (`status: on-dev`).

## What
- Removes V1 (Teamarr 1.x) database detection from `init_db` — the integrity probe now only catches corrupt SQLite files, with a simplified error message
- Drops the `1.4.9-archive` branch from the docker-publish workflow triggers
- README: removes the "Upgrading from Legacy (1.x)" section and the `1.4.9-archive` image-tag row; tagline updated to "Sports Channel Management for Dispatcharr"
- Docs updated to match (`api-layer.md`, `MIGRATIONS.md`)

## Gates
- `ruff check` clean
- `pytest`: 1857 passed
- `npm run build`: clean

Bead: `teamarrv2-096t`