### PR TITLE
test: cleanup-safety audit for pattern binding (#450, bpqb.8)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -66,6 +66,8 @@ Some IPTV providers rotate group names — `EPL (MW1)` becomes `EPL (MW2)`, date
 
 The editor shows a live **"Matches N groups"** preview as you type. A pattern that matches nothing means the source is treated as stale — same as a missing pinned group.
 
+A stale pattern never deletes your channels: when it matches nothing, the source simply skips the run and existing channels stay until their normal post-event expiry. If the pattern still matches *some* groups but misses one (say a rename escaped your regex), streams from the missed group are treated like streams removed from the M3U — they're detached on the next run, and a channel is removed only once no streams are left on it.
+
 ## Stream Matching Pipeline
 
 When EPG generation runs, each stream goes through:

--- a/tests/test_group_pattern.py
+++ b/tests/test_group_pattern.py
@@ -260,6 +260,114 @@ class TestCrudRoundtrip:
 
 
 # ---------------------------------------------------------------------------
+# Cleanup safety (bpqb.8)
+#
+# A pattern that stops matching (provider rename escaping the regex, M3U
+# outage) must NEVER cascade into channel deletion. The guarantee lives in
+# _process_group_internal's short-circuits: an empty fetch — and an
+# all-filtered / zero-match run — returns before cleanup_deleted_streams or
+# any lifecycle call, so existing channels are retained untouched.
+# ---------------------------------------------------------------------------
+
+
+def _tripwire(name):
+    def _fail(*args, **kwargs):
+        raise AssertionError(f"{name} must not be called on this path")
+
+    return _fail
+
+
+def _seeded_group_db():
+    """Schema DB with the template requirement satisfied and one real group."""
+    conn = _db()
+    cur = conn.execute("INSERT INTO templates (name, template_type) VALUES ('T', 'event')")
+    conn.execute("INSERT INTO subscription_templates (template_id) VALUES (?)", (cur.lastrowid,))
+    gid = create_group(
+        conn,
+        name="EPL",
+        leagues=["eng.1"],
+        m3u_group_name_pattern=r"EPL \(MW\d+\)",
+        m3u_group_name_pattern_enabled=True,
+    )
+    conn.commit()
+    return conn, get_group(conn, gid)
+
+
+class TestCleanupSafety:
+    def _processor(self, conn):
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+
+        return EventGroupProcessor(db_factory=_factory(conn))
+
+    def test_empty_fetch_short_circuits_before_any_cleanup(self, monkeypatch):
+        from datetime import date
+
+        conn, group = _seeded_group_db()
+        proc = self._processor(conn)
+        monkeypatch.setattr(proc, "_fetch_streams", lambda g: [])
+        for name in (
+            "_filter_streams",
+            "_match_streams",
+            "_process_channels",
+            "_get_lifecycle_service",
+        ):
+            monkeypatch.setattr(proc, name, _tripwire(name))
+
+        result = proc._process_group_internal(conn, group, date.today())
+
+        assert result.errors == ["No streams found for group"]
+        assert result.channels_deleted == 0
+
+    def test_all_filtered_short_circuits_before_matching(self, monkeypatch):
+        from datetime import date
+
+        from teamarr.services.stream_filter import FilterResult
+
+        conn, group = _seeded_group_db()
+        proc = self._processor(conn)
+        monkeypatch.setattr(
+            proc, "_fetch_streams", lambda g: [{"id": 11, "name": "Arsenal vs Spurs"}]
+        )
+        monkeypatch.setattr(
+            proc,
+            "_filter_streams",
+            lambda streams, g: ([], FilterResult(total_input=1, filtered_exclude=1)),
+        )
+        for name in ("_match_streams", "_process_channels", "_get_lifecycle_service"):
+            monkeypatch.setattr(proc, name, _tripwire(name))
+
+        result = proc._process_group_internal(conn, group, date.today())
+
+        assert result.errors == ["All streams filtered out by regex patterns"]
+        assert result.channels_deleted == 0
+
+    def test_zero_matches_never_reaches_lifecycle(self, monkeypatch):
+        from datetime import date
+
+        from teamarr.consumers.matching.matcher import BatchMatchResult
+        from teamarr.services.stream_filter import FilterResult
+
+        conn, group = _seeded_group_db()
+        proc = self._processor(conn)
+        streams = [{"id": 11, "name": "Arsenal vs Spurs"}]
+        monkeypatch.setattr(proc, "_fetch_streams", lambda g: list(streams))
+        monkeypatch.setattr(
+            proc,
+            "_filter_streams",
+            lambda s, g: (list(streams), FilterResult(total_input=1, passed_count=1)),
+        )
+        monkeypatch.setattr(proc, "_match_streams", lambda *a, **k: BatchMatchResult())
+        monkeypatch.setattr(proc, "_process_channels", _tripwire("_process_channels"))
+        monkeypatch.setattr(proc, "_get_lifecycle_service", _tripwire("_get_lifecycle_service"))
+
+        result = proc._process_group_internal(conn, group, date.today())
+
+        assert result.errors == []
+        assert result.channels_deleted == 0
+        assert result.streams_matched == 0
+
+
+# ---------------------------------------------------------------------------
 # API layer (bpqb.6)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_group_pattern.py
+++ b/tests/test_group_pattern.py
@@ -295,9 +295,14 @@ def _seeded_group_db():
 
 class TestCleanupSafety:
     def _processor(self, conn):
+        from unittest.mock import MagicMock
+
         from teamarr.consumers.event_group_processor import EventGroupProcessor
 
-        return EventGroupProcessor(db_factory=_factory(conn))
+        # Inject a stub service: the default one loads league mappings from the
+        # global DB path, which doesn't exist in CI (and none of these paths
+        # reach the provider layer anyway).
+        return EventGroupProcessor(db_factory=_factory(conn), service=MagicMock())
 
     def test_empty_fetch_short_circuits_before_any_cleanup(self, monkeypatch):
         from datetime import date


### PR DESCRIPTION
## Cleanup-safety audit (bpqb.8) — findings + regression tests

Audited all four channel-deletion mechanisms against the shipped pattern-binding code (#451–#453) plus the manual rebind path. **Verdict: no path exists where a pattern re-resolving (or failing to resolve) triggers channel deletion.**

### Findings

| Mechanism | Verdict |
|-----------|---------|
| Scheduled deletions (`lifecycle/cleanup.py::process_scheduled_deletions`) | Time-based (event end + buffer) only — group binding never consulted |
| Disabled-group cleanup (`cleanup_disabled_groups`) | Keyed on Teamarr `enabled=0`; pattern resolution only touches `source_missing` (UI flag, sole consumer is `GET /groups/stale`) |
| Reconciler | Detect-only during generation (`auto_fix=False`); `orphan_teamarr` requires a Dispatcharr-side channel disappearance, which pattern resolution can't cause |
| Unsubscribed-league sweep (`_cleanup_unsubscribed_leagues`) | Subscription-driven; a pattern-failed source stays enabled so its leagues still count toward the union; empty-union bail-out intact |

Load-bearing guards verified:
- **Empty fetch short-circuits** (`processor.py:625`): pattern-matches-nothing returns `[]` — identical to today's dead-pinned-id path — and group processing exits before `cleanup_deleted_streams` or any lifecycle call. Channels retained.
- **All-filtered and zero-match runs** also exit before lifecycle (`processor.py:646`, `:767`).
- **Team-filter cleanup** only deletes channels whose event was matched *this run* — no-op on empty runs.
- **Provenance gotcha**: `event_epg_group_id` / `source_group_id` are Teamarr ids; Dispatcharr group-id churn is invisible to every cleanup key.
- **Rebind via source edit** (`PUT /groups/{id}`) is a pure field update — no deletion side effects.

One documented behavioral delta (not a bug): a **partial** pattern miss (still matches ≥1 group) treats the missed group's streams as removed-from-M3U — stream-level detach, channel deleted only when nothing feeds it (same semantics as provider stream removal). Full miss retains everything. Added to the sources guide.

### Changes
- 3 regression tests pinning the short-circuits (`TestCleanupSafety`)
- Sources-guide paragraph on retention semantics

Tests 1,890 → 1,893. Closes bead `teamarrv2-bpqb.8`; #450 stays open (epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)