### PR TITLE
feat: pattern fields in groups API + preview endpoint (#450)

### DIFF
--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -98,6 +98,9 @@ class GroupCreate(BaseModel):
     m3u_group_name: str | None = None
     m3u_account_id: int | None = None
     m3u_account_name: str | None = None
+    # Group-name pattern binding (#450)
+    m3u_group_name_pattern: str | None = None
+    m3u_group_name_pattern_enabled: bool = False
     # Stream filtering
     stream_include_regex: str | None = None
     stream_include_regex_enabled: bool = False
@@ -155,6 +158,9 @@ class GroupUpdate(BaseModel):
     m3u_group_name: str | None = None
     m3u_account_id: int | None = None
     m3u_account_name: str | None = None
+    # Group-name pattern binding (#450)
+    m3u_group_name_pattern: str | None = None
+    m3u_group_name_pattern_enabled: bool | None = None
     # Stream filtering
     stream_include_regex: str | None = None
     stream_include_regex_enabled: bool | None = None
@@ -201,6 +207,7 @@ class GroupUpdate(BaseModel):
     clear_m3u_group_name: bool = False
     clear_m3u_account_id: bool = False
     clear_m3u_account_name: bool = False
+    clear_m3u_group_name_pattern: bool = False
     clear_stream_include_regex: bool = False
     clear_stream_exclude_regex: bool = False
     clear_custom_regex_teams: bool = False
@@ -240,6 +247,9 @@ class GroupResponse(BaseModel):
     m3u_group_name: str | None = None
     m3u_account_id: int | None = None
     m3u_account_name: str | None = None
+    # Group-name pattern binding (#450)
+    m3u_group_name_pattern: str | None = None
+    m3u_group_name_pattern_enabled: bool = False
     # Stream filtering
     stream_include_regex: str | None = None
     stream_include_regex_enabled: bool = False
@@ -614,6 +624,8 @@ def list_groups(
                 m3u_group_name=g.m3u_group_name,
                 m3u_account_id=g.m3u_account_id,
                 m3u_account_name=get_account_name(g),
+                m3u_group_name_pattern=g.m3u_group_name_pattern,
+                m3u_group_name_pattern_enabled=g.m3u_group_name_pattern_enabled,
                 stream_include_regex=g.stream_include_regex,
                 stream_include_regex_enabled=g.stream_include_regex_enabled,
                 stream_exclude_regex=g.stream_exclude_regex,
@@ -726,6 +738,8 @@ def create_group(request: GroupCreate):
             m3u_group_name=request.m3u_group_name,
             m3u_account_id=request.m3u_account_id,
             m3u_account_name=request.m3u_account_name,
+            m3u_group_name_pattern=request.m3u_group_name_pattern,
+            m3u_group_name_pattern_enabled=request.m3u_group_name_pattern_enabled,
             stream_include_regex=request.stream_include_regex,
             stream_include_regex_enabled=request.stream_include_regex_enabled,
             stream_exclude_regex=request.stream_exclude_regex,
@@ -797,6 +811,8 @@ def create_group(request: GroupCreate):
         m3u_group_name=group.m3u_group_name,
         m3u_account_id=group.m3u_account_id,
         m3u_account_name=group.m3u_account_name,
+        m3u_group_name_pattern=group.m3u_group_name_pattern,
+        m3u_group_name_pattern_enabled=group.m3u_group_name_pattern_enabled,
         stream_include_regex=group.stream_include_regex,
         stream_include_regex_enabled=group.stream_include_regex_enabled,
         stream_exclude_regex=group.stream_exclude_regex,
@@ -1182,6 +1198,8 @@ def get_group_by_id(group_id: int):
         m3u_group_name=group.m3u_group_name,
         m3u_account_id=group.m3u_account_id,
         m3u_account_name=m3u_account_name,
+        m3u_group_name_pattern=group.m3u_group_name_pattern,
+        m3u_group_name_pattern_enabled=group.m3u_group_name_pattern_enabled,
         stream_include_regex=group.stream_include_regex,
         stream_include_regex_enabled=group.stream_include_regex_enabled,
         stream_exclude_regex=group.stream_exclude_regex,
@@ -1303,6 +1321,8 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
                 m3u_group_name=request.m3u_group_name,
                 m3u_account_id=request.m3u_account_id,
                 m3u_account_name=request.m3u_account_name,
+                m3u_group_name_pattern=request.m3u_group_name_pattern,
+                m3u_group_name_pattern_enabled=request.m3u_group_name_pattern_enabled,
                 stream_include_regex=request.stream_include_regex,
                 stream_include_regex_enabled=request.stream_include_regex_enabled,
                 stream_exclude_regex=request.stream_exclude_regex,
@@ -1344,6 +1364,7 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
                 clear_m3u_group_name=request.clear_m3u_group_name,
                 clear_m3u_account_id=request.clear_m3u_account_id,
                 clear_m3u_account_name=request.clear_m3u_account_name,
+                clear_m3u_group_name_pattern=request.clear_m3u_group_name_pattern,
                 clear_stream_include_regex=request.clear_stream_include_regex,
                 clear_stream_exclude_regex=request.clear_stream_exclude_regex,
                 clear_custom_regex_teams=request.clear_custom_regex_teams,
@@ -1409,6 +1430,8 @@ def update_group_by_id(group_id: int, request: GroupUpdate):
         m3u_group_name=group.m3u_group_name,
         m3u_account_id=group.m3u_account_id,
         m3u_account_name=group.m3u_account_name,
+        m3u_group_name_pattern=group.m3u_group_name_pattern,
+        m3u_group_name_pattern_enabled=group.m3u_group_name_pattern_enabled,
         stream_include_regex=group.stream_include_regex,
         stream_include_regex_enabled=group.stream_include_regex_enabled,
         stream_exclude_regex=group.stream_exclude_regex,
@@ -1701,6 +1724,51 @@ def list_dispatcharr_channel_groups() -> dict:
     return {
         "groups": [{"id": g.id, "name": g.name} for g in groups],
         "total": len(groups),
+    }
+
+
+class GroupPatternPreviewRequest(BaseModel):
+    """Preview which live M3U groups a name pattern resolves to (#450)."""
+
+    pattern: str
+
+
+@router.post("/dispatcharr/group-pattern-preview")
+def preview_group_name_pattern(request: GroupPatternPreviewRequest) -> dict:
+    """Resolve a group-name pattern against live Dispatcharr M3U groups.
+
+    Powers the live "matches N groups" preview in the source editor. Only
+    M3U-provided groups are considered (same rule as generation-time
+    resolution). An invalid regex returns ``valid: false`` rather than an
+    error so the UI can show inline feedback while the user types.
+    """
+    from teamarr.services.group_pattern import (
+        compile_group_pattern,
+        resolve_group_name_pattern,
+    )
+
+    conn = get_dispatcharr_connection(get_db)
+    if not conn:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Dispatcharr not configured or not connected",
+        )
+
+    valid = compile_group_pattern(request.pattern) is not None
+
+    try:
+        live_groups = conn.m3u.list_groups()
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch channel groups: {e}",
+        ) from e
+
+    matched = resolve_group_name_pattern(live_groups, request.pattern) if valid else []
+    return {
+        "valid": valid,
+        "total": len(matched),
+        "matches": [{"id": g.id, "name": g.name} for g in matched[:50]],
     }
 
 

