### PR TITLE
feat: Pattern Tester pipeline-truth extraction verdicts (#458)

### DIFF
--- a/docs/guide/sources/creating-groups.md
+++ b/docs/guide/sources/creating-groups.md
@@ -93,6 +93,8 @@ Each extractor has an enable toggle. Leave disabled to use the built-in parser.
 
 Named groups accept both `(?<name>...)` and Python's `(?P<name>...)` syntax. The recognized names are `team1`/`team2` (Teams), `fighter1`/`fighter2` (Fighters), `date` or `month`/`day`/`year` (Date), `time` or `hour`/`minute`/`ampm` (Time), `league` (League), and `event_name` (Event name). When the recognized named groups are present they take precedence, so extra unnamed groups — like a `(vs|v)` separator — are safe. Without named groups, the first capture group is used (first two for Teams/Fighters).
 
+**Pattern Tester** — the *Open Pattern Tester* button opens a workspace that runs your patterns against the group's real stream names. Highlighting is instant client-side JavaScript regex, and each stream also gets a **pipeline verdict badge** computed by the real Python extraction functions: green `✓ pipeline` means the pattern fully extracts (both teams captured, date/time actually parseable), amber `✗` lists the fields the pipeline would reject even if the regex visually matches. Invalid Python patterns and configuration pitfalls (e.g. month/day patterns without the date toggle) are called out in a banner. Hover a badge to see the extracted values.
+
 **Tennis groups** use the **Teams** extractor for player pairs — the two named
 groups become player 1 and player 2 (surname-based matching handles tournament
 prefixes and extra tokens). The built-in parser also recognizes the

--- a/frontend/src/api/groups.ts
+++ b/frontend/src/api/groups.ts
@@ -137,6 +137,59 @@ export async function getRawStreams(
   return api.get(`/groups/${groupId}/streams/raw`)
 }
 
+// Pipeline-truth extraction tester (#458) — runs the REAL Python extraction
+// functions server-side; the client-side JS highlighting is only approximate.
+
+export interface ExtractionPatterns {
+  teams_pattern?: string | null
+  teams_enabled?: boolean
+  date_pattern?: string | null
+  date_enabled?: boolean
+  month_pattern?: string | null
+  month_enabled?: boolean
+  day_pattern?: string | null
+  day_enabled?: boolean
+  time_pattern?: string | null
+  time_enabled?: boolean
+  league_pattern?: string | null
+  league_enabled?: boolean
+  fighters_pattern?: string | null
+  fighters_enabled?: boolean
+  event_name_pattern?: string | null
+  event_name_enabled?: boolean
+}
+
+export interface ExtractionFieldResult {
+  matched: boolean
+  values: string[]
+}
+
+export interface StreamExtractionResult {
+  stream_name: string
+  teams: ExtractionFieldResult | null
+  fighters: ExtractionFieldResult | null
+  event_name: ExtractionFieldResult | null
+  date: ExtractionFieldResult | null
+  time: ExtractionFieldResult | null
+  league: ExtractionFieldResult | null
+}
+
+export interface TestExtractionResponse {
+  results: StreamExtractionResult[]
+  pattern_errors: Record<string, string>
+  warnings: string[]
+}
+
+export async function testExtraction(
+  streamNames: string[],
+  patterns: ExtractionPatterns
+): Promise<TestExtractionResponse> {
+  return api.post("/groups/test-extraction", {
+    stream_names: streamNames,
+    patterns,
+  })
+}
+
 export async function bulkUpdateGroups(
   data: BulkGroupUpdateRequest
 ): Promise<BulkGroupUpdateResponse> {

--- a/frontend/src/components/TestPatternsModal/StreamItem.tsx
+++ b/frontend/src/components/TestPatternsModal/StreamItem.tsx
@@ -9,6 +9,7 @@
 import { useMemo } from "react"
 import { cn } from "@/lib/utils"
 import type { MatchRange } from "@/lib/regex-utils"
+import type { StreamExtractionResult } from "@/api/groups"
 
 // ---------------------------------------------------------------------------
 // Color mapping for extraction fields
@@ -44,6 +45,8 @@ export interface StreamItemProps {
   excludeMatch: boolean
   /** Reason stream would be filtered by builtin filters (null if passes) */
   builtinFilterReason: string | null
+  /** Pipeline-truth extraction result from the backend (#458); null = not tested */
+  pipelineResult: StreamExtractionResult | null
   /** Whether built-in filtering is skipped */
   skipBuiltinFilter: boolean
   /** Called when user selects text for interactive pattern generation */
@@ -116,6 +119,7 @@ export function StreamItem({
   name,
   index,
   extractionRanges,
+  pipelineResult,
   includeMatch,
   excludeMatch,
   builtinFilterReason,
@@ -133,6 +137,27 @@ export function StreamItem({
 
   const isExcluded = excludeMatch || isBuiltinFiltered
   const isFilteredByInclude = includeMatch === false // include regex set but doesn't match
+
+  // Pipeline verdict (#458): per enabled field, did the REAL extraction succeed?
+  const pipeline = useMemo(() => {
+    if (!pipelineResult) return null
+    const fields: { label: string; matched: boolean; values: string[] }[] = []
+    const push = (label: string, f: { matched: boolean; values: string[] } | null) => {
+      if (f) fields.push({ label, ...f })
+    }
+    push("teams", pipelineResult.teams)
+    push("fighters", pipelineResult.fighters)
+    push("event", pipelineResult.event_name)
+    push("date", pipelineResult.date)
+    push("time", pipelineResult.time)
+    push("league", pipelineResult.league)
+    if (fields.length === 0) return null
+    const failed = fields.filter((f) => !f.matched)
+    const title = fields
+      .map((f) => `${f.label}: ${f.matched ? f.values.join(" vs ") || "✓" : "✗ not extracted"}`)
+      .join("\n")
+    return { failed, allOk: failed.length === 0, title }
+  }, [pipelineResult])
 
   const handleMouseUp = () => {
     if (!onTextSelect) return
@@ -184,6 +209,22 @@ export function StreamItem({
           )
         })}
       </span>
+      {/* Pipeline-truth verdict (#458) — only shown when a pattern is enabled */}
+      {pipeline && (
+        <span
+          className={cn(
+            "shrink-0 text-[10px] px-1.5 py-0.5 rounded whitespace-pre",
+            pipeline.allOk
+              ? "bg-green-500/15 text-green-400"
+              : "bg-yellow-500/20 text-yellow-400"
+          )}
+          title={pipeline.title}
+        >
+          {pipeline.allOk
+            ? "✓ pipeline"
+            : `✗ ${pipeline.failed.map((f) => f.label).join(", ")}`}
+        </span>
+      )}
       {/* Show filter reason badge when stream matches builtin filter */}
       {builtinFilterReason && (
         <span

--- a/frontend/src/components/TestPatternsModal/StreamList.tsx
+++ b/frontend/src/components/TestPatternsModal/StreamList.tsx
@@ -10,7 +10,7 @@ import { useVirtualizer } from "@tanstack/react-virtual"
 import { StreamItem } from "./StreamItem"
 import { getMatchRanges, testMatch } from "@/lib/regex-utils"
 import type { PatternState } from "./index"
-import type { RawStream } from "@/api/groups"
+import type { RawStream, StreamExtractionResult } from "@/api/groups"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,6 +19,9 @@ import type { RawStream } from "@/api/groups"
 interface StreamListProps {
   streams: RawStream[]
   patterns: PatternState
+  /** Pipeline-truth extraction results keyed by stream name (#458) */
+  pipelineResults: Map<string, StreamExtractionResult>
+  pipelineLoading: boolean
   onTextSelect?: (text: string, streamName: string) => void
 }
 
@@ -26,7 +29,7 @@ interface StreamListProps {
 // Component
 // ---------------------------------------------------------------------------
 
-export function StreamList({ streams, patterns, onTextSelect }: StreamListProps) {
+export function StreamList({ streams, patterns, pipelineResults, pipelineLoading, onTextSelect }: StreamListProps) {
   const parentRef = useRef<HTMLDivElement>(null)
 
   // Pre-compute match results for all streams
@@ -108,6 +111,18 @@ export function StreamList({ streams, patterns, onTextSelect }: StreamListProps)
     let builtinFiltered = 0
     let withExtractions = 0
 
+    let pipelineExtracted = 0
+    let pipelineRejected = 0
+    for (const s of streams) {
+      const pr = pipelineResults.get(s.stream_name)
+      if (!pr) continue
+      const fields = [pr.teams, pr.fighters, pr.event_name, pr.date, pr.time, pr.league]
+        .filter((f) => f !== null)
+      if (fields.length === 0) continue
+      if (fields.every((f) => f!.matched)) pipelineExtracted++
+      else pipelineRejected++
+    }
+
     for (const r of results) {
       // Count streams matching builtin filters (tracked separately)
       if (r.builtinFilterReason) builtinFiltered++
@@ -128,10 +143,12 @@ export function StreamList({ streams, patterns, onTextSelect }: StreamListProps)
       excluded,
       builtinFiltered,
       withExtractions,
+      pipelineExtracted,
+      pipelineRejected,
       total: streams.length,
       skipBuiltin: patterns.skip_builtin_filter,
     }
-  }, [results, streams.length, patterns.skip_builtin_filter])
+  }, [results, streams, patterns.skip_builtin_filter, pipelineResults])
 
   const virtualizer = useVirtualizer({
     count: streams.length,
@@ -147,6 +164,17 @@ export function StreamList({ streams, patterns, onTextSelect }: StreamListProps)
         <span>{stats.total} streams</span>
         {stats.withExtractions > 0 && (
           <span className="text-success">{stats.withExtractions} with extractions</span>
+        )}
+        {pipelineResults.size > 0 && (
+          <span className={pipelineLoading ? "opacity-50" : ""}>
+            pipeline: <span className="text-success">{stats.pipelineExtracted} extracted</span>
+            {stats.pipelineRejected > 0 && (
+              <>
+                {" · "}
+                <span className="text-yellow-500">{stats.pipelineRejected} partial/rejected</span>
+              </>
+            )}
+          </span>
         )}
         {stats.excluded > 0 && (
           <span className="text-destructive">{stats.excluded} excluded</span>
@@ -190,6 +218,7 @@ export function StreamList({ streams, patterns, onTextSelect }: StreamListProps)
                   name={stream.stream_name}
                   index={idx}
                   extractionRanges={r.extractionRanges}
+                  pipelineResult={pipelineResults.get(stream.stream_name) ?? null}
                   includeMatch={r.includeMatch}
                   excludeMatch={r.excludeMatch}
                   builtinFilterReason={r.builtinFilterReason}

--- a/frontend/src/components/TestPatternsModal/index.tsx
+++ b/frontend/src/components/TestPatternsModal/index.tsx
@@ -9,7 +9,7 @@
  * 5. Syncs patterns bidirectionally with the form (reads on open, writes on Apply)
  */
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   Dialog,
@@ -20,11 +20,12 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { getRawStreams } from "@/api/groups"
+import { getRawStreams, testExtraction } from "@/api/groups"
+import type { ExtractionPatterns, StreamExtractionResult } from "@/api/groups"
 import { StreamList } from "./StreamList"
 import { PatternPanel } from "./PatternPanel"
 import { InteractiveSelector } from "./InteractiveSelector"
-import { FlaskConical, LoaderCircle } from "lucide-react"
+import { FlaskConical, LoaderCircle, TriangleAlert } from "lucide-react"
 
 // ---------------------------------------------------------------------------
 // Types — shared across child components
@@ -145,6 +146,76 @@ export function TestPatternsModal({
 
   const streams = streamsData?.streams ?? []
 
+  // ------------------------------------------------------------------
+  // Pipeline-truth extraction (#458): debounce the pattern state, then
+  // run the REAL Python extraction functions server-side. JS highlighting
+  // stays instant; the backend verdict arrives ~half a second later.
+  // ------------------------------------------------------------------
+  const [debouncedPatterns, setDebouncedPatterns] = useState(patterns)
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedPatterns(patterns), 500)
+    return () => clearTimeout(t)
+  }, [patterns])
+
+  const extractionRequest: ExtractionPatterns | null = useMemo(() => {
+    const p = debouncedPatterns
+    const anyEnabled =
+      (p.custom_regex_teams_enabled && p.custom_regex_teams) ||
+      (p.custom_regex_date_enabled && p.custom_regex_date) ||
+      (p.custom_regex_month_enabled && p.custom_regex_month) ||
+      (p.custom_regex_day_enabled && p.custom_regex_day) ||
+      (p.custom_regex_time_enabled && p.custom_regex_time) ||
+      (p.custom_regex_league_enabled && p.custom_regex_league) ||
+      (p.custom_regex_fighters_enabled && p.custom_regex_fighters) ||
+      (p.custom_regex_event_name_enabled && p.custom_regex_event_name)
+    if (!anyEnabled) return null
+    return {
+      teams_pattern: p.custom_regex_teams,
+      teams_enabled: p.custom_regex_teams_enabled,
+      date_pattern: p.custom_regex_date,
+      date_enabled: p.custom_regex_date_enabled,
+      month_pattern: p.custom_regex_month,
+      month_enabled: p.custom_regex_month_enabled,
+      day_pattern: p.custom_regex_day,
+      day_enabled: p.custom_regex_day_enabled,
+      time_pattern: p.custom_regex_time,
+      time_enabled: p.custom_regex_time_enabled,
+      league_pattern: p.custom_regex_league,
+      league_enabled: p.custom_regex_league_enabled,
+      fighters_pattern: p.custom_regex_fighters,
+      fighters_enabled: p.custom_regex_fighters_enabled,
+      event_name_pattern: p.custom_regex_event_name,
+      event_name_enabled: p.custom_regex_event_name_enabled,
+    }
+  }, [debouncedPatterns])
+
+  const { data: extractionData, isFetching: extractionLoading } = useQuery({
+    queryKey: ["testExtraction", groupId, extractionRequest],
+    queryFn: () =>
+      testExtraction(
+        streams.map((s) => s.stream_name),
+        extractionRequest!
+      ),
+    enabled: open && extractionRequest !== null && streams.length > 0,
+    staleTime: 5 * 60 * 1000,
+    placeholderData: (prev) => prev, // keep old verdicts while retesting
+  })
+
+  const pipelineResults = useMemo(() => {
+    const map = new Map<string, StreamExtractionResult>()
+    if (extractionRequest !== null && extractionData) {
+      for (const r of extractionData.results) map.set(r.stream_name, r)
+    }
+    return map
+  }, [extractionData, extractionRequest])
+
+  const patternErrors = extractionRequest !== null
+    ? extractionData?.pattern_errors ?? {}
+    : {}
+  const pipelineWarnings = extractionRequest !== null
+    ? extractionData?.warnings ?? []
+    : []
+
   const handlePatternChange = useCallback((update: Partial<PatternState>) => {
     setPatterns((prev) => ({ ...prev, ...update }))
   }, [])
@@ -217,10 +288,29 @@ export function TestPatternsModal({
               </div>
             )}
 
+            {(Object.keys(patternErrors).length > 0 || pipelineWarnings.length > 0) && (
+              <div className="px-3 py-1.5 text-xs border-b border-border bg-yellow-500/10 space-y-0.5">
+                {Object.entries(patternErrors).map(([field, err]) => (
+                  <div key={field} className="text-destructive flex items-center gap-1.5">
+                    <TriangleAlert className="h-3 w-3 shrink-0" />
+                    <span><span className="font-semibold">{field}</span> pattern is invalid in Python: {err}</span>
+                  </div>
+                ))}
+                {pipelineWarnings.map((w, i) => (
+                  <div key={i} className="text-yellow-500 flex items-center gap-1.5">
+                    <TriangleAlert className="h-3 w-3 shrink-0" />
+                    <span>{w}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
             {!isLoading && !error && streams.length > 0 && (
               <StreamList
                 streams={streams}
                 patterns={patterns}
+                pipelineResults={pipelineResults}
+                pipelineLoading={extractionLoading}
                 onTextSelect={handleTextSelect}
               />
             )}
@@ -237,9 +327,9 @@ export function TestPatternsModal({
         <DialogFooter className="px-4 py-3 border-t border-border shrink-0">
           <div className="flex items-center justify-between w-full">
             <span className="text-xs text-muted-foreground">
-              Patterns are tested client-side using JavaScript regex.
-              Named groups accept both (?&lt;name&gt;...) and Python&apos;s
-              (?P&lt;name&gt;...) — they are converted automatically.
+              Highlighting is client-side JavaScript regex; the ✓/✗ badges are
+              the real Python extraction pipeline. Named groups accept both
+              (?&lt;name&gt;...) and Python&apos;s (?P&lt;name&gt;...).
             </span>
             <div className="flex gap-2">
               <Button variant="outline" size="sm" onClick={handleClose}>

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -2292,13 +2292,13 @@ def test_extraction(request: TestExtractionRequest):
         if p.teams_enabled and p.teams_pattern:
             t1, t2, ok = extract_teams_with_custom_regex(name, config)
             r.teams = ExtractionFieldResult(
-                matched=ok, values=[t1, t2] if ok else []
+                matched=ok, values=[v for v in (t1, t2) if v] if ok else []
             )
 
         if p.fighters_enabled and p.fighters_pattern:
             f1, f2, ok = extract_fighters_with_custom_regex(name, config)
             r.fighters = ExtractionFieldResult(
-                matched=ok, values=[f1, f2] if ok else []
+                matched=ok, values=[v for v in (f1, f2) if v] if ok else []
             )
 
         if p.event_name_enabled and p.event_name_pattern:

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -2151,3 +2151,186 @@ def get_combined_xmltv() -> Response:
         media_type="application/xml",
         headers={"Content-Disposition": "inline; filename=teamarr-events.xml"},
     )
+
+
+# =============================================================================
+# Custom regex extraction tester (#458)
+# =============================================================================
+
+
+class ExtractionPatterns(BaseModel):
+    """Custom regex patterns to test — mirrors CustomRegexConfig fields."""
+
+    teams_pattern: str | None = None
+    teams_enabled: bool = False
+    date_pattern: str | None = None
+    date_enabled: bool = False
+    month_pattern: str | None = None
+    month_enabled: bool = False
+    day_pattern: str | None = None
+    day_enabled: bool = False
+    time_pattern: str | None = None
+    time_enabled: bool = False
+    league_pattern: str | None = None
+    league_enabled: bool = False
+    fighters_pattern: str | None = None
+    fighters_enabled: bool = False
+    event_name_pattern: str | None = None
+    event_name_enabled: bool = False
+
+
+class ExtractionFieldResult(BaseModel):
+    """Pipeline extraction outcome for one field on one stream."""
+
+    matched: bool
+    values: list[str] = []
+
+
+class StreamExtractionResult(BaseModel):
+    """Per-stream pipeline extraction results (None = pattern not enabled)."""
+
+    stream_name: str
+    teams: ExtractionFieldResult | None = None
+    fighters: ExtractionFieldResult | None = None
+    event_name: ExtractionFieldResult | None = None
+    date: ExtractionFieldResult | None = None
+    time: ExtractionFieldResult | None = None
+    league: ExtractionFieldResult | None = None
+
+
+class TestExtractionRequest(BaseModel):
+    """Request to run the real extraction pipeline against stream names."""
+
+    stream_names: list[str] = Field(..., max_length=20000)
+    patterns: ExtractionPatterns
+
+
+class TestExtractionResponse(BaseModel):
+    """Pipeline-truth extraction results for the Pattern Tester."""
+
+    results: list[StreamExtractionResult]
+    # field -> compile error message (invalid Python regex)
+    pattern_errors: dict[str, str] = {}
+    warnings: list[str] = []
+
+
+@router.post("/test-extraction", response_model=TestExtractionResponse)
+def test_extraction(request: TestExtractionRequest):
+    """Run the REAL custom-regex extraction functions against stream names.
+
+    The Pattern Tester's client-side JS highlighting can diverge from the
+    pipeline (Python `re` dialect, two-required-groups rule for teams and
+    fighters, date/time parseability). This endpoint is the single source
+    of truth: it calls the same `extract_*_with_custom_regex` functions the
+    matcher uses, on the original stream names, and returns per-stream
+    per-field results.
+    """
+    import re as _re
+
+    from teamarr.consumers.matching.classifier import (
+        CustomRegexConfig,
+        extract_date_with_custom_regex,
+        extract_event_name_with_custom_regex,
+        extract_fighters_with_custom_regex,
+        extract_league_with_custom_regex,
+        extract_teams_with_custom_regex,
+        extract_time_with_custom_regex,
+    )
+
+    p = request.patterns
+    config = CustomRegexConfig(
+        teams_pattern=p.teams_pattern,
+        teams_enabled=p.teams_enabled,
+        date_pattern=p.date_pattern,
+        date_enabled=p.date_enabled,
+        month_pattern=p.month_pattern,
+        month_enabled=p.month_enabled,
+        day_pattern=p.day_pattern,
+        day_enabled=p.day_enabled,
+        time_pattern=p.time_pattern,
+        time_enabled=p.time_enabled,
+        league_pattern=p.league_pattern,
+        league_enabled=p.league_enabled,
+        fighters_pattern=p.fighters_pattern,
+        fighters_enabled=p.fighters_enabled,
+        event_name_pattern=p.event_name_pattern,
+        event_name_enabled=p.event_name_enabled,
+    )
+
+    # Surface compile errors explicitly — the pipeline logs-and-ignores an
+    # invalid pattern, which the tester must report instead of showing
+    # "no match" with no explanation.
+    pattern_errors: dict[str, str] = {}
+    for fname, pat, enabled in (
+        ("teams", p.teams_pattern, p.teams_enabled),
+        ("date", p.date_pattern, p.date_enabled),
+        ("month", p.month_pattern, p.month_enabled),
+        ("day", p.day_pattern, p.day_enabled),
+        ("time", p.time_pattern, p.time_enabled),
+        ("league", p.league_pattern, p.league_enabled),
+        ("fighters", p.fighters_pattern, p.fighters_enabled),
+        ("event_name", p.event_name_pattern, p.event_name_enabled),
+    ):
+        if enabled and pat:
+            try:
+                _re.compile(pat, _re.IGNORECASE)
+            except _re.error as e:
+                pattern_errors[fname] = str(e)
+
+    warnings: list[str] = []
+    if (p.month_enabled or p.day_enabled) and not p.date_enabled:
+        warnings.append(
+            "Month/day patterns only apply when the date pattern toggle is "
+            "enabled — the pipeline gates all date extraction on it."
+        )
+
+    date_attempted = p.date_enabled  # mirror _apply_custom_datetime_regex gate
+    results: list[StreamExtractionResult] = []
+    for name in request.stream_names:
+        r = StreamExtractionResult(stream_name=name)
+
+        if p.teams_enabled and p.teams_pattern:
+            t1, t2, ok = extract_teams_with_custom_regex(name, config)
+            r.teams = ExtractionFieldResult(
+                matched=ok, values=[t1, t2] if ok else []
+            )
+
+        if p.fighters_enabled and p.fighters_pattern:
+            f1, f2, ok = extract_fighters_with_custom_regex(name, config)
+            r.fighters = ExtractionFieldResult(
+                matched=ok, values=[f1, f2] if ok else []
+            )
+
+        if p.event_name_enabled and p.event_name_pattern:
+            event_name = extract_event_name_with_custom_regex(name, config)
+            r.event_name = ExtractionFieldResult(
+                matched=event_name is not None,
+                values=[event_name] if event_name else [],
+            )
+
+        if date_attempted:
+            extracted_date = extract_date_with_custom_regex(name, config)
+            r.date = ExtractionFieldResult(
+                matched=extracted_date is not None,
+                values=[extracted_date.isoformat()] if extracted_date else [],
+            )
+
+        if p.time_enabled and p.time_pattern:
+            extracted_time = extract_time_with_custom_regex(name, config)
+            r.time = ExtractionFieldResult(
+                matched=extracted_time is not None,
+                values=[extracted_time.strftime("%H:%M")] if extracted_time else [],
+            )
+
+        if p.league_enabled and p.league_pattern:
+            league = extract_league_with_custom_regex(name, config)
+            r.league = ExtractionFieldResult(
+                matched=league is not None,
+                values=[league] if league else [],
+            )
+
+        results.append(r)
+
+    return TestExtractionResponse(
+        results=results, pattern_errors=pattern_errors, warnings=warnings
+    )

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -499,8 +499,10 @@ def _parse_date_string(date_str: str) -> date | None:
         "%d.%m",  # 15.07
     ]
 
-    # Clean up ordinal suffixes (1st, 2nd, 3rd, 4th)
-    date_str = re.sub(r"(\d+)(st|nd|rd|th)", r"\1", date_str, flags=re.IGNORECASE)
+    # Clean up ordinal suffixes (1st, 2nd, 3rd, 4th). Day ordinals are 1-2
+    # digits; the bound also keeps backtracking linear on adversarial input
+    # (py/polynomial-redos — this runs on user-captured text via #458).
+    date_str = re.sub(r"(\d{1,2})(st|nd|rd|th)", r"\1", date_str, flags=re.IGNORECASE)
 
     for fmt in formats:
         try:
@@ -596,8 +598,12 @@ def _parse_time_string(time_str: str) -> time | None:
         "%H%M",  # 1845
     ]
 
-    # Normalize: remove spaces between number and am/pm
-    time_str_normalized = re.sub(r"(\d+)\s*(am|pm)", r"\1\2", time_str, flags=re.IGNORECASE)
+    # Normalize: remove spaces between number and am/pm. Times are at most
+    # 4 digits; the bounds also keep backtracking linear on adversarial input
+    # (py/polynomial-redos — this runs on user-captured text via #458).
+    time_str_normalized = re.sub(
+        r"(\d{1,4})\s{0,3}(am|pm)", r"\1\2", time_str, flags=re.IGNORECASE
+    )
 
     for fmt in formats:
         try:

--- a/tests/test_extraction_tester_api.py
+++ b/tests/test_extraction_tester_api.py
@@ -1,0 +1,95 @@
+"""Pattern Tester pipeline-truth endpoint tests (#458).
+
+The endpoint must mirror the real extraction pipeline exactly — including
+the two-required-groups rule (#456) and date parseability — so the tester
+stops green-lighting patterns the pipeline would reject.
+"""
+
+from teamarr.api.routes.groups import (
+    ExtractionPatterns,
+    TestExtractionRequest,
+)
+from teamarr.api.routes.groups import (
+    test_extraction as run_extraction,  # aliased so pytest doesn't collect it
+)
+
+
+def _run(patterns: ExtractionPatterns, names: list[str]):
+    return run_extraction(TestExtractionRequest(stream_names=names, patterns=patterns))
+
+
+def test_teams_named_groups_with_extra_unnamed_group():
+    # (ESPN|FOX) prefix group would corrupt numbered captures — named groups win (#456)
+    resp = _run(
+        ExtractionPatterns(
+            teams_pattern=r"(ESPN|FOX): (?P<team1>.+?) vs (?P<team2>.+)",
+            teams_enabled=True,
+        ),
+        ["ESPN: Tigers vs Twins", "TNT: Lakers vs Bulls"],
+    )
+    assert resp.results[0].teams.matched is True
+    assert resp.results[0].teams.values == ["Tigers", "Twins"]
+    assert resp.results[1].teams.matched is False
+    assert resp.results[1].teams.values == []
+
+
+def test_teams_single_group_fails_pipeline():
+    # JS regex would highlight this as a match; pipeline requires BOTH teams
+    resp = _run(
+        ExtractionPatterns(teams_pattern=r"(?P<team1>\w+) game", teams_enabled=True),
+        ["Tigers game"],
+    )
+    assert resp.results[0].teams.matched is False
+
+
+def test_date_unparseable_fails():
+    resp = _run(
+        ExtractionPatterns(date_pattern=r"(?P<date>\d{2}\.\d{2}\.\d{4}\.\d+)", date_enabled=True),
+        ["Game 16.07.2026.999"],
+    )
+    assert resp.results[0].date.matched is False
+
+
+def test_date_parseable_returns_iso():
+    resp = _run(
+        ExtractionPatterns(date_pattern=r"(?P<date>\d{2}/\d{2}/\d{4})", date_enabled=True),
+        ["Tigers vs Twins 07/16/2026"],
+    )
+    assert resp.results[0].date.matched is True
+    assert resp.results[0].date.values == ["2026-07-16"]
+
+
+def test_disabled_fields_are_null():
+    resp = _run(
+        ExtractionPatterns(teams_pattern=r"(.+) vs (.+)", teams_enabled=True),
+        ["A vs B"],
+    )
+    r = resp.results[0]
+    assert r.teams is not None
+    assert r.date is None
+    assert r.time is None
+    assert r.league is None
+    assert r.fighters is None
+    assert r.event_name is None
+
+
+def test_invalid_regex_reported():
+    resp = _run(
+        ExtractionPatterns(teams_pattern=r"(unclosed", teams_enabled=True),
+        ["A vs B"],
+    )
+    assert "teams" in resp.pattern_errors
+    assert resp.results[0].teams.matched is False
+
+
+def test_month_day_without_date_toggle_warns():
+    resp = _run(
+        ExtractionPatterns(
+            month_pattern=r"(?P<month>\d{2})", month_enabled=True,
+            day_pattern=r"(?P<day>\d{2})", day_enabled=True,
+        ),
+        ["Game 07 16"],
+    )
+    assert resp.warnings
+    # Pipeline gate: date extraction never attempted without date_enabled
+    assert resp.results[0].date is None


### PR DESCRIPTION
Follow-up to #456 (bead teamarrv2-pxc5). The Pattern Tester ran only client-side JS regex, so patterns the Python pipeline would reject (one-of-two groups captured, unparseable dates, dialect differences) highlighted green.

- **Backend**: `POST /api/v1/groups/test-extraction` — single source of truth. Runs the same `extract_*_with_custom_regex` functions the matcher uses, on original stream names. Returns per-stream per-field `{matched, values}` (dates as ISO, times as HH:MM), explicit Python compile errors per pattern, and a warning when month/day patterns are enabled without the date toggle (pipeline gates all date extraction on it).
- **Frontend**: modal keeps instant JS highlighting; a 500 ms-debounced backend call adds a per-stream verdict badge — green `✓ pipeline` (hover shows extracted values) or amber `✗ teams, date` listing rejected fields. Stats bar gains pipeline extracted/rejected counts; banner surfaces compile errors and warnings; footer note updated.
- Tests: 7 endpoint tests incl. the #456 named-groups-with-extra-unnamed-group case, single-group rejection, unparseable vs parseable dates, invalid-regex reporting, month/day gate warning.
- Verified live via Playwright against the NBA group: matchup streams badge ✓ with correct captures; Summer League feeds badge ✗; invalid pattern shows both the JS and Python error banners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)