### PR TITLE
Racing EPG matching fixes from the Belgian GP weekend: programme dates, per-session plans, session scoping, archival rejection; loopback EPG resolution

### DIFF
--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -191,7 +191,9 @@ class StreamMatching:
         # curated channel fallback). Both are single scoped fetches.
         try:
             epg_data_list = self._dispatcharr_client.channels.get_epg_data_list()
-            stream_channels = self._dispatcharr_client.channels.get_stream_channel_map()
+            stream_channels, channel_by_uuid = (
+                self._dispatcharr_client.channels.get_channel_maps()
+            )
         except Exception as e:
             logger.warning("[EPG-MATCH] Failed to load EPG resolution data: %s", e)
             return None
@@ -201,7 +203,10 @@ class StreamMatching:
         # excluded so we never resolve a stream to our generated guide.
         active_source_ids = self._active_epg_source_ids()
         resolution, _stats = resolve_program_tvg_ids(
-            streams, epg_data_list, stream_channels, active_source_ids=active_source_ids
+            streams, epg_data_list, stream_channels,
+            active_source_ids=active_source_ids,
+            channel_by_uuid=channel_by_uuid,
+            own_source_id=self._own_epg_source_id(),
         )
 
         # Window mirrors the event match window so programs overlapping any
@@ -241,6 +246,21 @@ class StreamMatching:
             group.id, index.program_count(), len(index.tvg_ids()),
         )
         return index
+
+    def _own_epg_source_id(self) -> "int | None":
+        """The app's OWN configured EPG-source id (``dispatcharr_epg_id`` setting).
+
+        Resolved at runtime rather than assumed: name checks ("_Teamarr")
+        silently miss installs whose source was renamed.
+        """
+        try:
+            from teamarr.database.channels.settings_helpers import get_dispatcharr_settings
+
+            with self._db_factory() as conn:
+                return get_dispatcharr_settings(conn).get("epg_id")
+        except Exception as e:
+            logger.debug("[EPG-MATCH] could not resolve own epg_id setting: %s", e)
+            return None
 
     def _active_epg_source_ids(self) -> set[int] | None:
         """Enabled EPG-source ids for name/direct matching (excludes _Teamarr).

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -80,6 +80,9 @@ class StreamFetcher:
                     "name": s.name,
                     "tvg_id": s.tvg_id,
                     "tvg_name": s.tvg_name,
+                    # Loopback EPG resolution reads the source-channel uuid
+                    # out of Dispatcharr-proxy URLs (see epg_resolver).
+                    "url": s.url,
                     "channel_group": s.channel_group,
                     "channel_group_id": s.channel_group_id,
                     "m3u_account_id": s.m3u_account_id,

--- a/teamarr/consumers/matching/epg_resolver.py
+++ b/teamarr/consumers/matching/epg_resolver.py
@@ -142,12 +142,16 @@ def resolve_program_tvg_ids(
     # cascade.
     epgdata_by_id = {e["id"]: e for e in epg_data_list if e.get("id") is not None}
 
-    def _resolvable(ed: dict | None) -> bool:
+    def _resolved_tvg(ed: dict | None) -> str | None:
+        """The program tvg_id ``ed`` resolves to, or None if it must not resolve."""
         if not ed or not ed.get("tvg_id"):
-            return False
+            return None
         if own_source_id is not None and ed.get("epg_source") == own_source_id:
-            return False
-        return not str(ed["tvg_id"]).startswith(_SYNTHETIC_EVENT_TVG_PREFIXES)
+            return None
+        tvg = ed["tvg_id"]
+        if str(tvg).startswith(_SYNTHETIC_EVENT_TVG_PREFIXES):
+            return None
+        return tvg
 
     # Direct + name match only the ACTIVE imported EPG (honor enabled sources).
     if active_source_ids is not None:
@@ -180,9 +184,9 @@ def resolve_program_tvg_ids(
         ch = stream_channel_map.get(sid) if sid is not None else None
         if ch:
             eid = ch.get("effective_epg_data_id") or ch.get("epg_data_id")
-            ed = epgdata_by_id.get(eid)
-            if _resolvable(ed):
-                resolution[s_tvg] = ed["tvg_id"]
+            resolved = _resolved_tvg(epgdata_by_id.get(eid))
+            if resolved:
+                resolution[s_tvg] = resolved
                 stats["channel"] += 1
                 continue
 
@@ -192,9 +196,9 @@ def resolve_program_tvg_ids(
             ch = channel_by_uuid.get(m.group(1).lower()) if m else None
             if ch:
                 eid = ch.get("effective_epg_data_id") or ch.get("epg_data_id")
-                ed = epgdata_by_id.get(eid)
-                if _resolvable(ed):
-                    resolution[s_tvg] = ed["tvg_id"]
+                resolved = _resolved_tvg(epgdata_by_id.get(eid))
+                if resolved:
+                    resolution[s_tvg] = resolved
                     stats["loopback"] += 1
                     continue
 

--- a/teamarr/consumers/matching/epg_resolver.py
+++ b/teamarr/consumers/matching/epg_resolver.py
@@ -74,11 +74,29 @@ def normalize_channel_name(name: str) -> str:
     return re.sub(r"\s+", " ", n).strip()
 
 
+# Dispatcharr's own channel-proxy URL shape. A "Dispatcharr inside
+# Dispatcharr" loopback M3U emits one stream per channel whose URL is
+# /proxy/ts/stream/<channel uuid> — the uuid is the source channel's stable
+# identity, unlike the loopback stream's own id/tvg_id which churn on every
+# playlist refresh.
+_PROXY_STREAM_UUID = re.compile(
+    r"/proxy/ts/stream/([0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})"
+)
+
+# tvg_id prefixes of SYNTHETIC event-channel guide entries (ours and a
+# sibling apex/vroomarr install's). These are generated placeholder/event
+# guides, not real broadcast listings — resolving a stream to one must never
+# happen (see _resolvable below).
+_SYNTHETIC_EVENT_TVG_PREFIXES = ("teamarr-event-", "apex-event-")
+
+
 def resolve_program_tvg_ids(
     streams: list[dict],
     epg_data_list: list[dict],
     stream_channel_map: dict[int, dict],
     active_source_ids: set[int] | None = None,
+    channel_by_uuid: dict[str, dict] | None = None,
+    own_source_id: int | None = None,
 ) -> tuple[dict[str, str], dict[str, int]]:
     """Map each candidate stream's ``tvg_id`` -> an EPG-source ``tvg_id``.
 