--- a/tests/test_group_pattern.py
+++ b/tests/test_group_pattern.py
@@ -257,3 +257,114 @@ class TestCrudRoundtrip:
         group = get_group(conn, gid)
         assert group.m3u_group_name_pattern is None
         assert group.m3u_group_name_pattern_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# API layer (bpqb.6)
+# ---------------------------------------------------------------------------
+
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from teamarr.api.app import app  # noqa: E402
+from teamarr.database import init_db  # noqa: E402
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "test.db"))
+    init_db()
+
+
+class TestGroupsApi:
+    def test_pattern_fields_round_trip(self, isolated_db):
+        resp = client.post(
+            "/api/v1/groups",
+            json={
+                "name": "EPL",
+                "leagues": ["eng.1"],
+                "m3u_group_name_pattern": r"EPL \(MW\d+\)",
+                "m3u_group_name_pattern_enabled": True,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        gid = resp.json()["id"]
+
+        got = client.get(f"/api/v1/groups/{gid}").json()
+        assert got["m3u_group_name_pattern"] == r"EPL \(MW\d+\)"
+        assert got["m3u_group_name_pattern_enabled"] is True
+
+    def test_update_and_clear_pattern_fields(self, isolated_db):
+        gid = client.post(
+            "/api/v1/groups", json={"name": "EPL", "leagues": ["eng.1"]}
+        ).json()["id"]
+
+        resp = client.put(
+            f"/api/v1/groups/{gid}",
+            json={"m3u_group_name_pattern": "EPL", "m3u_group_name_pattern_enabled": True},
+        )
+        assert resp.status_code == 200, resp.text
+        got = client.get(f"/api/v1/groups/{gid}").json()
+        assert got["m3u_group_name_pattern"] == "EPL"
+        assert got["m3u_group_name_pattern_enabled"] is True
+
+        resp = client.put(
+            f"/api/v1/groups/{gid}",
+            json={
+                "clear_m3u_group_name_pattern": True,
+                "m3u_group_name_pattern_enabled": False,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        got = client.get(f"/api/v1/groups/{gid}").json()
+        assert got["m3u_group_name_pattern"] is None
+        assert got["m3u_group_name_pattern_enabled"] is False
+
+
+class TestPatternPreviewApi:
+    def _patch_dispatcharr(self, monkeypatch, groups):
+        import teamarr.api.routes.groups as groups_routes
+
+        fake = SimpleNamespace(m3u=SimpleNamespace(list_groups=lambda: groups))
+        monkeypatch.setattr(
+            groups_routes, "get_dispatcharr_connection", lambda db_factory=None: fake
+        )
+
+    def test_preview_returns_matches(self, isolated_db, monkeypatch):
+        self._patch_dispatcharr(
+            monkeypatch, [_grp(1, "EPL (MW1)"), _grp(2, "EPL (MW2)"), _grp(3, "USA | MLB")]
+        )
+        resp = client.post(
+            "/api/v1/groups/dispatcharr/group-pattern-preview",
+            json={"pattern": r"EPL \(MW\d+\)"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["valid"] is True
+        assert body["total"] == 2
+        assert [m["name"] for m in body["matches"]] == ["EPL (MW1)", "EPL (MW2)"]
+
+    def test_preview_invalid_regex_is_soft_error(self, isolated_db, monkeypatch):
+        self._patch_dispatcharr(monkeypatch, [_grp(1, "EPL (MW1)")])
+        resp = client.post(
+            "/api/v1/groups/dispatcharr/group-pattern-preview",
+            json={"pattern": "EPL ("},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is False
+        assert body["total"] == 0
+
+    def test_preview_unconfigured_dispatcharr_is_400(self, isolated_db, monkeypatch):
+        import teamarr.api.routes.groups as groups_routes
+
+        monkeypatch.setattr(
+            groups_routes, "get_dispatcharr_connection", lambda db_factory=None: None
+        )
+        resp = client.post(
+            "/api/v1/groups/dispatcharr/group-pattern-preview", json={"pattern": "EPL"}
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
Second slice of #450 (bead `teamarrv2-bpqb.6`), on top of #451.

- `GroupCreate`/`GroupUpdate`/`GroupResponse` expose `m3u_group_name_pattern` + `m3u_group_name_pattern_enabled` (update gets `clear_m3u_group_name_pattern`); wired through create/update calls and all four response builders.
- New `POST /api/v1/groups/dispatcharr/group-pattern-preview` — resolves a pattern against live Dispatcharr M3U groups (same resolver as generation) and returns `{valid, total, matches[≤50]}`. Invalid regex is a soft `valid: false` so the UI can give inline feedback while typing; unconfigured Dispatcharr is a 400.
- Tests: round-trip create/read, update/clear, preview matches/invalid-regex/unconfigured (1890 passed).

Next: UI (bpqb.7) + stale-detector suggestion flywheel (bpqb.4/.5).

Gates: ruff clean · 1890 passed · frontend untouched.
Bead: `teamarrv2-bpqb.6`