### PR TITLE
fix: Pattern Tester rejects JS-style named groups; apply looked unsaved (#494)

### DIFF
--- a/frontend/src/components/TestPatternsModal/index.tsx
+++ b/frontend/src/components/TestPatternsModal/index.tsx
@@ -22,6 +22,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { getRawStreams, testExtraction } from "@/api/groups"
 import type { ExtractionPatterns, StreamExtractionResult } from "@/api/groups"
+import { jsToPython } from "@/lib/regex-utils"
 import { StreamList } from "./StreamList"
 import { PatternPanel } from "./PatternPanel"
 import { InteractiveSelector } from "./InteractiveSelector"
@@ -169,22 +170,26 @@ export function TestPatternsModal({
       (p.custom_regex_fighters_enabled && p.custom_regex_fighters) ||
       (p.custom_regex_event_name_enabled && p.custom_regex_event_name)
     if (!anyEnabled) return null
+    // The form (and this modal) hold patterns in JS syntax — convert to
+    // Python before the backend compiles them with `re` (#494), exactly
+    // like the form's save path does.
+    const py = (s: string | null) => (s ? jsToPython(s) : s)
     return {
-      teams_pattern: p.custom_regex_teams,
+      teams_pattern: py(p.custom_regex_teams),
       teams_enabled: p.custom_regex_teams_enabled,
-      date_pattern: p.custom_regex_date,
+      date_pattern: py(p.custom_regex_date),
       date_enabled: p.custom_regex_date_enabled,
-      month_pattern: p.custom_regex_month,
+      month_pattern: py(p.custom_regex_month),
       month_enabled: p.custom_regex_month_enabled,
-      day_pattern: p.custom_regex_day,
+      day_pattern: py(p.custom_regex_day),
       day_enabled: p.custom_regex_day_enabled,
-      time_pattern: p.custom_regex_time,
+      time_pattern: py(p.custom_regex_time),
       time_enabled: p.custom_regex_time_enabled,
-      league_pattern: p.custom_regex_league,
+      league_pattern: py(p.custom_regex_league),
       league_enabled: p.custom_regex_league_enabled,
-      fighters_pattern: p.custom_regex_fighters,
+      fighters_pattern: py(p.custom_regex_fighters),
       fighters_enabled: p.custom_regex_fighters_enabled,
-      event_name_pattern: p.custom_regex_event_name,
+      event_name_pattern: py(p.custom_regex_event_name),
       event_name_enabled: p.custom_regex_event_name_enabled,
     }
   }, [debouncedPatterns])

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -2239,6 +2239,7 @@ def test_extraction(request: TestExtractionRequest):
         extract_league_with_custom_regex,
         extract_teams_with_custom_regex,
         extract_time_with_custom_regex,
+        normalize_regex_syntax,
     )
 
     p = request.patterns
@@ -2277,7 +2278,9 @@ def test_extraction(request: TestExtractionRequest):
     ):
         if enabled and pat:
             try:
-                _re.compile(pat, _re.IGNORECASE)
+                # Same syntax acceptance as the pipeline (#494): JS-style
+                # (?<name> groups are translated before compiling.
+                _re.compile(normalize_regex_syntax(pat), _re.IGNORECASE)
             except _re.error as e:
                 pattern_errors[fname] = str(e)
 

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -68,6 +68,18 @@ class ClassifiedStream:
     feed_hint: str | None = None
 
 
+def normalize_regex_syntax(pattern: str) -> str:
+    """Accept JS/.NET-style named groups in custom patterns (#494).
+
+    The edit form displays patterns in JS syntax, so users naturally write
+    ``(?<team1>`` — which Python's ``re`` rejects. Translate to Python syntax
+    before compiling: ``(?<name>`` → ``(?P<name>``, ``\\k<name>`` → ``(?P=name)``.
+    Lookbehinds are safe: ``(?<=`` / ``(?<!`` don't start with a word character.
+    """
+    pattern = re.sub(r"\(\?<([A-Za-z_]\w*)>", r"(?P<\1>", pattern)
+    return re.sub(r"\\k<([A-Za-z_]\w*)>", r"(?P=\1)", pattern)
+
+
 @dataclass
 class CustomRegexConfig:
     """Configuration for custom regex extraction patterns."""
