### PR TITLE
fix: add |urlencode template filter for URL-safe variable values (#478)

### DIFF
--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -89,6 +89,25 @@ Dispatcharr channel logo — so the guide artwork and the channel logo always ma
 live preview in the template editor applies the base URL too, so what you see matches the
 generated output (and renders the actual image so you can confirm the link resolves).
 
+### URL-encoding variable values (`|urlencode`)
+
+When a variable value goes into the **query string** of an art URL, characters like
+spaces and `&` need to be percent-encoded — otherwise a value such as
+`{race_name}` = `Pit Stop & Podium` truncates the URL at the `&`, so only the first
+part reaches Game-Thumbs. Add the `|urlencode` filter (short alias `|url`) to any
+variable to encode its value:
+
+```
+/f1/cover?title={race_name|urlencode}&subtitle={session_name|urlencode}&iconurl=
+```
+
+- The filter encodes **only the variable's value** — the template's own `?`, `&`, and
+  `=` that form the URL structure stay literal.
+- It's **opt-in**: variables without the filter are unchanged, so a variable that already
+  holds a full URL is never double-encoded.
+- A misspelled filter (e.g. `|urlencodee`) renders literally, just like a misspelled
+  variable name, so you can spot the typo. The live preview applies the filter too.
+
 ---
 
 ## Identity

--- a/frontend/src/pages/template-form/constants.ts
+++ b/frontend/src/pages/template-form/constants.ts
@@ -171,17 +171,38 @@ function cleanupResolved(text: string): string {
   return out
 }
 
+// Template `|filter` modifiers, mirroring the backend resolver's _FILTERS
+// (teamarr/templates/resolver.py, #478). urlencode/url percent-encode a value
+// for safe use inside a URL. encodeURIComponent matches Python's
+// quote(safe="") closely enough for preview fidelity.
+const TEMPLATE_FILTERS: Record<string, (value: string) => string> = {
+  urlencode: encodeURIComponent,
+  url: encodeURIComponent,
+}
+
 // Helper to create resolveTemplate function with custom sample data.
 // A known variable resolves to its value even when that value is empty (e.g.
 // a pre-game {team_score.next}); only genuinely unknown variables stay literal.
 export function createResolver(sampleData: Record<string, string>) {
   return function resolveTemplate(template: string): string {
     if (!template) return ""
-    const substituted = template.replace(/\{([^}]+)\}/g, (match, varName) => {
-      if (varName in sampleData) return sampleData[varName]
-      const lower = varName.toLowerCase()
-      if (lower in sampleData) return sampleData[lower]
-      return match
+    const substituted = template.replace(/\{([^}]+)\}/g, (match, token) => {
+      // Split an optional `|filter` modifier off the variable name.
+      const pipe = token.indexOf("|")
+      const varName = pipe === -1 ? token : token.slice(0, pipe)
+      const filterName = pipe === -1 ? "" : token.slice(pipe + 1).toLowerCase()
+
+      let value: string
+      if (varName in sampleData) value = sampleData[varName]
+      else if (varName.toLowerCase() in sampleData) value = sampleData[varName.toLowerCase()]
+      else return match // unknown variable stays literal
+
+      if (filterName) {
+        const filterFn = TEMPLATE_FILTERS[filterName]
+        if (!filterFn) return match // unknown filter stays literal (visible typo)
+        return filterFn(value)
+      }
+      return value
     })
     return cleanupResolved(substituted)
   }

--- a/frontend/src/utils/templateValidation.ts
+++ b/frontend/src/utils/templateValidation.ts
@@ -58,12 +58,14 @@ export function buildValidVariableSet(categories: VariableCategory[]): {
  *
  * The engine only treats a braced token as a variable when it matches this shape:
  * a lowercase/underscore-led name (digits, `_`, `@` allowed — e.g. `vs_@`) with an
- * optional single dotted suffix. Anything else inside braces — `{2024}`, `{1-0}`,
+ * optional single dotted suffix and an optional trailing `|filter` modifier (e.g.
+ * `{race_name|urlencode}`, #478). Anything else inside braces — `{2024}`, `{1-0}`,
  * `{Team Name}`, `{a.b.c}` — is literal text the resolver leaves untouched, so the
- * validator must ignore it too rather than cry "unknown variable". The backend
+ * validator must ignore it too rather than cry "unknown variable". Group 1 is the
+ * variable name (validated); the filter in group 2 is ignored here. The backend
  * lowercases the captured name before lookup, so matching is case-insensitive.
  */
-const VARIABLE_PATTERN = /\{([a-z_][a-z0-9_@]*(?:\.[a-z]+)?)\}/gi
+const VARIABLE_PATTERN = /\{([a-z_][a-z0-9_@]*(?:\.[a-z]+)?)(?:\|[a-z_]+)?\}/gi
 
 /**
  * Extract variable references the engine would actually resolve, lowercased to

--- a/teamarr/templates/resolver.py
+++ b/teamarr/templates/resolver.py
@@ -9,7 +9,9 @@ game conditions (is_home, win_streak, etc.) and priority.
 
 import logging
 import re
+from collections.abc import Callable
 from typing import Any
+from urllib.parse import quote
 
 from teamarr.templates.conditions import get_condition_selector
 from teamarr.templates.context import GameContext, TemplateContext
@@ -18,9 +20,32 @@ from teamarr.utilities.art_url import apply_art_base_url
 
 logger = logging.getLogger(__name__)
 
-# Pattern matches: {variable} or {variable.next} or {variable.last}
-# Note: @ is allowed to support {vs_@} variable
-VARIABLE_PATTERN = re.compile(r"\{([a-z_][a-z0-9_@]*(?:\.[a-z]+)?)\}", re.IGNORECASE)
+# Pattern matches: {variable}, {variable.next}, {variable.last}, and an optional
+# trailing `|filter` modifier (e.g. {race_name|urlencode}). Group 1 is the
+# variable token (name + optional suffix); group 2 is the filter name, if any.
+# Note: @ is allowed to support {vs_@} variable.
+VARIABLE_PATTERN = re.compile(
+    r"\{([a-z_][a-z0-9_@]*(?:\.[a-z]+)?)(?:\|([a-z_]+))?\}", re.IGNORECASE
+)
+
+
+def _filter_urlencode(value: str) -> str:
+    """Percent-encode a resolved value for safe use inside a URL (#478).
+
+    Encodes every reserved character (space, ``&``, ``=``, ``?``, ``/`` …) so a
+    value interpolated into an art/poster URL query string — e.g. game-thumbs
+    ``/f1/cover?title={race_name|urlencode}`` — survives a value containing
+    spaces or ``&`` instead of truncating the URL.
+    """
+    return quote(value or "", safe="")
+
+
+# Registry of `|filter` modifiers usable in templates. Opt-in by design so
+# variables that legitimately hold full URLs are never encoded unless asked.
+_FILTERS: dict[str, Callable[[str], str]] = {
+    "urlencode": _filter_urlencode,
+    "url": _filter_urlencode,  # short alias
+}
 
 
 class TemplateResolver:
@@ -86,20 +111,33 @@ class TemplateResolver:
 
         def replace(match: re.Match) -> str:
             var_name = match.group(1).lower()
+            filter_name = (match.group(2) or "").lower()
             # Keep unknown variables literal (helps users identify typos)
             # Known variables with empty values still get replaced with ""
-            if var_name not in variables:
+            if var_name in variables:
+                value = variables[var_name]
+            elif self._is_contextless_suffix(var_name):
                 # A VALID registry variable with a LEGAL suffix that's simply
                 # missing its game context (no next/last game — offseason,
                 # season end) resolves to empty like any known-but-empty value
                 # (#418) — raw {game_time.next} braces must never reach a real
                 # guide. Typos and illegal suffix usage (e.g. .next on a
                 # BASE_ONLY variable) still stay literal.
-                if self._is_contextless_suffix(var_name):
-                    return ""
+                value = ""
+            else:
                 unreplaced.append(var_name)
                 return match.group(0)  # Return original {variable} unchanged
-            return variables[var_name]
+
+            # Apply an optional `|filter` modifier (e.g. |urlencode, #478). An
+            # unknown filter is treated like a typo: keep the whole token literal
+            # so the author can see and fix it, rather than silently dropping it.
+            if filter_name:
+                filter_fn = _FILTERS.get(filter_name)
+                if filter_fn is None:
+                    unreplaced.append(match.group(0))
+                    return match.group(0)
+                return filter_fn(value)
+            return value
 
         result = VARIABLE_PATTERN.sub(replace, template)
 

--- a/tests/templates/test_url_encode_filter.py
+++ b/tests/templates/test_url_encode_filter.py
@@ -1,0 +1,81 @@
+"""Tests for the `|urlencode` template filter (#478).
+
+Motorsports and other variables whose values contain spaces or `&` truncated
+art/poster URLs (e.g. game-thumbs) because the value was interpolated raw into
+the query string. The opt-in `|urlencode` (alias `|url`) filter percent-encodes
+the resolved value so it survives as a single query parameter.
+
+Tests drive the substitution core directly via ``resolve_with_map`` so they
+need no TemplateContext — the filter logic lives entirely in that path.
+"""
+
+from teamarr.templates.resolver import TemplateResolver
+
+
+def _resolve(template: str, variables: dict[str, str]) -> str:
+    return TemplateResolver().resolve_with_map(template, variables)
+
+
+def test_urlencode_encodes_ampersand():
+    # The bug: an '&' in the value split the query string at game-thumbs.
+    out = _resolve(
+        "/f1/cover?title={race_name|urlencode}&iconurl=",
+        {"race_name": "Pit Stop & Podium"},
+    )
+    assert out == "/f1/cover?title=Pit%20Stop%20%26%20Podium&iconurl="
+
+
+def test_urlencode_encodes_spaces():
+    out = _resolve("{race_name|urlencode}", {"race_name": "Emilia Romagna Grand Prix"})
+    assert out == "Emilia%20Romagna%20Grand%20Prix"
+
+
+def test_url_alias_matches_urlencode():
+    variables = {"race_name": "Grand Prix & Co"}
+    assert _resolve("{race_name|url}", variables) == _resolve(
+        "{race_name|urlencode}", variables
+    )
+
+
+def test_urlencode_leaves_literal_url_structure_untouched():
+    # Only the substituted VALUE is encoded — the template's own '?', '&', '='
+    # stay literal so the URL structure is preserved.
+    out = _resolve(
+        "/f1/cover?title={race_name|urlencode}&subtitle={session_name|urlencode}",
+        {"race_name": "Monaco GP", "session_name": "Qualifying 1 & 2"},
+    )
+    assert out == "/f1/cover?title=Monaco%20GP&subtitle=Qualifying%201%20%26%202"
+
+
+def test_unfiltered_variable_is_unchanged():
+    # Without the filter, behavior is exactly as before (no encoding).
+    out = _resolve("{race_name}", {"race_name": "Monaco & Grand Prix"})
+    assert out == "Monaco & Grand Prix"
+
+
+def test_urlencode_on_empty_value_yields_empty():
+    out = _resolve("x={race_name|urlencode}", {"race_name": ""})
+    assert out == "x="
+
+
+def test_urlencode_encodes_slashes_and_reserved_chars():
+    out = _resolve("{path|urlencode}", {"path": "a/b?c=d"})
+    assert out == "a%2Fb%3Fc%3Dd"
+
+
+def test_unknown_variable_with_filter_stays_literal():
+    # A typo'd variable name keeps the whole token literal so the author sees it.
+    out = _resolve("{nope|urlencode}", {"race_name": "x"})
+    assert out == "{nope|urlencode}"
+
+
+def test_unknown_filter_stays_literal():
+    # A typo'd filter name keeps the whole token literal rather than silently
+    # dropping the modifier.
+    out = _resolve("{race_name|urlencodee}", {"race_name": "Monaco"})
+    assert out == "{race_name|urlencodee}"
+
+
+def test_urlencode_case_insensitive_filter_name():
+    out = _resolve("{race_name|URLENCODE}", {"race_name": "A B"})
+    assert out == "A%20B"


### PR DESCRIPTION
## Summary

Fixes #478. Template variable values containing spaces or `&` were interpolated **raw** into art/poster URL query strings (e.g. game-thumbs). An `&` in a value like `{race_name}` = `Emilia Romagna & Grand Prix` truncated the URL, so only the first part reached the image host.

Adds an **opt-in** `|urlencode` filter (short alias `|url`) to the template syntax:

```
/f1/cover?title={race_name|urlencode}&subtitle={session_name|urlencode}&iconurl=
```

- Encodes **only the variable's value** with `urllib.parse.quote(safe="")` — the template's own `?`, `&`, `=` structure stays literal.
- Opt-in by design, so a variable that already holds a full URL is never double-encoded.
- An unknown/misspelled filter renders literally, just like a misspelled variable name (visible typo).

## Changes

- **`teamarr/templates/resolver.py`** — `VARIABLE_PATTERN` now captures an optional `|filter` group; `resolve_with_map` applies registered filters. `_FILTERS` = `{urlencode, url}`.
- **`frontend/src/utils/templateValidation.ts`** — pattern mirror updated so `{var|filter}` validates against the base name.
- **`frontend/src/pages/template-form/constants.ts`** — live-preview resolver applies the filter (`encodeURIComponent`) so preview matches the engine.
- **`docs/guide/epg/variables.md`** — documents the filter under Artwork & Game Thumbs.
- **`tests/templates/test_url_encode_filter.py`** — 10 tests (ampersand/space encoding, alias, structure preserved, opt-out unchanged, unknown var/filter literal, case-insensitivity).

## Test plan

- [x] `ruff check teamarr/ tests/` — clean
- [x] `pytest tests/templates/ -q` — 462 passed
- [x] New filter tests — 10 passed
- [x] `cd frontend && npm run build` — green
- [ ] Reviewer: verify against a live motorsports F1 template with `{race_name|urlencode}` pointed at a game-thumbs instance

> Note: full-suite run shows one **pre-existing** failure — `test_registry_sweep.py::test_every_variable_renders_non_empty_somewhere` — a cross-module test-isolation flake (passes in isolation and within `tests/templates/`, and still fails with this PR's `resolver.py` change reverted). Unrelated to this change.

Bead: `teamarrv2-3s6g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)