@@ -113,8 +131,23 @@ def resolve_program_tvg_ids(
         program_tvg_id}`` and ``stats`` counts hits per strategy plus
         ``unresolved`` and ``ambiguous_name`` for logging/observability.
     """
-    # Channel curation is trusted against the FULL catalog (the user linked it).
+    # Channel curation is trusted against the FULL catalog (the user linked it)
+    # — with ONE exception: links to generated event-channel guides. Managed
+    # event channels carry a synthetic EPG, and each run consolidates matched
+    # streams into them as sources — so on the NEXT run those streams
+    # channel-resolve to a generated guide, which either yields no programmes
+    # (our own, excluded from the index) or all-day "Coming up: F1 Racing ..."
+    # placeholder blocks (a sibling install's) that bind the stream to every
+    # session of the named event. Generated-guide links don't terminate the
+    # cascade.
     epgdata_by_id = {e["id"]: e for e in epg_data_list if e.get("id") is not None}
+
+    def _resolvable(ed: dict | None) -> bool:
+        if not ed or not ed.get("tvg_id"):
+            return False
+        if own_source_id is not None and ed.get("epg_source") == own_source_id:
+            return False
+        return not str(ed["tvg_id"]).startswith(_SYNTHETIC_EVENT_TVG_PREFIXES)
 
     # Direct + name match only the ACTIVE imported EPG (honor enabled sources).
     if active_source_ids is not None:
@@ -132,7 +165,10 @@ def resolve_program_tvg_ids(
             name_to_tvgids.setdefault(norm, set()).add(tvg)
 
     resolution: dict[str, str] = {}
-    stats = {"channel": 0, "direct": 0, "name": 0, "unresolved": 0, "ambiguous_name": 0}
+    stats = {
+        "channel": 0, "loopback": 0, "direct": 0, "name": 0,
+        "unresolved": 0, "ambiguous_name": 0,
+    }
 
     for s in streams:
         s_tvg = s.get("tvg_id")
@@ -145,10 +181,22 @@ def resolve_program_tvg_ids(
         if ch:
             eid = ch.get("effective_epg_data_id") or ch.get("epg_data_id")
             ed = epgdata_by_id.get(eid)
-            if ed and ed.get("tvg_id"):
+            if _resolvable(ed):
                 resolution[s_tvg] = ed["tvg_id"]
                 stats["channel"] += 1
                 continue
+
+        # 1b. Loopback: the stream URL names its source channel by uuid.
+        if channel_by_uuid:
+            m = _PROXY_STREAM_UUID.search(s.get("url") or "")
+            ch = channel_by_uuid.get(m.group(1).lower()) if m else None
+            if ch:
+                eid = ch.get("effective_epg_data_id") or ch.get("epg_data_id")
+                ed = epgdata_by_id.get(eid)
+                if _resolvable(ed):
+                    resolution[s_tvg] = ed["tvg_id"]
+                    stats["loopback"] += 1
+                    continue
 
         # 2. Direct: the stream tvg_id is itself an active imported-EPG tvg_id.
         if s_tvg in epgdata_tvgids:
@@ -169,9 +217,9 @@ def resolve_program_tvg_ids(
         stats["unresolved"] += 1
 
     logger.info(
-        "[EPG-RESOLVE] resolved %d stream tvg_ids (channel=%d direct=%d name=%d "
-        "ambiguous_name=%d unresolved=%d)",
-        len(resolution), stats["channel"], stats["direct"], stats["name"],
-        stats["ambiguous_name"], stats["unresolved"],
+        "[EPG-RESOLVE] resolved %d stream tvg_ids (channel=%d loopback=%d direct=%d "
+        "name=%d ambiguous_name=%d unresolved=%d)",
+        len(resolution), stats["channel"], stats["loopback"], stats["direct"],
+        stats["name"], stats["ambiguous_name"], stats["unresolved"],
     )
     return resolution, stats

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -49,8 +49,8 @@ from teamarr.consumers.matching.result import (
     ResultAggregator,
 )
 from teamarr.consumers.matching.team_matcher import TeamMatcher
-from teamarr.consumers.racing_segments import nearest_session
 from teamarr.consumers.matching.tennis_matcher import TennisMatcher
+from teamarr.consumers.racing_segments import nearest_session
 from teamarr.consumers.stream_match_cache import (
     StreamMatchCache,
     get_generation_counter,

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -49,6 +49,7 @@ from teamarr.consumers.matching.result import (
     ResultAggregator,
 )
 from teamarr.consumers.matching.team_matcher import TeamMatcher
+from teamarr.consumers.racing_segments import nearest_session
 from teamarr.consumers.matching.tennis_matcher import TennisMatcher
 from teamarr.consumers.stream_match_cache import (
     StreamMatchCache,
@@ -804,8 +805,9 @@ class StreamMatcher:
         # event (e.g. a pre-game block + the game itself both pass the anchor
         # gate), we keep only the one whose start is nearest the event — the live
         # broadcast — giving a deterministic, correctly-anchored window (bead
-        # t5e). Different events on the same channel keep distinct keys.
-        best_by_event: dict[str | None, tuple[float, MatchOutcome, ClassifiedStream]] = {}
+        # t5e). Different events on the same channel keep distinct keys. Racing
+        # events key by (event id, session) instead — see the bucketing below.
+        best_by_event: dict[object, tuple[float, MatchOutcome, ClassifiedStream]] = {}
         league_event_type = self._get_dominant_event_type()
 
         # Full sorted timeline for this tvg_id. A linear channel legitimately
@@ -928,9 +930,25 @@ class StreamMatcher:
                     round(skew_s / 60),
                 )
                 # Keep the nearest-to-event program per event (live over pre-game).
-                prev = best_by_event.get(ev_id)
+                # Racing weekends are the exception: the guide carries one
+                # programme per SESSION (FP1, Qualifying, Race, ...) and every
+                # one of them matches the same event — keyed by event id alone
+                # they'd collapse to a single entry/window and the weekend's
+                # other session channels would never see this stream. Bucket
+                # racing programmes by (event, nearest session) instead, with
+                # skew measured against that session so "live over pre-game"
+                # still holds within each bucket.
+                key: object = ev_id
+                if getattr(ev, "sessions", None) and program.start_dt is not None:
+                    s_code, s_dist = nearest_session(
+                        ev, program.start_dt, self._sport_durations
+                    )
+                    if s_code is not None:
+                        key = (ev_id, s_code)
+                        skew_s = s_dist
+                prev = best_by_event.get(key)
                 if prev is None or skew_s < prev[0]:
-                    best_by_event[ev_id] = (skew_s, outcome, eff_classified)
+                    best_by_event[key] = (skew_s, outcome, eff_classified)
 
         plan = [(o, c) for _, o, c in best_by_event.values()]
         if programs:

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -939,7 +939,11 @@ class StreamMatcher:
                 # skew measured against that session so "live over pre-game"
                 # still holds within each bucket.
                 key: object = ev_id
-                if getattr(ev, "sessions", None) and program.start_dt is not None:
+                if (
+                    ev is not None
+                    and getattr(ev, "sessions", None)
+                    and program.start_dt is not None
+                ):
                     s_code, s_dist = nearest_session(
                         ev, program.start_dt, self._sport_durations
                     )

--- a/teamarr/consumers/matching/racing_matcher.py
+++ b/teamarr/consumers/matching/racing_matcher.py
@@ -15,20 +15,28 @@ Matching strategy:
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from rapidfuzz import fuzz
 
-from teamarr.consumers.matching.classifier import ClassifiedStream, StreamCategory
+from teamarr.consumers.matching.classifier import (
+    ClassifiedStream,
+    StreamCategory,
+    has_racing_text_evidence,
+)
 from teamarr.consumers.matching.result import (
     FailedReason,
     FilteredReason,
     MatchMethod,
     MatchOutcome,
 )
-from teamarr.consumers.racing_segments import get_session_times
+from teamarr.consumers.racing_segments import (
+    RACING_ANCHOR_TOLERANCE_SECONDS,
+    get_session_times,
+)
 from teamarr.consumers.stream_match_cache import StreamMatchCache, event_to_cache_data
 from teamarr.core.types import Event
 from teamarr.services.sports_data import SportsDataService
@@ -52,7 +60,31 @@ SINGLE_EVENT_SANITY_THRESHOLD = 50
 # to "the one race covering this date" regardless of what hour it airs — a
 # program landing hours away from every real session is not a broadcast of
 # that event.
-RACING_ANCHOR_TOLERANCE_SECONDS = 90 * 60
+# (Value lives in racing_segments, shared with EPG session scoping; re-exported
+# here for the anchor-gate usage below and existing importers.)
+
+# Plausible season years in stream/programme text (1950 — F1's first season —
+# through 2049). Deliberately NOT \d{4}: resolutions ("2160p"), bitrates and
+# channel numbers must not read as years.
+_YEAR_RE = re.compile(r"\b(19[5-9]\d|20[0-4]\d)\b")
+
+
+def _years_in_text(text: str) -> set[int]:
+    """All plausible season years mentioned in ``text``."""
+    return {int(m) for m in _YEAR_RE.findall(text)}
+
+
+def _augment_compounds(normalized: str) -> str:
+    """Append fused adjacent-token bigrams to a normalized string.
+
+    Guides and providers disagree on compound-word spelling ("Faith Fest
+    250" vs "FaithFest 250"), leaving token-based scoring with only the
+    tokens both spellings share. Adding each adjacent pair fused as an
+    extra token lets either spelling grow the other's compound form, so
+    the pair scores as related without loosening the threshold.
+    """
+    tokens = normalized.split()
+    return " ".join(tokens + [a + b for a, b in zip(tokens, tokens[1:])])
 
 
 @dataclass
@@ -124,7 +156,14 @@ class RacingMatcher:
         # Race-weekend streams carry the session's own date (e.g. "Sun 14 Jun"
         # for the race), which may differ from today's batch target_date.
         # Use that date to find the covering event/session when present.
-        match_date = classified.normalized.extracted_date or target_date
+        # EPG programmes rarely carry a date in their text, but always carry
+        # their broadcast instant — fall back to the programme's own date so
+        # a Friday session can bind as soon as the guide publishes it, rather
+        # than waiting for the run date to reach the race weekend. The
+        # anchor_dt gate below still enforces real session proximity.
+        match_date = classified.normalized.extracted_date
+        if match_date is None:
+            match_date = anchor_dt.astimezone(user_tz).date() if anchor_dt else target_date
 
         ctx = RacingMatchContext(
             stream_name=classified.normalized.original,
@@ -169,6 +208,27 @@ class RacingMatcher:
                 stream_id=stream_id,
                 detail=f"No {league} events covering {ctx.target_date}",
             )
+
+        # Season-year gate: text naming a year that isn't a candidate event's
+        # year is archival, not coverage. FAST channels air classic races
+        # around the current weekend ("2008 Belgian Grand Prix" started 33
+        # minutes into 2026 qualifying — inside anchor tolerance, carrying
+        # racing text evidence, and a near-perfect fuzzy match). A text with
+        # no year (the normal case) is unaffected; any mentioned year
+        # matching the event keeps it ("... Indycar 2026 (2026-07-19 ...)").
+        years = _years_in_text(ctx.stream_name)
+        if years:
+            window_events = [e for e in window_events if e.start_time.year in years]
+            if not window_events:
+                return MatchOutcome.failed(
+                    FailedReason.NO_RACING_MATCH,
+                    stream_name=ctx.stream_name,
+                    stream_id=stream_id,
+                    detail=(
+                        f"Text names year(s) {sorted(years)} matching no "
+                        f"{league} event covering {ctx.target_date} (archival?)"
+                    ),
+                )
 
         # EPG path only: further gate to events with a session actually airing
         # near the program's broadcast instant, not just sharing a date.
@@ -259,6 +319,14 @@ class RacingMatcher:
         if not self._covers_date(event, ctx.target_date, ctx.user_tz):
             return None
 
+        # Season-year gate, same as match(): a cached archival bind ("2008
+        # Belgian Grand Prix" cached before the gate existed) must not keep
+        # resurrecting through the cache.
+        years = _years_in_text(ctx.stream_name)
+        if years and event.start_time.year not in years:
+            self._cache.delete(ctx.group_id, ctx.stream_id, ctx.stream_name)
+            return None
+
         # EPG path only: cached match must still have a session airing near
         # this program's instant (see match()'s anchor_dt gate above).
         if ctx.anchor_dt is not None and not self._covers_instant(
@@ -291,6 +359,13 @@ class RacingMatcher:
         # unique-country fallback below (country-named streams, e.g.
         # "NASCAR Cup Series at Mexico City").
         stream_norm = normalize_text(ctx.stream_name)
+        # Compound-spelling tolerance: score the plain normalized forms AND
+        # bigram-augmented forms, taking the best. The augmented pass only
+        # ever helps when adjacent tokens fuse into the other side's
+        # compound spelling ("Faith Fest" -> "faithfest"); unrelated pairs
+        # score LOWER augmented (more non-shared tokens), and max() keeps
+        # their plain score, so no existing accept/reject flips.
+        stream_aug = _augment_compounds(stream_norm)
         best_score = 0
         best_event: Event | None = None
         country_scores: dict[str, float] = {}
@@ -299,7 +374,11 @@ class RacingMatcher:
             for candidate in (event.name, event.short_name, event.circuit_name):
                 if not candidate:
                     continue
-                score = fuzz.token_set_ratio(stream_norm, normalize_text(candidate))
+                cand_norm = normalize_text(candidate)
+                score = max(
+                    fuzz.token_set_ratio(stream_norm, cand_norm),
+                    fuzz.token_set_ratio(stream_aug, _augment_compounds(cand_norm)),
+                )
                 if score > best_score:
                     best_score = score
                     best_event = event
@@ -317,9 +396,19 @@ class RacingMatcher:
         # happening this weekend" purely by elimination. The country score
         # counts here: with one covering event there's no ambiguity for it
         # to create.
+        #
+        # The score alone isn't a reliable bar: generic venue words
+        # ("Speedway", "International Circuit", ...) can clear it on a
+        # single shared token with zero real connection to the event, so a
+        # stream also needs actual textual evidence it's the right racing
+        # series before Strategy 1 is allowed to fire.
         if len(events) == 1 and best_score < SINGLE_EVENT_SANITY_THRESHOLD:
             best_score = max(best_score, country_scores.get(events[0].id, 0))
-        if len(events) == 1 and best_score >= SINGLE_EVENT_SANITY_THRESHOLD:
+        if (
+            len(events) == 1
+            and best_score >= SINGLE_EVENT_SANITY_THRESHOLD
+            and has_racing_text_evidence(ctx.stream_name)
+        ):
             event = events[0]
             logger.debug(
                 "[MATCHED] racing stream=%s -> %s (method=direct, single event, score=%d)",

--- a/teamarr/consumers/matching/racing_matcher.py
+++ b/teamarr/consumers/matching/racing_matcher.py
@@ -84,7 +84,7 @@ def _augment_compounds(normalized: str) -> str:
     the pair scores as related without loosening the threshold.
     """
     tokens = normalized.split()
-    return " ".join(tokens + [a + b for a, b in zip(tokens, tokens[1:])])
+    return " ".join(tokens + [a + b for a, b in zip(tokens, tokens[1:], strict=False)])
 
 
 @dataclass

--- a/teamarr/consumers/racing_segments.py
+++ b/teamarr/consumers/racing_segments.py
@@ -38,6 +38,14 @@ _HYPERPOLE_RE = re.compile(
 )
 _PROLOGUE_RE = re.compile(r"prologue", re.IGNORECASE)
 
+# How far a broadcast instant may sit from a session's real [start, end]
+# window and still count as covering that session. 90 minutes accommodates
+# pre-session build-up coverage (a broadcast starting well before lights
+# out) without letting a program merely NAMING a racing series bind to a
+# session airing hours away. Shared by the racing matcher's EPG anchor gate
+# and the session-scoping logic below.
+RACING_ANCHOR_TOLERANCE_SECONDS = 90 * 60
+
 # Canonical session order, earliest to latest within a race weekend.
 SESSION_ORDER = [
     "fp1",
@@ -233,6 +241,33 @@ def _session_category_from_stream_name(stream_name: str) -> str | None:
     label = _isolate_stream_session_label(stream_name)
     if not label:
         return None
+    if category := _classify_session_label(label):
+        return category
+    # Fallback: the label isn't ENTIRELY a session type, but ENDS in one —
+    # e.g. NASCAR/TSN+'s "NASCAR Cup Series Qualifying" or "2026 NASCAR ORAP
+    # Series Qualifying", vs. tsdb/STAN's convention of the label being just
+    # "Qualifying" on its own (handled above).
+    if category := _session_category_from_trailing_keyword(label):
+        return category
+    # Apple-TV-PPV shape: "NEXT | BELGIUM: RACE | Sun 19 Jul ... | UK: ..."
+    # — the session name is a colon-VALUE in a middle segment, which the
+    # last-segment label isolation above never sees (live: dedicated
+    # "BELGIUM: RACE" streams fanned out onto the Qualifying channel). Scan
+    # every pipe segment's colon-separated fields with the ANCHORED
+    # classifiers only — the whole field must be a session name, so a
+    # session word merely embedded in branding text still doesn't count
+    # (no trailing-keyword fallback here).
+    for segment in stream_name.split("|"):
+        for field in segment.split(":", 1):
+            if category := _classify_session_label(field.strip()):
+                return category
+    return None
+
+
+def _classify_session_label(label: str) -> str | None:
+    """Anchored classification of a field that should BE a session name."""
+    if not label:
+        return None
     if category := _EXACT_SESSION_LABELS.get(label.lower()):
         return category
     if m := _FREE_PRACTICE_RE.match(label):
@@ -243,11 +278,7 @@ def _session_category_from_stream_name(stream_name: str) -> str | None:
         return "hyperpole"
     if _PROLOGUE_RE.search(label):
         return "prologue"
-    # Fallback: the label isn't ENTIRELY a session type, but ENDS in one —
-    # e.g. NASCAR/TSN+'s "NASCAR Cup Series Qualifying" or "2026 NASCAR ORAP
-    # Series Qualifying", vs. tsdb/STAN's convention of the label being just
-    # "Qualifying" on its own (handled above).
-    return _session_category_from_trailing_keyword(label)
+    return None
 
 
 def _session_in_category(session_code: str, category: str) -> bool:
@@ -317,6 +348,37 @@ def get_session_times(
     return event.start_time, event.start_time + timedelta(hours=duration)
 
 
+def nearest_session(
+    event: Event,
+    instant: datetime,
+    sport_durations: dict[str, float] | None = None,
+) -> tuple[str | None, float]:
+    """The session of ``event`` airing nearest ``instant``.
+
+    Distance is 0 inside a session's real [start, end] window, else the gap
+    to the nearest window edge, in seconds. Used to bucket EPG programmes by
+    the session they broadcast (a race weekend's guide carries one programme
+    per session, all matching the same event).
+
+    Returns:
+        (session_code, distance_seconds); (None, inf) when the event carries
+        no session data.
+    """
+    best_code: str | None = None
+    best_dist = float("inf")
+    for session in event.sessions or []:
+        start, end = get_session_times(event, session.code, sport_durations)
+        if start <= instant <= end:
+            dist = 0.0
+        elif instant < start:
+            dist = (start - instant).total_seconds()
+        else:
+            dist = (instant - end).total_seconds()
+        if dist < best_dist:
+            best_code, best_dist = session.code, dist
+    return best_code, best_dist
+
+
 def expand_racing_segments(
     matched_streams: list[dict],
     sport_durations: dict[str, float] | None = None,
@@ -362,8 +424,52 @@ def expand_racing_segments(
         stream_name = match.get("stream", {}).get("name") or ""
         if category := _session_category_from_stream_name(stream_name):
             scoped = [s for s in sessions if _session_in_category(s.code, category)]
-            if scoped:
-                sessions = scoped
+            # No session of the named category: providers list sessions the
+            # data source doesn't (ESPN's IndyCar events often carry only
+            # the race). A dedicated "Practice 1"/"Qualifying" feed must not
+            # fall back to the full fan-out and land on the Race channel —
+            # better no channel than the wrong one.
+            if not scoped:
+                logger.debug(
+                    "[RACING_SEGMENTS] Dropping '%s': names session category "
+                    "'%s' but event '%s' has no such session",
+                    stream_name[:60],
+                    category,
+                    event.name,
+                )
+                continue
+            sessions = scoped
+        elif match.get("match_method") == "epg" and match.get("epg_program_start") is not None:
+            # EPG-matched linear channel: the guide names the exact slot this
+            # stream airs, so scope to the session(s) that slot covers —
+            # PRACTICE INCLUDED. The generic practice exclusion below exists
+            # because a name-path stream's coverage is unknown; here the
+            # listing is positive evidence the channel airs this session.
+            prog_start = match["epg_program_start"]
+            prog_end = match.get("epg_program_end") or prog_start
+            overlapping = []
+            for s in sessions:
+                start, end = get_session_times(event, s.code, sport_durations)
+                if start <= prog_end and prog_start <= end:
+                    overlapping.append(s)
+            if not overlapping:
+                # Build-up coverage that ends before lights out (no overlap):
+                # the matcher's anchor gate already proved a session airs
+                # within tolerance of this slot — bind to the nearest one.
+                code, dist = nearest_session(event, prog_start, sport_durations)
+                if code is not None and dist <= RACING_ANCHOR_TOLERANCE_SECONDS:
+                    overlapping = [s for s in sessions if s.code == code]
+            if not overlapping:
+                logger.debug(
+                    "[RACING_SEGMENTS] Dropping '%s': EPG slot [%s..%s] covers "
+                    "no session of event '%s'",
+                    stream_name[:60],
+                    prog_start,
+                    prog_end,
+                    event.name,
+                )
+                continue
+            sessions = overlapping
         else:
             # Providers frequently don't carry a dedicated practice feed at
             # all (coverage often starts at qualifying), so a generic

--- a/teamarr/dispatcharr/managers/channels.py
+++ b/teamarr/dispatcharr/managers/channels.py
@@ -763,12 +763,26 @@ class ChannelManager:
             Dict mapping stream id -> channel dict (id, epg_data_id, etc.).
             A stream assigned to multiple channels keeps the last one seen.
         """
+        return self.get_channel_maps()[0]
+
+    def get_channel_maps(self) -> tuple[dict[int, dict], dict[str, dict]]:
+        """One paginated channel fetch -> (stream id -> channel, uuid -> channel).
+
+        Superset of ``get_stream_channel_map`` for callers that also need the
+        uuid index (loopback-stream EPG resolution: a Dispatcharr-loopback M3U
+        stream's URL names its source channel by uuid) without paying for a
+        second fetch. Uuid keys are lowercased.
+        """
         channels = self._client.paginated_get(
             "/api/channels/channels/?page_size=500",
             error_context="channels",
         )
-        mapping: dict[int, dict] = {}
+        stream_map: dict[int, dict] = {}
+        uuid_map: dict[str, dict] = {}
         for ch in channels:
             for stream_id in ch.get("streams") or []:
-                mapping[stream_id] = ch
-        return mapping
+                stream_map[stream_id] = ch
+            uuid = ch.get("uuid")
+            if uuid:
+                uuid_map[str(uuid).lower()] = ch
+        return stream_map, uuid_map

--- a/tests/epg/test_epg_resolver.py
+++ b/tests/epg/test_epg_resolver.py
@@ -191,3 +191,169 @@ def test_first_stream_wins_for_shared_tvg_id():
     epg = _epgdata([(100, "82547", "FS1 HD")])
     res, _ = resolve_program_tvg_ids(streams, epg, {})
     assert res == {"dup.us": "82547"}
+
+
+# ==================================================================== loopback
+
+
+_UUID = "523949c3-ac85-4c4a-baa7-bc9800000000"
+
+
+def _loopback_stream(sid=7, tvg="166", name="Sky Sports F1 HD", uuid=_UUID):
+    # A Dispatcharr-loopback M3U stream: tvg_id is the channel NUMBER (churns
+    # meaning), url names the source channel by its stable uuid.
+    return {
+        "id": sid,
+        "name": name,
+        "tvg_id": tvg,
+        "url": f"http://192.168.7.220:9191/proxy/ts/stream/{uuid}",
+    }
+
+
+def test_loopback_resolves_via_source_channel_uuid():
+    # Live case: the loopback stream is in NO channel, its tvg_id ("166", a
+    # channel number) exists in no guide, and its name is ambiguous across
+    # multiple guide entries — only the proxy URL identifies it.
+    streams = [_loopback_stream()]
+    epg = _epgdata([
+        (200, "87578", "Sky Sports F1 HD"),
+        (201, "131261", "Sky Sports F1 UHD"),
+    ])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {}, channel_by_uuid={_UUID: {"epg_data_id": 200}}
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1
+
+
+def test_loopback_survives_stream_id_churn():
+    # The loopback account recreates streams (new ids) on every refresh; the
+    # uuid in the URL is the stable identity, so resolution must not depend
+    # on the stream id appearing in the stream->channel map.
+    streams = [_loopback_stream(sid=999999)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {12345: {"epg_data_id": 200}},  # stale map, old id
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1
+
+
+def test_channel_membership_outranks_loopback():
+    streams = [_loopback_stream(sid=7)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD"), (300, "99999", "Other")])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {7: {"epg_data_id": 300}},
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+    )
+    assert res == {"166": "99999"}
+    assert stats["channel"] == 1 and stats["loopback"] == 0
+
+
+def test_loopback_uuid_lookup_is_case_insensitive():
+    streams = [_loopback_stream(uuid=_UUID.upper())]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {}, channel_by_uuid={_UUID: {"epg_data_id": 200}}
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1
+
+
+def test_unknown_uuid_falls_through_to_name_cascade():
+    # A proxy-shaped URL whose uuid isn't a known channel must not block the
+    # rest of the cascade.
+    streams = [_loopback_stream(uuid="00000000-0000-0000-0000-000000000000")]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {}, channel_by_uuid={_UUID: {"epg_data_id": 200}}
+    )
+    assert res == {"166": "87578"}
+    assert stats["name"] == 1
+
+
+def test_non_loopback_url_ignores_uuid_map():
+    streams = [{
+        "id": 7, "name": "Sky Sports F1 HD", "tvg_id": "sky.uk",
+        "url": "https://provider.example/live/user/pass/369549.ts",
+    }]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {}, channel_by_uuid={_UUID: {"epg_data_id": 200}}
+    )
+    assert res == {"sky.uk": "87578"}
+    assert stats["name"] == 1 and stats["loopback"] == 0
+
+
+# ===================================================== generated-guide poisoning
+
+
+def test_own_guide_channel_link_falls_through_to_loopback():
+    # Feedback loop (live, Belgian GP): a matched stream gets consolidated
+    # into the managed event channel it matched; next run the channel path
+    # resolves it to our OWN generated guide, whose programmes the index
+    # excludes — EPG matching dies for that stream forever. Own-guide links
+    # must not terminate the cascade.
+    streams = [_loopback_stream(sid=7)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    epg.append({"id": 900, "tvg_id": "teamarr-f1-race", "name": "F1: Belgian GP - Race",
+                "epg_source": 32})
+    res, stats = resolve_program_tvg_ids(
+        streams, epg,
+        {7: {"epg_data_id": 900}},          # membership in own event channel
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+        own_source_id=32,
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1 and stats["channel"] == 0
+
+
+def test_own_guide_link_still_trusted_when_own_source_unknown():
+    # Without own_source_id (back-compat), behavior is unchanged for
+    # non-synthetic tvg ids.
+    streams = [_loopback_stream(sid=7)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    epg.append({"id": 900, "tvg_id": "teamarr-f1-race", "name": "F1: Belgian GP - Race",
+                "epg_source": 32})
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {7: {"epg_data_id": 900}},
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+    )
+    assert res == {"166": "teamarr-f1-race"}
+    assert stats["channel"] == 1
+
+
+def test_sibling_event_guide_link_falls_through():
+    # Same poisoning via a sibling install writing to the same Dispatcharr:
+    # its event channels' synthetic guide airs all-day "Coming up: F1
+    # Racing ..." placeholder blocks that bind the stream to every session
+    # (live: TSN 5 landed on all five Belgian GP session channels). Synthetic
+    # event guides are identified by tvg prefix, regardless of source id.
+    streams = [_loopback_stream(sid=7)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    epg.append({"id": 950, "tvg_id": "apex-event-600057439-qualifying",
+                "name": "F1 | Belgian Grand Prix - Qualifying", "epg_source": 8})
+    res, stats = resolve_program_tvg_ids(
+        streams, epg,
+        {7: {"epg_data_id": 950}},          # membership in sibling's channel
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+        own_source_id=32,
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1 and stats["channel"] == 0
+
+
+def test_own_event_guide_prefix_blocked_even_without_source_id():
+    # Our own event-channel tvg prefix is synthetic by construction — blocked
+    # by prefix even when the own source id could not be resolved.
+    streams = [_loopback_stream(sid=7)]
+    epg = _epgdata([(200, "87578", "Sky Sports F1 HD")])
+    epg.append({"id": 960, "tvg_id": "teamarr-event-600057439-race",
+                "name": "F1 | Belgian Grand Prix - Race", "epg_source": 32})
+    res, stats = resolve_program_tvg_ids(
+        streams, epg, {7: {"epg_data_id": 960}},
+        channel_by_uuid={_UUID: {"epg_data_id": 200}},
+    )
+    assert res == {"166": "87578"}
+    assert stats["loopback"] == 1 and stats["channel"] == 0

--- a/tests/lifecycle/test_stream_account_name.py
+++ b/tests/lifecycle/test_stream_account_name.py
@@ -105,6 +105,7 @@ def _fake_stream(sid, name, account_id):
         name=name,
         tvg_id=None,
         tvg_name=None,
+        url=None,
         channel_group="G",
         channel_group_id=7,
         m3u_account_id=account_id,

--- a/tests/matching/test_racing.py
+++ b/tests/matching/test_racing.py
@@ -7,6 +7,7 @@ regression-prone path (cf. #157): a team-sport stream that leaks into a
 racing-dominant group must NOT be hijacked as a race.
 """
 
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
@@ -26,6 +27,7 @@ from teamarr.consumers.racing_segments import (
     _session_duration_hours,
     _session_in_category,
     expand_racing_segments,
+    nearest_session,
 )
 from teamarr.services.detection_keywords import DetectionKeywordService
 
@@ -840,14 +842,18 @@ def test_expand_racing_segments_scopes_unnumbered_trailing_practice_stream():
     assert [m["segment"] for m in out] == ["practice"]
 
 
-def test_expand_racing_segments_falls_back_when_no_session_of_the_category_exists():
-    # Defensive: a hint that doesn't match anything in THIS event's sessions
-    # must not silently produce zero segments for a real matched stream.
+def test_expand_racing_segments_drops_stream_when_no_session_of_the_category_exists():
+    # Live false positive (Grand Prix of Nashville, 2026-07-17): ESPN's
+    # IndyCar events carry only the race session, so dedicated "Practice 1:"
+    # and "Qualifying:" streams found no session of their category and the
+    # old fallback fanned them out to everything — all three landed as
+    # sources on the Race channel. A stream that names a session category
+    # the event doesn't have must be dropped, not rebound to other sessions.
     sessions = [s for s in _wec_sessions() if s.code != "fp3"]
     matched = [{"stream": {"id": 1, "name": "AU (STAN) | Free Practice 3: 6 Hours of Sao Paulo"},
                 "event": _wec_event(sessions)}]
     out = expand_racing_segments(matched)
-    assert len(out) == len(sessions)
+    assert out == []
 
 
 def test_expand_racing_segments_produces_no_channel_when_only_practice_exists():
@@ -861,3 +867,347 @@ def test_expand_racing_segments_produces_no_channel_when_only_practice_exists():
     matched = [{"stream": {"id": 1, "name": "TSN+ 016"}, "event": _wec_event(sessions)}]
     out = expand_racing_segments(matched)
     assert out == []
+
+
+# ---------------------------------------------------------------------------
+# RacingMatcher EPG-path match date: a programme's own broadcast date, not the
+# run's target_date, decides which race weekend it can bind to.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRacingEvent:
+    """dataclass (not SimpleNamespace) so _cache_result's asdict() works."""
+
+    id: str
+    name: str
+    short_name: str
+    circuit_name: str
+    league: str
+    sport: str
+    start_time: datetime
+    sessions: list
+    venue: object = None
+
+
+class _FakeMatchCache:
+    def __init__(self):
+        self.set_calls = []
+
+    def get(self, *args, **kwargs):
+        return None
+
+    def touch(self, *args, **kwargs):
+        pass
+
+    def delete(self, *args, **kwargs):
+        pass
+
+    def set(self, **kwargs):
+        self.set_calls.append(kwargs)
+
+
+class _FakeSportsService:
+    def __init__(self, events):
+        self._events = events
+        self.requested_dates = []
+
+    def get_provider_name(self, league):
+        return "espn"
+
+    def get_events(self, league, target_date, cache_only=False):
+        self.requested_dates.append(target_date)
+        return self._events
+
+
+def _racing_session2(code, start_time):
+    return SimpleNamespace(code=code, start_time=start_time)
+
+
+def _belgian_gp():
+    fp1 = datetime(2026, 7, 17, 11, 30, tzinfo=UTC)
+    race = datetime(2026, 7, 19, 13, 0, tzinfo=UTC)
+    return _FakeRacingEvent(
+        id="espn_f1_belgium_2026",
+        name="Belgian Grand Prix",
+        short_name="Belgian Grand Prix",
+        circuit_name="Circuit de Spa-Francorchamps",
+        league="f1",
+        sport="racing",
+        start_time=fp1,
+        sessions=[_racing_session2("fp1", fp1), _racing_session2("race", race)],
+    )
+
+
+def _match_belgian_gp(anchor_dt):
+    event = _belgian_gp()
+    service = _FakeSportsService([event])
+    matcher = RacingMatcher(service=service, cache=_FakeMatchCache())
+    classified = classify_stream(
+        "Formula 1 | Belgian Grand Prix: 1st Practice", league_event_type="event"
+    )
+    assert classified.category == StreamCategory.RACING_EVENT
+    assert classified.normalized.extracted_date is None  # premise: no date in text
+    outcome = matcher.match(
+        classified=classified,
+        league="f1",
+        target_date=date(2026, 7, 16),  # Thursday's run, weekend starts Friday
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("America/Chicago"),
+        anchor_dt=anchor_dt,
+    )
+    return outcome, service
+
+
+def test_epg_programme_matches_by_its_own_broadcast_date():
+    # Friday 11:00 UTC guide slot, 30 min before FP1 — inside anchor tolerance.
+    outcome, service = _match_belgian_gp(anchor_dt=datetime(2026, 7, 17, 11, 0, tzinfo=UTC))
+    assert outcome.is_matched and outcome.event.id == "espn_f1_belgium_2026"
+    # Events were fetched for the programme's date, not the run's.
+    assert service.requested_dates == [date(2026, 7, 17)]
+
+
+def test_name_path_still_uses_run_target_date():
+    # Without an anchor (plain stream-name path) the old fallback holds: the
+    # Thursday run date isn't covered by the weekend, so no match yet.
+    outcome, service = _match_belgian_gp(anchor_dt=None)
+    assert not outcome.is_matched
+    assert service.requested_dates == [date(2026, 7, 16)]
+
+
+# ---------------------------------------------------------------------------
+# expand_racing_segments: EPG-matched entries scope by their programme slot
+# ---------------------------------------------------------------------------
+
+
+def _belgian_sessions():
+    return [
+        SimpleNamespace(code="fp1", name="Practice 1",
+                        start_time=datetime(2026, 7, 17, 11, 30, tzinfo=UTC)),
+        SimpleNamespace(code="fp2", name="Practice 2",
+                        start_time=datetime(2026, 7, 17, 15, 0, tzinfo=UTC)),
+        SimpleNamespace(code="qualifying", name="Qualifying",
+                        start_time=datetime(2026, 7, 18, 14, 0, tzinfo=UTC)),
+        SimpleNamespace(code="race", name="Race",
+                        start_time=datetime(2026, 7, 19, 13, 0, tzinfo=UTC)),
+    ]
+
+
+def _epg_entry(prog_start, prog_end):
+    return {
+        "stream": {"id": 1, "name": "Sky Sports F1 HD"},
+        "event": _wec_event(_belgian_sessions()),
+        "match_method": "epg",
+        "epg_program_start": prog_start,
+        "epg_program_end": prog_end,
+    }
+
+
+def test_epg_entry_scopes_to_practice_session_its_programme_covers():
+    # "Live: Formula 1 | Belgian Grand Prix: 1st Practice" 11:00–12:55 UTC.
+    out = expand_racing_segments([_epg_entry(
+        datetime(2026, 7, 17, 11, 0, tzinfo=UTC),
+        datetime(2026, 7, 17, 12, 55, tzinfo=UTC),
+    )])
+    assert [m["segment"] for m in out] == ["fp1"]
+
+
+def test_epg_entry_scopes_to_race_for_race_slot():
+    out = expand_racing_segments([_epg_entry(
+        datetime(2026, 7, 19, 12, 30, tzinfo=UTC),
+        datetime(2026, 7, 19, 15, 30, tzinfo=UTC),
+    )])
+    assert [m["segment"] for m in out] == ["race"]
+
+
+def test_epg_buildup_programme_binds_to_nearest_session_within_tolerance():
+    # Pre-race build-up that ENDS before lights out (no window overlap) —
+    # the anchor gate admitted it, so it binds to the nearest session.
+    out = expand_racing_segments([_epg_entry(
+        datetime(2026, 7, 19, 11, 30, tzinfo=UTC),
+        datetime(2026, 7, 19, 12, 50, tzinfo=UTC),
+    )])
+    assert [m["segment"] for m in out] == ["race"]
+
+
+def test_epg_entry_covering_no_session_is_dropped():
+    # A slot hours from every session (stale plan entry): no channel at all
+    # beats a wrong one.
+    out = expand_racing_segments([_epg_entry(
+        datetime(2026, 7, 18, 2, 0, tzinfo=UTC),
+        datetime(2026, 7, 18, 3, 0, tzinfo=UTC),
+    )])
+    assert out == []
+
+
+def test_name_path_generic_stream_still_excludes_practice():
+    # Non-EPG entry (no match_method/window): generic fan-out minus practice,
+    # unchanged.
+    entry = {
+        "stream": {"id": 1, "name": "Sky Sports F1 HD"},
+        "event": _wec_event(_belgian_sessions()),
+    }
+    out = expand_racing_segments([entry])
+    assert {m["segment"] for m in out} == {"qualifying", "race"}
+
+
+def test_nearest_session_inside_window_is_zero_distance():
+    event = _wec_event(_belgian_sessions())
+    code, dist = nearest_session(event, datetime(2026, 7, 17, 11, 45, tzinfo=UTC))
+    assert code == "fp1" and dist == 0.0
+
+
+def test_nearest_session_picks_closest_edge():
+    event = _wec_event(_belgian_sessions())
+    # 14:40 UTC Friday: FP1 ended 12:30 (7800s away), FP2 starts 15:00 (1200s).
+    code, dist = nearest_session(event, datetime(2026, 7, 17, 14, 40, tzinfo=UTC))
+    assert code == "fp2" and dist == 1200.0
+
+
+def test_nearest_session_no_sessions():
+    event = _wec_event([])
+    code, dist = nearest_session(event, datetime(2026, 7, 17, 11, 45, tzinfo=UTC))
+    assert code is None and dist == float("inf")
+
+
+# ---------------------------------------------------------------------------
+# Session scoping: Apple-TV-PPV "<tag> | <COUNTRY>: <SESSION> | ..." names
+# ---------------------------------------------------------------------------
+
+
+class TestColonValueSessionLabels:
+    def test_apple_tv_race_stream_scopes_to_race(self):
+        assert _session_category_from_stream_name(
+            "NEXT | BELGIUM: RACE | Sun 19 Jul 11:50 UTC (UK) | 8K EXCLUSIVE "
+            "| UK: APPLE TV F1 PPV 1"
+        ) == "race"
+
+    def test_apple_tv_sprint_stream_scopes_to_sprint(self):
+        assert _session_category_from_stream_name(
+            "NEXT | NETHERLANDS: SPRINT | Sat 22 Aug 09:15 UTC (UK) | 8K EXCLUSIVE "
+            "| UK: APPLE TV F1 PPV 3"
+        ) == "sprint"
+
+    def test_session_word_embedded_in_branding_does_not_count(self):
+        # "RACING"/"Race" inside branding text is not an anchored field match.
+        assert _session_category_from_stream_name(
+            "UK ★ SKY SPORTS F1 RACING HD"
+        ) is None
+        assert _session_category_from_stream_name(
+            "US: Racecourse Network | Live: Horse Coverage"
+        ) is None
+
+    def test_timestamp_colons_do_not_confuse_field_scan(self):
+        # "11:50" splits into non-session fields; a generic linear name with
+        # times must keep the full fan-out.
+        assert _session_category_from_stream_name(
+            "HBO UK 065 | Live 11:50 | Grand Prix Coverage"
+        ) is None
+
+
+def test_expand_scopes_apple_tv_race_stream_to_race_only():
+    # Live: "NEXT | BELGIUM: RACE ..." PPV streams (name-path matches) were
+    # fanned out generically and landed as full-life sources on the
+    # Qualifying channel too.
+    entry = {
+        "stream": {"id": 1, "name": "NEXT | BELGIUM: RACE | Sun 19 Jul 11:50 UTC (UK) "
+                   "| 8K EXCLUSIVE | UK: APPLE TV F1 PPV 1"},
+        "event": _wec_event(_belgian_sessions()),
+    }
+    out = expand_racing_segments([entry])
+    assert [m["segment"] for m in out] == ["race"]
+
+
+# ---------------------------------------------------------------------------
+# RacingMatcher season-year gate: archival replays name the wrong year
+# ---------------------------------------------------------------------------
+
+
+def _match_named_stream(name, anchor_dt):
+    event = _belgian_gp()
+    service = _FakeSportsService([event])
+    matcher = RacingMatcher(service=service, cache=_FakeMatchCache())
+    classified = classify_stream(name, league_event_type="event")
+    assert classified.category == StreamCategory.RACING_EVENT
+    return matcher.match(
+        classified=classified,
+        league="f1",
+        target_date=date(2026, 7, 19),
+        group_id=1,
+        stream_id=1,
+        generation=1,
+        user_tz=ZoneInfo("America/Chicago"),
+        anchor_dt=anchor_dt,
+    )
+
+
+def test_archival_replay_naming_old_year_is_rejected():
+    # Live (Plex FAST "F1 Channel"): "2008 Belgian Grand Prix" aired 33 min
+    # into 2026 qualifying — inside anchor tolerance, racing text evidence,
+    # near-perfect fuzzy score. The year is the tell.
+    out = _match_named_stream(
+        "2008 Belgian Grand Prix", datetime(2026, 7, 19, 13, 33, tzinfo=UTC)
+    )
+    assert not out.is_matched
+    assert "archival" in (out.detail or "")
+
+
+def test_last_years_replay_is_rejected():
+    out = _match_named_stream(
+        "F1 2025 Belgium Grand Prix", datetime(2026, 7, 19, 13, 33, tzinfo=UTC)
+    )
+    assert not out.is_matched
+
+
+def test_current_year_in_text_still_matches():
+    out = _match_named_stream(
+        "Formula 1 2026: Belgian Grand Prix Race", datetime(2026, 7, 19, 13, 0, tzinfo=UTC)
+    )
+    assert out.is_matched
+
+
+def test_no_year_in_text_is_unaffected():
+    out = _match_named_stream(
+        "Live: Formula 1 | Belgian Grand Prix: Race", datetime(2026, 7, 19, 13, 0, tzinfo=UTC)
+    )
+    assert out.is_matched
+
+
+def test_resolution_tokens_do_not_read_as_years():
+    # "2160P" must not be treated as a season year and veto the match.
+    out = _match_named_stream(
+        "NOW: BELGIAN GRAND PRIX RACE 2160P", datetime(2026, 7, 19, 13, 0, tzinfo=UTC)
+    )
+    assert out.is_matched
+
+
+# ---------------------------------------------------------------------------
+# Compound-word spelling tolerance in fuzzy scoring
+# ---------------------------------------------------------------------------
+
+
+def test_compound_spelling_mismatch_still_matches():
+    # Live (NASCAR Trucks, FaithFest 250): the guide writes "Faith Fest 250"
+    # but the provider event is "FaithFest 250 presented by Mercer
+    # Transportation" — plain token scoring shares only "250" and lands under
+    # the 50 sanity threshold, so the qualifying broadcast never matched.
+    a = _event("a", "FaithFest 250 presented by Mercer Transportation",
+               circuit="North Wilkesboro Speedway")
+    out = _matcher()._match_to_event(
+        _ctx("NASCAR Craftsman Truck Series | Faith Fest 250, Qualifying"),
+        [a], "nascar-truck",
+    )
+    assert out.is_matched and out.event.id == "a"
+
+
+def test_unrelated_stream_still_rejected_with_augmentation():
+    # The augmented pass must not rescue unrelated pairs: same FIM Speedway
+    # guard as above, still rejected.
+    a = _event("a", "Focused Health 250", circuit="Atlanta Motor Speedway")
+    out = _matcher()._match_to_event(
+        _ctx("HBO UK 047 | Malilla - FIM Speedway GP | Round 6 | Malilla"),
+        [a], "nascar-xfinity",
+    )
+    assert not out.is_matched

--- a/tests/test_group_pattern.py
+++ b/tests/test_group_pattern.py
@@ -75,6 +75,7 @@ def _stream(sid, name, account=7):
         name=name,
         tvg_id=None,
         tvg_name=None,
+        url=None,
         channel_group=None,
         channel_group_id=None,
         m3u_account_id=account,

--- a/uv.lock
+++ b/uv.lock
@@ -615,7 +615,7 @@ wheels = [
 
 [[package]]
 name = "teamarr"
-version = "2.11.1"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Ports a weekend's worth of live-verified racing/EPG matching fixes from my apex fork, all found and validated during the 2026 Belgian GP + IndyCar Nashville + NASCAR Trucks weekend (2026-07-17). Follow-up to #394/#405. Every fix below shipped on my production instance first; the "live" notes are actual observed failures, not hypotheticals.

## Commit 1 — Racing EPG matching (racing_matcher, racing_segments, matcher)

- **Programme-date matching**: EPG programmes carry no date in their text, so the racing matcher matched them against the *run's* target date — Friday's "Belgian Grand Prix: 1st Practice" listing stayed unmatched until the run date reached the weekend. The EPG path always has the programme's broadcast instant, so its own date is now the fallback. Name-path behavior unchanged (regression test included).
- **Per-session plan buckets**: `_compute_epg_plan` kept one programme per *event*, but a race weekend's guide has one programme per *session*, all matching the same event — FP1/FP2/Quali/Race collapsed to a single entry/window. Racing entries now bucket by (event, nearest session).
- **Programme-slot session scoping**: EPG-matched linear channels took the generic fan-out (which excludes practice), so FP1 aired with no channel despite the guide naming it. EPG entries now scope to the session(s) their programme slot covers — practice included, since the listing is positive evidence of coverage.
- **Session-named streams with no such session are dropped**: ESPN's IndyCar events carry only the race session; dedicated "Practice 1:"/"Qualifying:" feeds fell back to the full fan-out and landed on the Race channel. Also handles Apple-TV-PPV names ("NEXT | BELGIUM: RACE | …") where the session is a colon-value in a middle segment — those race feeds were landing on the Qualifying channel.
- **Archival-replay rejection**: Plex's FAST "F1 Channel" aired *2008 Belgian Grand Prix* 33 minutes into 2026 qualifying — inside anchor tolerance, with racing text evidence and a near-perfect fuzzy score. A year in the text that matches no candidate event's year now rejects the match (and invalidates stale cache entries). 1950–2049 only, so "2160P" never reads as a year.
- **Compound-spelling tolerance**: guide "Faith **Fest** 250" vs event "**FaithFest** 250 presented by Mercer Transportation" shared only "250" (46.6 < the 50 sanity threshold), so the Trucks qualifying broadcast never matched. Scoring now also compares bigram-augmented forms (adjacent tokens fused) and takes the max; unrelated pairs score *lower* augmented, so nothing previously rejected flips.
- **Strategy-1 text-evidence gate**: single-covering-event matches now also require `has_racing_text_evidence`, not just a score — generic venue words ("Speedway") could clear the sanity threshold on one shared token (live: a FIM Speedway GP stream binding to NASCAR's Atlanta event). This was already in apex but had never been upstreamed.

## Commit 2 — EPG resolver: loopback streams + generated-guide poisoning

- **Loopback-stream resolution**: a "Dispatcharr inside Dispatcharr" M3U (one stable stream per curated channel — one match entry per event instead of dozens of provider duplicates) was unreachable by all three resolver paths: the tvg_id is a channel *number*, names are ambiguous across guides, and channel-membership curation dies on every refresh because the loopback account recreates its streams with new ids. The stream's URL (`/proxy/ts/stream/<channel uuid>`) is its stable identity; new step 1b resolves that uuid to the source channel's EPG link. The uuid map rides on the existing paginated channel fetch — zero extra API calls.
- **Own-guide poisoning**: a stream that EPG-matches gets consolidated into the managed event channel it matched; next run the channel path resolves it to our own generated guide (whose programmes the index excludes) and the stream never matches again. Own source is identified by the `dispatcharr_epg_id` setting rather than the `"_Teamarr"` name (which misses renamed sources). Own-guide links now fall through the cascade.
- **Sibling-install poisoning**: an apex/vroomarr install writing to the same Dispatcharr has the same effect with worse symptoms — its synthetic guide airs all-day "Coming up: F1 Racing …" placeholder blocks, which bound TSN 5 (a qualifying+race broadcaster) to all five Belgian GP session channels. Synthetic event guides are recognized by their code-controlled tvg prefixes (`teamarr-event-`, `apex-event-`) regardless of source id.

## Tests

Full suite: **1990 passed** on this branch. ~35 new tests covering every fix above, each documenting the live failure it pins.

I'm aware of the ongoing discussion about motorsports scope — happy to split this PR (the commit-2 resolver fixes are general EPG matching, not racing-specific) if that makes review or any future extraction easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168e49DmKeWX9cDEyDk6xuF
