### PR TITLE
feat: broadcast_feed_team_short + abbrev variables (#496)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 ## Key Subsystems
 
 **Template Engine** (`teamarr/templates/`):
-- 260 variables in `variables/` (20 categories)
+- 262 variables in `variables/` (20 categories)
 - 33 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`

--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -11,7 +11,7 @@ redirect_from:
 
 # Template Variables
 
-Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 260 variables across 20 categories.
+Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 262 variables across 20 categories.
 
 ## Team vs Event Templates
 
@@ -230,10 +230,12 @@ These are most useful for Event EPG templates on stream-separated channels (e.g.
 | `{feed_home_away}` | `'Home'` if home feed, `'Away'` if away feed, `''` if no feed | base | `Home` |
 | `{broadcast_feed}` | `'Home Team Feed'` / `'Away Team Feed'` / `''` if no feed | base | `Home Team Feed` |
 | `{broadcast_feed_team}` | `'{Team Name} Feed'` or `''` if no feed | base | `Baltimore Orioles Feed` |
+| `{broadcast_feed_team_short}` | `'{Team Short Name} Feed'` or `''` if no feed | base | `Orioles Feed` |
+| `{broadcast_feed_team_abbrev}` | `'{TEAM ABBREV} Feed'` or `''` if no feed | base | `BAL Feed` |
 
 Feed Team variables do **not** support `.next` / `.last` suffixes — they describe the channel's configuration, not a specific game's schedule. For per-game home/away references, use the `{home_team}` / `{away_team}` variables above.
 
-`{broadcast_feed}` and `{broadcast_feed_team}` are **pre-formatted** — they include the literal `" Feed"` suffix. When feed separation isn't active they return `""` as a unit, so the whole phrase disappears cleanly from the template (unlike composing `{feed_home_away} Team Feed` yourself, which would leave `"Team Feed"` orphaned).
+`{broadcast_feed}` and the `{broadcast_feed_team}`/`{broadcast_feed_team_short}`/`{broadcast_feed_team_abbrev}` family are **pre-formatted** — they include the literal `" Feed"` suffix. When feed separation isn't active they return `""` as a unit, so the whole phrase disappears cleanly from the template (unlike composing `{feed_home_away} Team Feed` yourself, which would leave `"Team Feed"` orphaned).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 ## Features
 
 - **350+ leagues across 15 sports** - Football, basketball, hockey, baseball, soccer (~250 leagues via ESPN discovery), cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar), and tennis (ATP, WTA). 169 pre-configured leagues plus dynamically discovered soccer leagues.
-- **260 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
+- **262 template variables** - Customize channel names and EPG with team records, scores, venues, broadcasts, standings, playoff status, motorsports sessions/results, tennis tournament context, and more
 - **Flexible matching** - Aliases, fuzzy matching, and configurable stream ordering to handle inconsistent IPTV naming
 - **Channel groups & profiles** - Use existing Dispatcharr groups/profiles or create them dynamically using variables and wildcards
 - **Smart sorting** - Configurable stream and channel sorting modes based on priority rules

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -8,13 +8,13 @@ docs_version: "2.3.1"
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 260 variables across 20 categories, 33 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 262 variables across 20 categories, 33 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
 ```
 TemplateResolver
-  ├── VariableRegistry (260 variables, 20 categories)
+  ├── VariableRegistry (262 variables, 20 categories)
   ├── ConditionEvaluator (23 evaluators)
   └── ContextBuilder (Event + Team → TemplateContext)
 ```

--- a/teamarr/templates/variables/home_away.py
+++ b/teamarr/templates/variables/home_away.py
@@ -423,6 +423,32 @@ def extract_broadcast_feed_team(ctx: TemplateContext, game_ctx: GameContext | No
     return f"{ctx.feed_team.name} Feed"
 
 
+@register_variable(
+    name="broadcast_feed_team_short",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'{Team Short Name} Feed' (e.g., 'Mariners Feed') or '' if no feed",
+    scope=TemplateScope.EVENT_ONLY,
+)
+def extract_broadcast_feed_team_short(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return f"{ctx.feed_team.short_name or ctx.feed_team.name} Feed"
+
+
+@register_variable(
+    name="broadcast_feed_team_abbrev",
+    category=Category.HOME_AWAY,
+    suffix_rules=SuffixRules.BASE_ONLY,
+    description="'{TEAM ABBREV} Feed' (e.g., 'SEA Feed') or '' if no feed",
+    scope=TemplateScope.EVENT_ONLY,
+)
+def extract_broadcast_feed_team_abbrev(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
+    if not ctx.feed_team:
+        return ""
+    return f"{ctx.feed_team.abbreviation.upper()} Feed"
+
+
 # --- Article-aware naming + matchup connector (tvnk.7, #329) ---
 # Gracenote convention: clubs/franchises take "the", national teams and
 # individual-sport competitors don't. Lowercase "the" — the resolver


### PR DESCRIPTION
Closes #496 (short-name form as requested, plus the abbrev form).

Adds `{broadcast_feed_team_short}` (`Blue Jays Feed`) and `{broadcast_feed_team_abbrev}` (`SEA Feed`) alongside `{broadcast_feed_team}` — same pre-formatted contract: the literal ` Feed` suffix is included and the whole value is empty when no feed separation is active, so national broadcasts never leave an orphaned `Feed` behind.

Docs: variable table rows + pre-formatted note in `variables.md`; count claims bumped 260 → 262 in `variables.md`, `template-engine.md`, `docs/index.md`, `CLAUDE.md` (registry count verified: 262).

Gates: ruff clean · 2042 passed · frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)