### PR TITLE
fix: strip catchup start:/stop: metadata before team extraction (#495)

### DIFF
--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -252,6 +252,24 @@ TIME_PATTERNS = [
 # Standalone TZ pattern (after time has been masked, e.g., "@ ET" at end)
 TZ_STANDALONE_PATTERN = rf"\s*@?\s*({_TZ_ABBREVS})\s*$"
 
+# Catchup/timeshift metadata some providers append to stream names (#495):
+#   "Dodgers x Yankees start:2026-07-19 17:35:00 stop:2026-07-20 00:48:20"
+# The start timestamp doubles as the stream's date/time, but the WHOLE tail has
+# to go before separator/team detection: generic masking replaces only the
+# first date+time, so the stop timestamp would survive and corrupt team
+# extraction ("Yankees start:" reads as a show-name prefix, leaving
+# team2="stop:2026-07-20 00:48:20").
+CATCHUP_START_PATTERN = re.compile(
+    r"\bstart\s*[:=]\s*(\d{4})-(\d{1,2})-(\d{1,2})[ T](\d{1,2}):(\d{2})(?::\d{2})?",
+    re.IGNORECASE,
+)
+# Stop timestamp may be truncated by provider name-length limits ("stop:20"),
+# so accept any digit-led date/time fragment after the label.
+CATCHUP_STOP_PATTERN = re.compile(
+    r"\bstop\s*[:=]\s*\d[\d/\-]*(?:[ T]\d{1,2}(?::\d{2}){0,2})?",
+    re.IGNORECASE,
+)
+
 # Map timezone abbreviations to IANA timezone names
 TZ_ABBREVIATION_MAP = {
     # === North America ===
@@ -372,13 +390,27 @@ def extract_and_mask_datetime(text: str) -> tuple[str, date | None, time | None,
     extracted_time = None
     extracted_tz = None
 
+    # Catchup metadata (#495): take date/time from the start timestamp, then
+    # strip both start and stop labels entirely.
+    catchup_match = CATCHUP_START_PATTERN.search(result)
+    if catchup_match:
+        try:
+            year, month, day, hour, minute = (int(g) for g in catchup_match.groups())
+            extracted_date = date(year, month, day)
+            extracted_time = time(hour, minute)
+        except ValueError:
+            pass
+        result = CATCHUP_START_PATTERN.sub(" ", result)
+    result = CATCHUP_STOP_PATTERN.sub(" ", result)
+
     # Extract and mask dates
     for pattern, mask in DATE_PATTERNS:
         match = re.search(pattern, result, re.IGNORECASE)
         if match:
             is_iso = mask == "DATE_MASK_ISO"
             no_year = mask == "DATE_MASK_NO_YEAR"
-            extracted_date = _parse_date_match(match, is_iso=is_iso, no_year=no_year)
+            if extracted_date is None:
+                extracted_date = _parse_date_match(match, is_iso=is_iso, no_year=no_year)
             result = re.sub(pattern, " DATE_MASK ", result, count=1, flags=re.IGNORECASE)
             break
 
@@ -386,7 +418,10 @@ def extract_and_mask_datetime(text: str) -> tuple[str, date | None, time | None,
     for pattern, mask in TIME_PATTERNS:
         match = re.search(pattern, result, re.IGNORECASE)
         if match:
-            extracted_time, extracted_tz = _parse_time_match(match)
+            parsed_time, parsed_tz = _parse_time_match(match)
+            if extracted_time is None:
+                extracted_time = parsed_time
+            extracted_tz = extracted_tz or parsed_tz
             result = re.sub(pattern, f" {mask} ", result, count=1, flags=re.IGNORECASE)
             break
 

--- a/tests/matching/test_catchup_metadata.py
+++ b/tests/matching/test_catchup_metadata.py
@@ -1,0 +1,88 @@
+"""Regression tests for catchup/timeshift metadata in stream names (#495).
+
+Some providers append catchup window timestamps to stream names:
+
+    "MLB 02 | Dodgers x Yankees start:2026-07-19 17:35:00 stop:2026-07-20 00:48:20"
+
+Generic datetime masking replaces only the FIRST date+time (the start pair),
+so the stop timestamp survived into team extraction. The show-name-prefix
+cleanup then ate "Yankees start:" and team2 came out as
+"stop:2026-07-20 00:48:20" — no_event_found.
+
+The normalizer now recognizes the start/stop labels: the start timestamp
+becomes the stream's date/time and the whole metadata tail is stripped before
+separator detection.
+"""
+
+from datetime import date, time
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.normalizer import (
+    extract_and_mask_datetime,
+    normalize_stream,
+)
+
+
+class TestCatchupMetadata:
+    """start:/stop: catchup tails are stripped and the start timestamp kept."""
+
+    def test_full_start_stop_tail(self):
+        masked, d, t, tz = extract_and_mask_datetime(
+            "MLB 02 | Dodgers x Yankees start:2026-07-19 17:35:00 stop:2026-07-20 00:48:20"
+        )
+        assert masked == "MLB 02 | Dodgers x Yankees"
+        assert d == date(2026, 7, 19)
+        assert t == time(17, 35)
+        assert tz is None
+
+    def test_truncated_stop_timestamp(self):
+        # Provider name-length limits can cut the stop timestamp short.
+        masked, d, t, _ = extract_and_mask_datetime(
+            "MLB 02 | Dodgers x Yankees start:2026-07-19 17:35:00 stop:20"
+        )
+        assert masked == "MLB 02 | Dodgers x Yankees"
+        assert d == date(2026, 7, 19)
+        assert t == time(17, 35)
+
+    def test_start_without_stop(self):
+        masked, d, t, _ = extract_and_mask_datetime(
+            "NHL | Bruins vs Rangers start:2026-01-09 19:00:00"
+        )
+        assert masked == "NHL | Bruins vs Rangers"
+        assert d == date(2026, 1, 9)
+        assert t == time(19, 0)
+
+    def test_x_separator_stream_classifies(self):
+        # The exact stream from #495 end-to-end through the classifier.
+        c = classify_stream(
+            "MLB 02 | Dodgers x Yankees start:2026-07-19 17:35:00 stop:2026-07-20 00:48:20"
+        )
+        assert c.category.value == "team_vs_team"
+        assert c.team1 == "Dodgers"
+        assert c.team2 == "Yankees"
+        assert c.league_hint == "mlb"
+        assert c.normalized.extracted_date == date(2026, 7, 19)
+
+    def test_invalid_start_timestamp_still_strips(self):
+        # Nonsense month: no date extracted, but the tail must not leak into teams.
+        masked, d, t, _ = extract_and_mask_datetime(
+            "MLB | Dodgers x Yankees start:2026-13-40 17:35:00 stop:2026-07-20 00:48:20"
+        )
+        assert masked == "MLB | Dodgers x Yankees"
+        assert d is None
+        assert t is None
+
+
+class TestNoRegressions:
+    """Streams without catchup metadata keep their existing behaviour."""
+
+    def test_plain_time_stream(self):
+        norm = normalize_stream("NHL | Bruins vs Rangers 7:00 PM ET")
+        assert norm.extracted_time == time(19, 0)
+        assert norm.extracted_tz == "America/New_York"
+
+    def test_word_start_in_team_context_untouched(self):
+        # "start" without a timestamp is not catchup metadata.
+        masked, d, t, _ = extract_and_mask_datetime("NBA | Lakers vs Celtics start of season")
+        assert "start of season" in masked
+        assert d is None


### PR DESCRIPTION
Fixes #495.

`MLB 02 | Dodgers x Yankees start:2026-07-19 17:35:00 stop:2026-07-20 00:48:20` failed with `no_event_found`: generic datetime masking replaces only the **first** date+time pair (the `start:` one), so the `stop:` timestamp survived into team extraction. The show-name-prefix cleanup (`^[A-Z][A-Za-z\s]+:`) then ate `Yankees start:`, leaving team2 = `stop:2026-07-20 00:48:20` — exactly the reporter's log.

- Normalizer now recognizes catchup labels: the start timestamp becomes the stream's extracted date/time, and the whole metadata tail is stripped before separator detection.
- Stop fragments truncated by provider name-length limits (`stop:20`) are handled.
- 7 new regression tests, including the exact reported stream end-to-end through the classifier (`x` separator → `Dodgers`/`Yankees`, date 2026-07-19).

Gates: ruff clean · 2042 passed · frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)