### PR TITLE
feat: pattern-binding UI in source editor + live preview (#450)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -58,6 +58,14 @@ Click **Matched** numbers to see which streams matched to which events. Click th
 
 Click **Import** to pull stream groups from your Dispatcharr M3U accounts. Teamarr shows available groups with stream counts. Select the groups you want and they'll be created as sources with default settings.
 
+## Binding by Name Pattern
+
+Some IPTV providers rotate group names — `EPL (MW1)` becomes `EPL (MW2)`, dated tournament groups come and go. Dispatcharr matches M3U groups by exact name, so a provider rename always creates a **new** group and a source pinned to the old one silently stops finding streams.
+
+**Bind by name pattern** (in the source's Basic Settings) makes the source rename-proof: instead of the pinned group, the source binds to a regular expression over live M3U group names, re-resolved on every generation run. A pattern like `EPL \(MW\d+\)` keeps matching no matter which matchweek the provider is on. If the pattern matches several groups at once, the source scans all of them (scoped to its M3U account), and while a renamed group's old and new versions briefly coexist, stale streams from the old one are filtered out automatically.
+
+The editor shows a live **"Matches N groups"** preview as you type. A pattern that matches nothing means the source is treated as stale — same as a missing pinned group.
+
 ## Stream Matching Pipeline
 
 When EPG generation runs, each stream goes through:

--- a/frontend/src/api/groups.ts
+++ b/frontend/src/api/groups.ts
@@ -43,6 +43,19 @@ export async function createGroup(data: EventGroupCreate): Promise<EventGroup> {
   return api.post("/groups", data)
 }
 
+/** Live resolution of a group-name pattern against Dispatcharr M3U groups (#450). */
+export interface GroupPatternPreview {
+  valid: boolean
+  total: number
+  matches: { id: number; name: string }[]
+}
+
+export async function previewGroupPattern(
+  pattern: string
+): Promise<GroupPatternPreview> {
+  return api.post("/groups/dispatcharr/group-pattern-preview", { pattern })
+}
+
 export async function updateGroup(
   groupId: number,
   data: EventGroupUpdate

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -30,6 +30,9 @@ export interface EventGroup {
   m3u_group_name: string | null
   m3u_account_id: number | null
   m3u_account_name: string | null
+  // Group-name pattern binding (#450)
+  m3u_group_name_pattern: string | null
+  m3u_group_name_pattern_enabled: boolean
   // Stream filtering
   stream_include_regex: string | null
   stream_include_regex_enabled: boolean
@@ -103,6 +106,9 @@ export interface EventGroupCreate {
   m3u_group_name?: string | null
   m3u_account_id?: number | null
   m3u_account_name?: string | null
+  // Group-name pattern binding (#450)
+  m3u_group_name_pattern?: string | null
+  m3u_group_name_pattern_enabled?: boolean
   // Stream filtering
   stream_include_regex?: string | null
   stream_include_regex_enabled?: boolean
@@ -148,6 +154,7 @@ export interface EventGroupUpdate extends Partial<EventGroupCreate> {
   clear_m3u_group_name?: boolean
   clear_m3u_account_id?: boolean
   clear_m3u_account_name?: boolean
+  clear_m3u_group_name_pattern?: boolean
   clear_stream_include_regex?: boolean
   clear_stream_exclude_regex?: boolean
   clear_custom_regex_teams?: boolean

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react"
+import { useState, useMemo, useCallback, useEffect } from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { ArrowLeft, LoaderCircle, FlaskConical } from "lucide-react"
@@ -26,6 +26,7 @@ import { LeaguePicker } from "@/components/LeaguePicker"
 import { SoccerModeSelector, type SoccerMode } from "@/components/SoccerModeSelector"
 import { getLeagues } from "@/api/teams"
 import { getSubscription } from "@/api/subscription"
+import { previewGroupPattern, type GroupPatternPreview } from "@/api/groups"
 import type { SoccerFollowedTeam } from "@/api/types"
 
 export function EventGroupForm() {
@@ -166,6 +167,11 @@ export function EventGroupForm() {
         m3u_group_name: group.m3u_group_name,
         m3u_account_id: group.m3u_account_id,
         m3u_account_name: group.m3u_account_name,
+        // Group-name pattern binding (#450)
+        m3u_group_name_pattern: group.m3u_group_name_pattern
+          ? pythonToJs(group.m3u_group_name_pattern)
+          : null,
+        m3u_group_name_pattern_enabled: group.m3u_group_name_pattern_enabled,
         // Stream filtering
         stream_include_regex: group.stream_include_regex ? pythonToJs(group.stream_include_regex) : null,
         stream_include_regex_enabled: group.stream_include_regex_enabled,
@@ -250,6 +256,7 @@ export function EventGroupForm() {
     try {
       const submitData = {
         ...data,
+        m3u_group_name_pattern: data.m3u_group_name_pattern ? jsToPython(data.m3u_group_name_pattern) : null,
         stream_include_regex: data.stream_include_regex ? jsToPython(data.stream_include_regex) : null,
         stream_exclude_regex: data.stream_exclude_regex ? jsToPython(data.stream_exclude_regex) : null,
         custom_regex_teams: data.custom_regex_teams ? jsToPython(data.custom_regex_teams) : null,
@@ -284,6 +291,9 @@ export function EventGroupForm() {
           }
           if (shouldClear(group.stream_timezone, data.stream_timezone)) {
             updateData.clear_stream_timezone = true
+          }
+          if (shouldClear(group.m3u_group_name_pattern, data.m3u_group_name_pattern)) {
+            updateData.clear_m3u_group_name_pattern = true
           }
           // Clear subscription override when switching back to global
           if (useGlobalSubscription && group.subscription_leagues !== null) {
@@ -456,6 +466,8 @@ export function EventGroupForm() {
                   <div>Group: {formData.m3u_group_name} (#{formData.m3u_group_id})</div>
                 </div>
               )}
+
+              <PatternBindingFields formData={formData} setFormData={setFormData} />
 
               <div className="flex items-center gap-2">
                 <Switch
@@ -1203,6 +1215,93 @@ export function EventGroupForm() {
         initialPatterns={currentPatterns}
         onApply={handlePatternsApply}
       />
+    </div>
+  )
+}
+
+/** Group-name pattern binding (#450): opt-in regex binding to live M3U group
+ * names so provider renames (which spawn a new Dispatcharr group id) re-bind
+ * automatically. Shows a debounced live "matches N groups" preview. */
+function PatternBindingFields({
+  formData,
+  setFormData,
+}: {
+  formData: EventGroupCreate
+  setFormData: React.Dispatch<React.SetStateAction<EventGroupCreate>>
+}) {
+  const enabled = formData.m3u_group_name_pattern_enabled || false
+  const pattern = formData.m3u_group_name_pattern || ""
+  // Result keyed by the pattern it was computed for: staleness and "checking"
+  // are derived at render time, so the effect never calls setState
+  // synchronously (react-hooks/set-state-in-effect).
+  const [result, setResult] = useState<{
+    forPattern: string
+    data: GroupPatternPreview | null
+  } | null>(null)
+
+  useEffect(() => {
+    if (!enabled || !pattern.trim()) return
+    const handle = setTimeout(async () => {
+      try {
+        setResult({ forPattern: pattern, data: await previewGroupPattern(jsToPython(pattern)) })
+      } catch {
+        setResult({ forPattern: pattern, data: null })
+      }
+    }, 400)
+    return () => clearTimeout(handle)
+  }, [enabled, pattern])
+
+  const preview = result?.forPattern === pattern ? result.data : undefined
+  const previewLoading = enabled && !!pattern.trim() && preview === undefined
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={enabled}
+          onCheckedChange={(checked) =>
+            setFormData((prev) => ({ ...prev, m3u_group_name_pattern_enabled: checked }))
+          }
+        />
+        <div>
+          <Label className="font-normal">Bind by name pattern</Label>
+          <p className="text-xs text-muted-foreground">
+            Match M3U groups by a name regex instead of the pinned group above —
+            survives provider renames like "EPL (MW1)" → "EPL (MW2)".
+          </p>
+        </div>
+      </div>
+      {enabled && (
+        <div className="space-y-1 pl-10">
+          <Input
+            value={pattern}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                m3u_group_name_pattern: e.target.value || null,
+              }))
+            }
+            placeholder={String.raw`e.g. EPL \(MW\d+\)`}
+            className="font-mono text-sm"
+          />
+          <p className="text-xs text-muted-foreground">
+            {!pattern.trim()
+              ? "Enter a pattern to see which live M3U groups it matches."
+              : previewLoading || preview === undefined
+                ? "Checking…"
+                : preview === null
+                  ? "Preview unavailable (Dispatcharr not reachable)."
+                  : !preview.valid
+                    ? "Invalid regular expression."
+                    : preview.total === 0
+                      ? "Matches no live M3U groups — the source would be treated as stale."
+                      : `Matches ${preview.total} group${preview.total === 1 ? "" : "s"}: ${preview.matches
+                          .slice(0, 5)
+                          .map((m) => m.name)
+                          .join(", ")}${preview.total > 5 ? ", …" : ""}`}
+          </p>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Third slice of #450 (bead `teamarrv2-bpqb.7` core), on top of #452.

- **Bind by name pattern** toggle + regex input in the source editor's Basic Settings (edit mode), under the M3U source info
- Debounced (400ms) live **"Matches N groups: …"** preview via `POST /groups/dispatcharr/group-pattern-preview`; distinct messages for invalid regex, zero matches (warns the source would be stale), and unreachable Dispatcharr
- Preview state keyed by the pattern it was computed for — loading/staleness derived at render, no setState-in-effect (react-compiler lint clean)
- Pattern round-trips `jsToPython`/`pythonToJs` like the other regex fields; clearing on edit emits `clear_m3u_group_name_pattern`
- Docs: new **Binding by Name Pattern** section in `docs/guide/sources/index.md`

**Verified live** on the dev instance: toggled the field on a real source, typed `USA \| MLB`, preview returned "Matches 3 groups: USA | MLB ⚾, USA | MLB Teams ⚾, USA | MLB Backup ⚾" from live Dispatcharr (not saved).

Remaining in epic: re-bind suggestion card + pattern-suggestion flywheel (bpqb.4/.5), cleanup-safety audit (bpqb.8).

Gates: ruff clean · 1890 passed · frontend build + ESLint clean.
Bead: `teamarrv2-bpqb.7`