### PR TITLE
fix: TSDB season-format retry for calendar-year leagues (pgtq.5, #60)

### DIFF
--- a/teamarr/providers/tsdb/client.py
+++ b/teamarr/providers/tsdb/client.py
@@ -517,6 +517,32 @@ class TSDBClient(BaseHTTPClient):
         """eventsnextleague.php by raw league ID, no DB mapping."""
         return self._request("eventsnextleague.php", {"id": league_id})
 
+    def _season_candidates(self, league: str) -> list[str]:
+        """Season strings to try, most likely format first (#60 pgtq.5).
+
+        TSDB's season format varies by league WITHIN a sport: Brazilian
+        state championships and Scandinavian soccer run calendar years
+        ("2026") while European soccer runs fall-spring ("2025-2026").
+        Callers try candidates in order and fall through on empty, so a
+        wrong first guess costs one extra request and self-heals instead
+        of silently returning 0 events.
+        """
+        from datetime import date
+
+        today = date.today()
+        calendar = str(today.year)
+        if today.month < 8:
+            fall_spring = f"{today.year - 1}-{today.year}"
+        else:
+            fall_spring = f"{today.year}-{today.year + 1}"
+
+        sport = (self.get_sport(league) or "").lower()
+        if sport in ("cricket", "boxing", "soccer"):
+            # TSDB's soccer set skews calendar-year (Brazilian state,
+            # Scandinavian); European fall-spring soccer is served by ESPN.
+            return [calendar, fall_spring]
+        return [fall_spring, calendar]
+
     def get_events_by_season(self, league: str, season: str | None = None) -> dict | None:
         """Fetch all events for a league season.
 
@@ -525,6 +551,9 @@ class TSDBClient(BaseHTTPClient):
         (e.g., Unrivaled). Replaces the former eventsround.php path, which
         TheSportsDB has removed — it returns 404 for every league, including
         TSDB's own documented examples (see GH #217).
+
+        Without an explicit season, both season formats are tried in
+        likelihood order (see _season_candidates) — first non-empty wins.
 
         Args:
             league: Canonical league code
@@ -537,21 +566,27 @@ class TSDBClient(BaseHTTPClient):
         if not league_id:
             return None
 
-        if not season:
-            # Use current year for calendar-year leagues
-            season = str(date.today().year)
+        candidates = [season] if season else self._season_candidates(league)
 
-        cache_key = make_cache_key("tsdb", "eventsseason", league, season)
-        cached = self._cache.get(cache_key)
-        if cached is not None:
-            logger.debug("[TSDB] Cache hit: %s", cache_key)
-            return cached
+        last_result: dict | None = None
+        for s in candidates:
+            cache_key = make_cache_key("tsdb", "eventsseason", league, s)
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                logger.debug("[TSDB] Cache hit: %s", cache_key)
+                if cached.get("events"):
+                    return cached
+                last_result = cached
+                continue  # cached-empty: try the other format, don't re-request
 
-        result = self._request("eventsseason.php", {"id": league_id, "s": season})
-        if result:
-            # Cache for 2 hours (same as eventsday)
-            self._cache.set(cache_key, result, 2 * 60 * 60)
-        return result
+            result = self._request("eventsseason.php", {"id": league_id, "s": s})
+            if result:
+                # Cache for 2 hours (same as eventsday)
+                self._cache.set(cache_key, result, 2 * 60 * 60)
+            if result and result.get("events"):
+                return result
+            last_result = result or last_result
+        return last_result
 
     def get_team_next_events(self, team_id: str) -> dict | None:
         """Fetch upcoming events for a team.
@@ -633,10 +668,12 @@ class TSDBClient(BaseHTTPClient):
 
         Args:
             league: Canonical league code
-            season: Season string. Format varies by sport:
-                    - Hockey: "2024-2025" (fall-spring)
-                    - Cricket: "2024" (calendar year)
-                    - Boxing: "2024" (calendar year)
+            season: Season string. Format varies BY LEAGUE, not just sport
+                    (#60): "2024-2025" fall-spring vs "2024" calendar year.
+                    When omitted, both formats are tried in likelihood order
+                    (see _season_candidates) — Brazilian state championships
+                    previously got a fall-spring guess, returned 0 events,
+                    and silently capped team discovery at 10.
 
         Returns:
             Raw TSDB response or None
@@ -645,26 +682,15 @@ class TSDBClient(BaseHTTPClient):
         if not league_id:
             return None
 
-        if not season:
-            from datetime import date
+        candidates = [season] if season else self._season_candidates(league)
 
-            year = date.today().year
-            month = date.today().month
-            sport = self.get_sport(league).lower()
-
-            # Different sports use different season formats
-            if sport in ("cricket", "boxing"):
-                # Calendar year seasons
-                season = str(year)
-            else:
-                # Fall-spring seasons (hockey, etc.)
-                # Use previous year if before August
-                if month < 8:
-                    season = f"{year - 1}-{year}"
-                else:
-                    season = f"{year}-{year + 1}"
-
-        return self._request("eventsseason.php", {"id": league_id, "s": season})
+        last_result: dict | None = None
+        for s in candidates:
+            result = self._request("eventsseason.php", {"id": league_id, "s": s})
+            if result and result.get("events"):
+                return result
+            last_result = result or last_result
+        return last_result
 
     def get_teams_in_league(self, league: str) -> dict | None:
         """Get all teams in a league.

--- a/tests/providers/test_tsdb.py
+++ b/tests/providers/test_tsdb.py
@@ -392,3 +392,86 @@ def test_premium_tsdb_leagues_query():
     # The known premium-tier codes are present; free-tier ones are not.
     assert set(PREMIUM).issubset(premium)
     assert premium.isdisjoint(FREE)
+
+
+# ---------------------------------------------------------------------------
+# Season format candidates + retry-on-empty (#60, bead pgtq.5)
+# ---------------------------------------------------------------------------
+
+
+def _season_client(sport: str):
+    """TSDBClient with league lookups and transport stubbed for season tests."""
+    from unittest.mock import MagicMock
+
+    from teamarr.providers.tsdb.client import TSDBClient
+
+    client = TSDBClient.__new__(TSDBClient)
+    client.get_league_id = MagicMock(return_value="5766")
+    client.get_sport = MagicMock(return_value=sport)
+    client._cache = MagicMock()
+    client._cache.get.return_value = None
+    client._request = MagicMock()
+    return client
+
+
+class TestSeasonCandidates:
+    def test_soccer_tries_calendar_year_first(self):
+        client = _season_client("soccer")
+        candidates = client._season_candidates("bra.camp.paranaense")
+        assert candidates[0].isdigit()  # "2026"
+        assert "-" in candidates[1]  # "2025-2026"
+
+    def test_hockey_tries_fall_spring_first(self):
+        client = _season_client("hockey")
+        candidates = client._season_candidates("some.league")
+        assert "-" in candidates[0]
+        assert candidates[1].isdigit()
+
+    def test_get_season_events_retries_alternate_format_on_empty(self):
+        # Brazilian league: calendar-year first; simulate TSDB having data
+        # only under the second candidate to prove the fall-through fires
+        client = _season_client("hockey")  # fall-spring first = wrong guess
+        empty = {"events": None}
+        good = {"events": [{"idEvent": "1"}]}
+        client._request.side_effect = [empty, good]
+
+        result = client.get_season_events("bra.camp.paranaense")
+
+        assert result is good
+        assert client._request.call_count == 2
+        seasons = [c.args[1]["s"] for c in client._request.call_args_list]
+        assert "-" in seasons[0] and seasons[1].isdigit()
+
+    def test_get_season_events_explicit_season_single_request(self):
+        client = _season_client("soccer")
+        client._request.return_value = {"events": None}
+
+        client.get_season_events("bra.camp.paranaense", season="2024")
+
+        client._request.assert_called_once()
+        assert client._request.call_args.args[1]["s"] == "2024"
+
+    def test_get_events_by_season_first_format_hit_stops(self):
+        client = _season_client("soccer")
+        client._request.return_value = {"events": [{"idEvent": "1"}]}
+
+        result = client.get_events_by_season("bra.camp.paranaense")
+
+        assert result["events"]
+        client._request.assert_called_once()
+        assert client._request.call_args.args[1]["s"].isdigit()
+
+    def test_get_events_by_season_cached_empty_skips_to_alternate(self):
+        # A fresh cached-empty for the first format must not re-request it —
+        # only the alternate format goes to the API
+        client = _season_client("soccer")
+        empty = {"events": None}
+        good = {"events": [{"idEvent": "1"}]}
+        client._cache.get.side_effect = [empty, None]
+        client._request.return_value = good
+
+        result = client.get_events_by_season("bra.camp.paranaense")
+
+        assert result is good
+        client._request.assert_called_once()
+        assert "-" in client._request.call_args.args[1]["s"]


### PR DESCRIPTION
Closes out epic teamarrv2-pgtq (bead pgtq.5). TSDB's season format varies by league within a sport — Brazilian state championships and Scandinavian soccer run calendar years ("2026") while the old code guessed fall-spring ("2025-2026") for everything non-cricket/boxing, silently returning 0 events and capping team discovery at 10 teams.

- `_season_candidates(league)`: most-likely format first, alternate second
- Both season fetchers (`get_season_events`, `get_events_by_season`) try candidates in order and fall through on empty — self-healing for any league, no hardcoded league lists; a wrong first guess costs one extra request
- Cached-empty results skip to the alternate without re-requesting
- Verified live against TSDB premium: Paranaense (league 5766) serves seasons "2025" (80 events) / "2026" (56 events), confirming calendar-year; the old default asked for "2025-2026" → 0

Tests: 6 new (candidate ordering per sport, retry-on-empty ordering, explicit-season single request, cached-empty skip). Full suite 1973 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)