@@ -152,7 +164,9 @@ class CustomRegexConfig:
 
         if self._compiled_teams is None:
             try:
-                self._compiled_teams = re.compile(self.teams_pattern, re.IGNORECASE)
+                self._compiled_teams = re.compile(
+                    normalize_regex_syntax(self.teams_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom teams regex pattern: %s", e)
                 return None
@@ -166,7 +180,9 @@ class CustomRegexConfig:
 
         if self._compiled_date is None:
             try:
-                self._compiled_date = re.compile(self.date_pattern, re.IGNORECASE)
+                self._compiled_date = re.compile(
+                    normalize_regex_syntax(self.date_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom date regex pattern: %s", e)
                 return None
@@ -180,7 +196,9 @@ class CustomRegexConfig:
 
         if self._compiled_month is None:
             try:
-                self._compiled_month = re.compile(self.month_pattern, re.IGNORECASE)
+                self._compiled_month = re.compile(
+                    normalize_regex_syntax(self.month_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom month regex pattern: %s", e)
                 return None
@@ -194,7 +212,9 @@ class CustomRegexConfig:
 
         if self._compiled_day is None:
             try:
-                self._compiled_day = re.compile(self.day_pattern, re.IGNORECASE)
+                self._compiled_day = re.compile(
+                    normalize_regex_syntax(self.day_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom day regex pattern: %s", e)
                 return None
@@ -208,7 +228,9 @@ class CustomRegexConfig:
 
         if self._compiled_time is None:
             try:
-                self._compiled_time = re.compile(self.time_pattern, re.IGNORECASE)
+                self._compiled_time = re.compile(
+                    normalize_regex_syntax(self.time_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom time regex pattern: %s", e)
                 return None
@@ -222,7 +244,9 @@ class CustomRegexConfig:
 
         if self._compiled_league is None:
             try:
-                self._compiled_league = re.compile(self.league_pattern, re.IGNORECASE)
+                self._compiled_league = re.compile(
+                    normalize_regex_syntax(self.league_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom league regex pattern: %s", e)
                 return None
@@ -236,7 +260,9 @@ class CustomRegexConfig:
 
         if self._compiled_fighters is None:
             try:
-                self._compiled_fighters = re.compile(self.fighters_pattern, re.IGNORECASE)
+                self._compiled_fighters = re.compile(
+                    normalize_regex_syntax(self.fighters_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom fighters regex pattern: %s", e)
                 return None
@@ -250,7 +276,9 @@ class CustomRegexConfig:
 
         if self._compiled_event_name is None:
             try:
-                self._compiled_event_name = re.compile(self.event_name_pattern, re.IGNORECASE)
+                self._compiled_event_name = re.compile(
+                    normalize_regex_syntax(self.event_name_pattern), re.IGNORECASE
+                )
             except re.error as e:
                 logger.warning("[CLASSIFY] Invalid custom event_name regex pattern: %s", e)
                 return None
@@ -413,9 +441,7 @@ def extract_date_with_custom_regex(
                     date_str = match.group("date")
                     if date_str:
                         return (
-                            _parse_date_string(
-                                date_str.strip(), config.learned_date_formats
-                            ),
+                            _parse_date_string(date_str.strip(), config.learned_date_formats),
                             blob_format_known,
                         )
                 except (IndexError, re.error):
@@ -443,9 +469,7 @@ def extract_date_with_custom_regex(
                 groups = match.groups()
                 if groups and groups[0]:
                     return (
-                        _parse_date_string(
-                            groups[0].strip(), config.learned_date_formats
-                        ),
+                        _parse_date_string(groups[0].strip(), config.learned_date_formats),
                         blob_format_known,
                     )
 
@@ -741,9 +765,7 @@ def _parse_time_string(time_str: str) -> time | None:
     # Normalize: remove spaces between number and am/pm. Times are at most
     # 4 digits; the bounds also keep backtracking linear on adversarial input
     # (py/polynomial-redos — this runs on user-captured text via #458).
-    time_str_normalized = re.sub(
-        r"(\d{1,4})\s{0,3}(am|pm)", r"\1\2", time_str, flags=re.IGNORECASE
-    )
+    time_str_normalized = re.sub(r"(\d{1,4})\s{0,3}(am|pm)", r"\1\2", time_str, flags=re.IGNORECASE)
 
     for fmt in formats:
         try:
@@ -1593,9 +1615,7 @@ def _apply_custom_datetime_regex(
     # month+day combination path — the old date_enabled-only gate made them
     # silently dead.
     if custom_regex.date_enabled or custom_regex.month_enabled or custom_regex.day_enabled:
-        custom_date, format_verified = extract_date_with_custom_regex(
-            stream_name, custom_regex
-        )
+        custom_date, format_verified = extract_date_with_custom_regex(stream_name, custom_regex)
         if custom_date:
             normalized.extracted_date = custom_date
             normalized.extracted_date_trusted = format_verified

--- a/tests/test_extraction_tester_api.py
+++ b/tests/test_extraction_tester_api.py
@@ -95,3 +95,45 @@ def test_month_day_only_extracts(month_first=True):
     assert resp.results[0].date is not None
     assert resp.results[0].date.matched is True
     assert resp.results[0].date.values[0].endswith("-07-16")
+
+
+# --- JS/.NET-style named groups accepted (#494) ---
+# The edit form displays patterns in JS syntax ((?<team1>), so users see and
+# write that form. Both the tester and the pipeline translate it to Python
+# syntax before compiling.
+
+
+def test_js_style_named_groups_accepted():
+    resp = _run(
+        ExtractionPatterns(
+            teams_pattern=r"(?<team1>.+?) vs (?<team2>.+)",
+            teams_enabled=True,
+        ),
+        ["Tigers vs Twins"],
+    )
+    assert resp.pattern_errors == {}
+    assert resp.results[0].teams.matched is True
+    assert resp.results[0].teams.values == ["Tigers", "Twins"]
+
+
+def test_js_style_date_pattern_accepted():
+    resp = _run(
+        ExtractionPatterns(date_pattern=r"(?<date>\d{2}/\d{2}/\d{4})", date_enabled=True),
+        ["Tigers vs Twins 07/16/2026"],
+    )
+    assert resp.pattern_errors == {}
+    assert resp.results[0].date.matched is True
+    assert resp.results[0].date.values == ["2026-07-16"]
+
+
+def test_lookbehind_not_mangled_by_syntax_translation():
+    # (?<=...) and (?<!...) must survive the (?<name> -> (?P<name> translation
+    resp = _run(
+        ExtractionPatterns(
+            teams_pattern=r"(?<=: )(?P<team1>\w+) vs (?P<team2>\w+)(?<! HD)",
+            teams_enabled=True,
+        ),
+        ["MLB: Tigers vs Twins"],
+    )
+    assert resp.pattern_errors == {}
+    assert resp.results[0].teams.matched is True


### PR DESCRIPTION
Fixes #494.

The form stores patterns in Python regex syntax but **displays** them in JS syntax (`(?<team1>`) via the pythonToJs/jsToPython layer. Since #458 the Pattern Tester runs patterns through the real Python pipeline server-side — but the modal sent the **display** syntax verbatim, so Python `re` rejected `(?<team1>` ("invalid pattern" on previously-working configs). The "changes aren't saved" half is the same bug: hand-typing `(?P<` and applying saves fine, but reopening re-displays JS syntax and the tester wrongly flags it again.

- `normalize_regex_syntax()` in the classifier: `(?<name>` → `(?P<name>`, `\k<name>` → `(?P=name)`, applied in every `CustomRegexConfig` compile and the tester endpoint's compile check. Lookbehinds (`(?<=`/`(?<!`) are unaffected (verified by test).
- `TestPatternsModal` converts patterns `jsToPython` before calling `/groups/test-extraction` — same as the form's save path.
- Docs already state both syntaxes are accepted (`creating-groups.md`); this makes that claim true at every layer, including for patterns stored via any path that bypassed the form.

3 new tests. Gates: ruff clean · 2038 passed · frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)