### PR TITLE
fix: builtin D-backs aliases + user-over-builtin precedence (#480)

### DIFF
--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -1659,8 +1659,9 @@ class TeamMatcher:
         """Resolve a team name to its canonical form via alias lookup.
 
         Priority:
-        1. Built-in aliases (TEAM_ALIASES constant) - league-agnostic
-        2. User-defined aliases (database) - league-specific
+        1. User-defined aliases (database, league-specific) — a user's
+           deliberate mapping outranks shipped defaults (#480)
+        2. Built-in aliases (TEAM_ALIASES constant) - league-agnostic
         3. International country name auto-resolution (e.g. "brasil" → "Brazil")
 
         Args:
@@ -1672,16 +1673,17 @@ class TeamMatcher:
         """
         normalized = normalize_text(team_name)
 
-        # First check built-in aliases (league-agnostic)
-        canonical = _NORMALIZED_TEAM_ALIASES.get(normalized)
-        if canonical:
-            return canonical
-
-        # Then check user-defined aliases (league-specific)
+        # User-defined aliases first — deliberate user mappings outrank
+        # shipped defaults (#480)
         if league and self._user_aliases:
             user_canonical = self._lookup_user_alias(normalized, league)
             if user_canonical:
                 return user_canonical
+
+        # Then built-in aliases (league-agnostic)
+        canonical = _NORMALIZED_TEAM_ALIASES.get(normalized)
+        if canonical:
+            return canonical
 
         # Finally, try automatic country name resolution for national-team sports.
         # Memoized: the same stream team names are re-checked against every

--- a/teamarr/utilities/constants.py
+++ b/teamarr/utilities/constants.py
@@ -161,6 +161,10 @@ TEAM_ALIASES: dict[str, str] = {
     "sens": "ottawa senators",
     "jets": "winnipeg jets",
     # MLB
+    # Official club nickname with no matching provider string — ESPN says
+    # "Diamondbacks" in every field, so "D-backs" scores ~53 without this (#480)
+    "d-backs": "arizona diamondbacks",
+    "dbacks": "arizona diamondbacks",
     "yanks": "new york yankees",
     "bosox": "boston red sox",
     "redsox": "boston red sox",

--- a/tests/matching/test_nickname_alias_matching.py
+++ b/tests/matching/test_nickname_alias_matching.py
@@ -72,11 +72,16 @@ def _match(stream_name: str, events: list[Event], matcher=None, cfg=None):
 
 
 class TestShortNameScoring:
-    def test_dbacks_without_alias_still_fails_honestly(self):
-        # With the REAL short_name ('Diamondbacks'), 'D-backs' scores ~53 —
-        # documents why an alias (below) is the user-facing answer
+    def test_dbacks_matches_out_of_the_box_via_builtin_alias(self):
+        # ESPN has no "D-backs" string anywhere (short_name scores ~53), so
+        # the official club nickname is a BUILTIN alias (#480) — no user
+        # alias required
         outcome = _match("Cardinals x D-backs", [_event()])
-        assert outcome.category == ResultCategory.FAILED
+        assert outcome.category == ResultCategory.MATCHED
+
+    def test_dbacks_no_hyphen_variant_matches(self):
+        outcome = _match("Cardinals x Dbacks", [_event()])
+        assert outcome.category == ResultCategory.MATCHED
 
 
 class TestAliasNormalization:


### PR DESCRIPTION
Final piece of #480, maintainer-approved: "too common not to."

- **Builtin aliases** `d-backs`/`dbacks` → Arizona Diamondbacks in `TEAM_ALIASES`. ESPN carries no "D-backs" string in any field (verified: name/shortDisplayName/nickname all "Diamondbacks" or None), so the official club nickname scored ~53 and could never match without a per-user alias. Now works out of the box.
- **Precedence fix the new test surfaced**: `_resolve_alias` checked builtins before user aliases, so the new builtin would have *overridden* a user's deliberate re-mapping of the same text. Flipped: user-defined (league-scoped) → builtin → country resolution.
- Tests: no-alias "Cardinals x D-backs" and "Cardinals x Dbacks" both match via builtin; a wrong-team user alias still wins over the builtin and fails the match honestly. Full suite 2,032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)