### PR TITLE
feat: group-name pattern binding — schema + resolver + stale detection (#450)

### DIFF
--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -62,7 +62,11 @@ class StreamFetcher:
             m3u_manager = self._dispatcharr_client.m3u
 
             # Fetch streams filtered by M3U group if configured
-            if group.m3u_group_id:
+            if getattr(group, "m3u_group_name_pattern_enabled", False) and getattr(
+                group, "m3u_group_name_pattern", None
+            ):
+                streams = self._fetch_pattern_streams(group, m3u_manager)
+            elif group.m3u_group_id:
                 streams = m3u_manager.list_streams(group_id=group.m3u_group_id)
             else:
                 # Fetch all streams if no group filter
@@ -91,6 +95,48 @@ class StreamFetcher:
         except Exception as e:
             logger.error("[EVENT_EPG] Failed to fetch streams: %s", e)
             return []
+
+    def _fetch_pattern_streams(self, group: EventEPGGroup, m3u_manager: Any) -> list:
+        """Fetch streams via group-name pattern binding (#450).
+
+        Re-resolves the group's name pattern against live Dispatcharr M3U
+        groups and unions the streams of every match, scoped to the source's
+        M3U account. Provider renames spawn a NEW group id, so re-resolving by
+        name at fetch time re-binds automatically; during the provider's
+        transition window old+new groups both resolve and the stale-stream
+        filter drops the old group's streams.
+        """
+        from teamarr.services.group_pattern import resolve_group_name_pattern
+
+        live_groups = m3u_manager.list_groups()
+        matched = resolve_group_name_pattern(live_groups, group.m3u_group_name_pattern)
+        if not matched:
+            logger.warning(
+                "[EVENT_EPG] Group '%s': pattern %r matched no live M3U groups "
+                "— source is effectively stale",
+                group.name,
+                group.m3u_group_name_pattern,
+            )
+            return []
+
+        logger.info(
+            "[EVENT_EPG] Group '%s': pattern %r resolved to %d live group(s): %s",
+            group.name,
+            group.m3u_group_name_pattern,
+            len(matched),
+            ", ".join(g.name for g in matched[:5]) + ("…" if len(matched) > 5 else ""),
+        )
+
+        streams: list = []
+        seen_ids: set[int] = set()
+        for g in matched:
+            for s in m3u_manager.list_streams(
+                group_name=g.name, account_id=group.m3u_account_id
+            ):
+                if s.id not in seen_ids:
+                    seen_ids.add(s.id)
+                    streams.append(s)
+        return streams
 
     def _fetch_channel_source_streams(self) -> list[dict]:
         """Build EPG-match candidates from streams curated onto Dispatcharr channels.

--- a/teamarr/consumers/reconciliation.py
+++ b/teamarr/consumers/reconciliation.py
@@ -831,14 +831,27 @@ def detect_stale_groups(db_factory: Any) -> list[dict]:
     with db_factory() as conn:
         rows = conn.execute(
             """
-            SELECT id, name, m3u_group_id, m3u_group_name
+            SELECT id, name, m3u_group_id, m3u_group_name,
+                   m3u_group_name_pattern, m3u_group_name_pattern_enabled
             FROM event_epg_groups
             WHERE enabled = 1
-              AND m3u_group_id IS NOT NULL
+              AND (m3u_group_id IS NOT NULL
+                   OR COALESCE(m3u_group_name_pattern_enabled, 0) = 1)
               AND COALESCE(is_channel_source, 0) = 0
             """
         ).fetchall()
         for row in rows:
+            # Pattern-bound sources (#450) are judged by pattern resolution,
+            # not by the pinned id: present iff the pattern matches at least
+            # one live M3U-provided group.
+            if row["m3u_group_name_pattern_enabled"] and row["m3u_group_name_pattern"]:
+                from teamarr.services.group_pattern import resolve_group_name_pattern
+
+                if resolve_group_name_pattern(live_groups, row["m3u_group_name_pattern"]):
+                    mark_group_source_seen(conn, row["id"])
+                else:
+                    mark_group_source_missing(conn, row["id"])
+                continue
             if row["m3u_group_id"] in existing_ids:
                 mark_group_source_seen(conn, row["id"])
                 continue

--- a/teamarr/database/groups.py
+++ b/teamarr/database/groups.py
@@ -84,6 +84,10 @@ class EventEPGGroup:
     m3u_group_name: str | None = None
     m3u_account_id: int | None = None
     m3u_account_name: str | None = None
+    # Group-name pattern binding (#450): regex over live M3U group names,
+    # re-resolved at stream-fetch time for provider-rename resilience.
+    m3u_group_name_pattern: str | None = None
+    m3u_group_name_pattern_enabled: bool = False
     # Processing stats
     last_refresh: datetime | None = None
     stream_count: int = 0
@@ -194,6 +198,14 @@ def _row_to_group(row) -> EventEPGGroup:
         m3u_group_name=row["m3u_group_name"],
         m3u_account_id=row["m3u_account_id"],
         m3u_account_name=row["m3u_account_name"],
+        m3u_group_name_pattern=(
+            row["m3u_group_name_pattern"] if "m3u_group_name_pattern" in row.keys() else None
+        ),
+        m3u_group_name_pattern_enabled=(
+            bool(row["m3u_group_name_pattern_enabled"])
+            if "m3u_group_name_pattern_enabled" in row.keys()
+            else False
+        ),
         last_refresh=last_refresh,
         stream_count=row["stream_count"] or 0,
         matched_count=row["matched_count"] or 0,
@@ -498,6 +510,8 @@ def create_group(
     m3u_group_name: str | None = None,
     m3u_account_id: int | None = None,
     m3u_account_name: str | None = None,
+    m3u_group_name_pattern: str | None = None,
+    m3u_group_name_pattern_enabled: bool = False,
     # Stream filtering
     stream_include_regex: str | None = None,
     stream_include_regex_enabled: bool = False,
@@ -574,6 +588,7 @@ def create_group(
             stream_timezone, duplicate_event_handling,
             channel_assignment_mode, sort_order, total_stream_count,
             m3u_group_id, m3u_group_name, m3u_account_id, m3u_account_name,
+            m3u_group_name_pattern, m3u_group_name_pattern_enabled,
             stream_include_regex, stream_include_regex_enabled,
             stream_exclude_regex, stream_exclude_regex_enabled,
             custom_regex_teams, custom_regex_teams_enabled,
@@ -589,7 +604,7 @@ def create_group(
             include_teams, exclude_teams, team_filter_mode,
             channel_sort_order, overlap_handling, enabled,
             subscription_leagues, subscription_soccer_mode, subscription_soccer_followed_teams
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",  # noqa: E501
         (
             name,
             display_name,
@@ -607,6 +622,8 @@ def create_group(
             m3u_group_name,
             m3u_account_id,
             m3u_account_name,
+            m3u_group_name_pattern,
+            int(m3u_group_name_pattern_enabled),
             stream_include_regex,
             int(stream_include_regex_enabled),
             stream_exclude_regex,
@@ -673,6 +690,8 @@ def update_group(
     m3u_group_name: str | None = None,
     m3u_account_id: int | None = None,
     m3u_account_name: str | None = None,
+    m3u_group_name_pattern: str | None = None,
+    m3u_group_name_pattern_enabled: bool | None = None,
     # Stream filtering
     stream_include_regex: str | None = None,
     stream_include_regex_enabled: bool | None = None,
@@ -716,6 +735,7 @@ def update_group(
     clear_m3u_group_name: bool = False,
     clear_m3u_account_id: bool = False,
     clear_m3u_account_name: bool = False,
+    clear_m3u_group_name_pattern: bool = False,
     clear_stream_include_regex: bool = False,
     clear_stream_exclude_regex: bool = False,
     clear_custom_regex_teams: bool = False,
@@ -778,6 +798,10 @@ def update_group(
     builder.set_("m3u_group_name", m3u_group_name, clear=clear_m3u_group_name)
     builder.set_("m3u_account_id", m3u_account_id, clear=clear_m3u_account_id)
     builder.set_("m3u_account_name", m3u_account_name, clear=clear_m3u_account_name)
+    builder.set_(
+        "m3u_group_name_pattern", m3u_group_name_pattern, clear=clear_m3u_group_name_pattern
+    )
+    builder.set_("m3u_group_name_pattern_enabled", m3u_group_name_pattern_enabled, encoder=int)
 
     # Stream filtering
     builder.set_("stream_include_regex", stream_include_regex, clear=clear_stream_include_regex)

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -527,6 +527,14 @@ CREATE TABLE IF NOT EXISTS event_epg_groups (
     m3u_account_id INTEGER,                  -- Dispatcharr M3U account ID
     m3u_account_name TEXT,                   -- M3U account name for display
 
+    -- Group-name pattern binding (#450): when enabled, the source is bound to a
+    -- regex over live M3U group NAMES instead of the pinned m3u_group_id. The
+    -- pattern re-resolves to live group ids at stream-fetch time, so provider
+    -- renames (which always spawn a NEW Dispatcharr group id) re-bind
+    -- automatically. Scope: M3U-provided groups only.
+    m3u_group_name_pattern TEXT,
+    m3u_group_name_pattern_enabled BOOLEAN DEFAULT 0,
+
     -- Stale-source detection (lylt): a group is "stale" when its M3U source
     -- channel-group no longer exists in Dispatcharr (deleted/renamed). Distinct
     -- from off-season (group exists, zero current streams). Updated during the

--- a/teamarr/services/group_pattern.py
+++ b/teamarr/services/group_pattern.py
@@ -1,0 +1,62 @@
+"""Group-name pattern resolution for rename-resilient source binding (#450).
+
+IPTV providers churn M3U group names ("EPL (MW1)" -> "EPL (MW2)"); Dispatcharr
+matches M3U groups by exact name, so a provider rename always spawns a NEW
+Dispatcharr group id and a source pinned to the old id goes stale. A source
+with pattern binding enabled is instead bound to a regex over live M3U group
+NAMES, re-resolved on every stream fetch — renames re-bind automatically.
+
+Scope: M3U-provided groups only (groups carrying at least one M3U-account
+relationship). Teamarr-created output/dynamic channel groups and manually
+created channel groups are never pattern-resolvable.
+
+Account scoping happens at STREAM fetch, not here: Dispatcharr group names are
+global (one ChannelGroup row shared by every account whose playlist has that
+group-title), so the resolver returns name matches and the caller passes the
+source's m3u_account_id to list_streams. During a provider's transition week
+the old (stale) and new groups coexist (~stale_stream_days, default 7); both
+resolve, and the existing stale-stream filter drops the old group's streams.
+"""
+
+import logging
+import re
+
+from teamarr.dispatcharr.types import DispatcharrChannelGroup
+
+logger = logging.getLogger(__name__)
+
+
+def compile_group_pattern(pattern: str | None) -> re.Pattern | None:
+    """Compile a group-name pattern, or None if empty/invalid.
+
+    Case-insensitive substring semantics (``re.search``), matching the
+    behavior of the other user-facing regex fields (stream include/exclude).
+    """
+    if not pattern or not pattern.strip():
+        return None
+    try:
+        return re.compile(pattern, re.IGNORECASE)
+    except re.error as e:
+        logger.warning("[GROUP_PATTERN] Invalid pattern %r: %s", pattern, e)
+        return None
+
+
+def resolve_group_name_pattern(
+    live_groups: list[DispatcharrChannelGroup],
+    pattern: str | None,
+) -> list[DispatcharrChannelGroup]:
+    """Resolve a group-name pattern against live Dispatcharr groups.
+
+    Args:
+        live_groups: Current groups from ``m3u.list_groups()``
+        pattern: Regex to match against group names (case-insensitive search)
+
+    Returns:
+        Matching M3U-provided groups (empty on empty/invalid pattern).
+    """
+    rx = compile_group_pattern(pattern)
+    if rx is None:
+        return []
+    # getattr with an EMPTY default fails closed: a group object without
+    # account relations (or without the field at all) is never pattern-bound.
+    return [g for g in live_groups if getattr(g, "m3u_accounts", ()) and rx.search(g.name)]

--- a/tests/test_group_pattern.py
+++ b/tests/test_group_pattern.py
@@ -1,0 +1,259 @@
+"""Group-name pattern binding (#450, epic bpqb).
+
+Covers the resolver (regex over live M3U-provided group names), the
+stream-fetch integration (union across resolved groups, account scoping),
+stale detection for pattern-bound sources, and the CRUD roundtrip.
+"""
+
+import contextlib
+import sqlite3
+from types import SimpleNamespace
+
+from teamarr.consumers.event_group_processor.stream_fetcher import StreamFetcher
+from teamarr.consumers.reconciliation import detect_stale_groups
+from teamarr.database.groups import EventEPGGroup, create_group, get_group, update_group
+from teamarr.services.group_pattern import (
+    compile_group_pattern,
+    resolve_group_name_pattern,
+)
+from tests.helpers import SCHEMA_PATH
+
+
+def _grp(gid, name, m3u=True):
+    return SimpleNamespace(id=gid, name=name, m3u_accounts=(1,) if m3u else ())
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+class TestResolver:
+    LIVE = [
+        _grp(1, "EPL (MW1)"),
+        _grp(2, "EPL (MW2)"),
+        _grp(3, "USA | MLB"),
+        _grp(4, "epl classics", m3u=False),  # not M3U-provided
+    ]
+
+    def test_matches_by_regex(self):
+        got = resolve_group_name_pattern(self.LIVE, r"EPL \(MW\d+\)")
+        assert [g.id for g in got] == [1, 2]
+
+    def test_case_insensitive_search(self):
+        got = resolve_group_name_pattern(self.LIVE, r"usa \| mlb")
+        assert [g.id for g in got] == [3]
+
+    def test_non_m3u_groups_excluded(self):
+        # "epl classics" matches the regex but has no M3U account relation.
+        got = resolve_group_name_pattern(self.LIVE, r"epl")
+        assert [g.id for g in got] == [1, 2]
+
+    def test_missing_m3u_accounts_field_fails_closed(self):
+        bare = [SimpleNamespace(id=9, name="EPL (MW3)")]
+        assert resolve_group_name_pattern(bare, r"EPL") == []
+
+    def test_invalid_pattern_returns_empty(self):
+        assert resolve_group_name_pattern(self.LIVE, r"EPL (") == []
+        assert compile_group_pattern(r"EPL (") is None
+
+    def test_empty_pattern_returns_empty(self):
+        assert resolve_group_name_pattern(self.LIVE, None) == []
+        assert resolve_group_name_pattern(self.LIVE, "   ") == []
+
+
+# ---------------------------------------------------------------------------
+# Stream-fetch integration
+# ---------------------------------------------------------------------------
+
+
+def _stream(sid, name, account=7):
+    return SimpleNamespace(
+        id=sid,
+        name=name,
+        tvg_id=None,
+        tvg_name=None,
+        channel_group=None,
+        channel_group_id=None,
+        m3u_account_id=account,
+        is_stale=False,
+    )
+
+
+class _FakeM3U:
+    def __init__(self, groups, streams_by_group):
+        self._groups = groups
+        self._streams_by_group = streams_by_group
+        self.stream_calls: list[tuple] = []
+
+    def list_groups(self):
+        return self._groups
+
+    def list_accounts(self, include_custom=False):
+        return [SimpleNamespace(id=7, name="Acct")]
+
+    def list_streams(self, group_name=None, group_id=None, account_id=None, limit=None):
+        self.stream_calls.append((group_name, account_id))
+        return self._streams_by_group.get(group_name, [])
+
+
+class _Fetcher(StreamFetcher):
+    def __init__(self, m3u):
+        self._dispatcharr_client = SimpleNamespace(m3u=m3u)
+        self._db_factory = None
+        self._service = None
+
+
+def _pattern_group(pattern, account_id=7):
+    return EventEPGGroup(
+        id=1,
+        name="EPL",
+        m3u_group_id=999,  # dead pinned id — pattern must win
+        m3u_account_id=account_id,
+        m3u_group_name_pattern=pattern,
+        m3u_group_name_pattern_enabled=True,
+    )
+
+
+class TestPatternFetch:
+    def test_unions_streams_across_resolved_groups(self):
+        m3u = _FakeM3U(
+            groups=[_grp(1, "EPL (MW1)"), _grp(2, "EPL (MW2)"), _grp(3, "USA | MLB")],
+            streams_by_group={
+                "EPL (MW1)": [_stream(11, "Arsenal vs Spurs")],
+                "EPL (MW2)": [_stream(12, "Chelsea vs Wolves"), _stream(11, "Arsenal vs Spurs")],
+            },
+        )
+        fetcher = _Fetcher(m3u)
+        streams = fetcher._fetch_streams(_pattern_group(r"EPL \(MW\d+\)"))
+        assert sorted(s["id"] for s in streams) == [11, 12]  # deduped union
+
+    def test_account_id_scopes_stream_fetch(self):
+        m3u = _FakeM3U(
+            groups=[_grp(1, "EPL (MW1)")],
+            streams_by_group={"EPL (MW1)": [_stream(11, "Arsenal vs Spurs")]},
+        )
+        fetcher = _Fetcher(m3u)
+        fetcher._fetch_streams(_pattern_group(r"EPL", account_id=7))
+        assert m3u.stream_calls == [("EPL (MW1)", 7)]
+
+    def test_no_match_returns_empty_not_all_streams(self):
+        m3u = _FakeM3U(groups=[_grp(3, "USA | MLB")], streams_by_group={})
+        fetcher = _Fetcher(m3u)
+        assert fetcher._fetch_streams(_pattern_group(r"EPL")) == []
+        assert m3u.stream_calls == []  # never fell through to unfiltered fetch
+
+    def test_disabled_pattern_uses_pinned_id(self):
+        m3u = _FakeM3U(groups=[_grp(1, "EPL (MW1)")], streams_by_group={})
+        calls = []
+        m3u.list_streams = lambda **kw: calls.append(kw) or []
+        fetcher = _Fetcher(m3u)
+        group = _pattern_group(r"EPL")
+        group.m3u_group_name_pattern_enabled = False
+        fetcher._fetch_streams(group)
+        assert calls == [{"group_id": 999}]
+
+
+# ---------------------------------------------------------------------------
+# Stale detection (pattern-bound sources)
+# ---------------------------------------------------------------------------
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_PATH.read_text())
+    return conn
+
+
+def _factory(conn):
+    @contextlib.contextmanager
+    def factory():
+        yield conn
+        conn.commit()
+
+    return factory
+
+
+def _add_pattern_group(conn, name, pattern, m3u_group_id=999):
+    conn.execute(
+        "INSERT INTO event_epg_groups "
+        "(name, leagues, m3u_group_id, m3u_group_name_pattern, "
+        " m3u_group_name_pattern_enabled, enabled) "
+        "VALUES (?, '[]', ?, ?, 1, 1)",
+        (name, m3u_group_id, pattern),
+    )
+    conn.commit()
+
+
+def _patch_dispatcharr(monkeypatch, groups):
+    import teamarr.consumers.reconciliation as reconciliation
+
+    fake = SimpleNamespace(m3u=SimpleNamespace(list_groups=lambda: groups))
+    monkeypatch.setattr(reconciliation, "get_dispatcharr_connection", lambda db_factory=None: fake)
+
+
+class TestPatternStaleDetection:
+    def test_pattern_match_marks_seen_despite_dead_pinned_id(self, monkeypatch):
+        conn = _db()
+        _add_pattern_group(conn, "EPL", r"EPL \(MW\d+\)", m3u_group_id=999)
+        _patch_dispatcharr(monkeypatch, [_grp(2, "EPL (MW2)")])  # id 999 long gone
+
+        assert detect_stale_groups(_factory(conn)) == []
+        row = conn.execute(
+            "SELECT source_missing, source_last_seen FROM event_epg_groups WHERE name='EPL'"
+        ).fetchone()
+        assert row["source_missing"] == 0
+        assert row["source_last_seen"] is not None
+
+    def test_pattern_without_match_marks_missing(self, monkeypatch):
+        conn = _db()
+        _add_pattern_group(conn, "EPL", r"EPL \(MW\d+\)")
+        _patch_dispatcharr(monkeypatch, [_grp(3, "USA | MLB")])
+
+        stale = detect_stale_groups(_factory(conn))
+        assert {g["name"] for g in stale} == {"EPL"}
+
+    def test_pattern_group_without_pinned_id_is_evaluated(self, monkeypatch):
+        conn = _db()
+        _add_pattern_group(conn, "EPL", r"EPL", m3u_group_id=None)
+        _patch_dispatcharr(monkeypatch, [_grp(2, "EPL (MW2)")])
+
+        assert detect_stale_groups(_factory(conn)) == []
+
+
+# ---------------------------------------------------------------------------
+# CRUD roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestCrudRoundtrip:
+    def test_create_and_read_pattern_fields(self):
+        conn = _db()
+        gid = create_group(
+            conn,
+            name="EPL",
+            leagues=["eng.1"],
+            m3u_group_name_pattern=r"EPL \(MW\d+\)",
+            m3u_group_name_pattern_enabled=True,
+        )
+        group = get_group(conn, gid)
+        assert group.m3u_group_name_pattern == r"EPL \(MW\d+\)"
+        assert group.m3u_group_name_pattern_enabled is True
+
+    def test_update_and_clear_pattern(self):
+        conn = _db()
+        gid = create_group(conn, name="EPL", leagues=["eng.1"])
+        update_group(
+            conn, gid, m3u_group_name_pattern=r"EPL", m3u_group_name_pattern_enabled=True
+        )
+        group = get_group(conn, gid)
+        assert group.m3u_group_name_pattern == "EPL"
+        assert group.m3u_group_name_pattern_enabled is True
+
+        update_group(
+            conn, gid, clear_m3u_group_name_pattern=True, m3u_group_name_pattern_enabled=False
+        )
+        group = get_group(conn, gid)
+        assert group.m3u_group_name_pattern is None
+        assert group.m3u_group_name_pattern_enabled is False


### PR DESCRIPTION
First implementation slice of #450 (epic `teamarrv2-bpqb`, beads .2 + .3).

## What
- **Schema**: `m3u_group_name_pattern` (TEXT) + `m3u_group_name_pattern_enabled` (BOOLEAN DEFAULT 0) on `event_epg_groups` — reconciliation auto-adds, no migration block.
- **Resolver** (`services/group_pattern.py`): case-insensitive regex search over live Dispatcharr group names, restricted to **M3U-provided groups** (must carry an M3U-account relation; fails closed when the field is absent). Invalid/empty pattern → no matches.
- **Fetch integration**: pattern-enabled sources re-resolve at every stream fetch and union streams across all resolved groups, scoped to the source's `m3u_account_id` (group names are global in Dispatcharr — account scoping happens at the stream query). Zero matches → empty fetch, never a fall-through to all streams.
- **Stale detection**: `detect_stale_groups` judges pattern-bound sources by resolution (≥1 live match = present) instead of the pinned id, which stays as display metadata.

## Why this shape (from the bpqb.1 investigation)
Dispatcharr matches M3U groups by exact name — a provider rename always spawns a **new group id**, and old+new coexist for ~`stale_stream_days` (7). Re-resolving by name at fetch time makes renames self-healing; during the transition week both groups resolve and the existing stale-stream filter drops the old group's streams.

## Not in this PR (next beads)
API fields + preview endpoint (bpqb.6), UI with live 'matches N groups' preview + suggestion flywheel (bpqb.4/.5/.7), cleanup-safety audit (bpqb.8), user docs (ship with the UI).

Gates: ruff clean · **1885 passed** (+15) · frontend builds.
Bead: `teamarrv2-bpqb.2`/`.3`