### PR TITLE
fix: EPG channel-source stream flapping inside attach window (#512)

### DIFF
--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -191,8 +191,11 @@ class StreamMatching:
         # curated channel fallback). Both are single scoped fetches.
         try:
             epg_data_list = self._dispatcharr_client.channels.get_epg_data_list()
-            stream_channels, channel_by_uuid = (
-                self._dispatcharr_client.channels.get_channel_maps()
+            # Teamarr's own output channels must not claim stream->channel slots
+            # (#512): last-write-wins would let them mask a shared stream's
+            # curated channel and break tier-1 (curated) EPG resolution.
+            stream_channels, channel_by_uuid = self._dispatcharr_client.channels.get_channel_maps(
+                exclude_channel_ids=self._managed_channel_ids()
             )
         except Exception as e:
             logger.warning("[EPG-MATCH] Failed to load EPG resolution data: %s", e)

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -9,6 +9,9 @@ from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from teamarr.consumers.event_group_processor.stream_fetcher import (
+    managed_channel_ids,
+)
 from teamarr.consumers.matching import BatchMatchResult, StreamCategory, StreamMatcher
 from teamarr.database.groups import EventEPGGroup
 from teamarr.database.settings import get_feed_separation_settings
@@ -195,7 +198,7 @@ class StreamMatching:
             # (#512): last-write-wins would let them mask a shared stream's
             # curated channel and break tier-1 (curated) EPG resolution.
             stream_channels, channel_by_uuid = self._dispatcharr_client.channels.get_channel_maps(
-                exclude_channel_ids=self._managed_channel_ids()
+                exclude_channel_ids=managed_channel_ids(self._db_factory)
             )
         except Exception as e:
             logger.warning("[EPG-MATCH] Failed to load EPG resolution data: %s", e)

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -965,7 +965,10 @@ class EventGroupProcessor(
         if current_streams is not None:
             try:
                 cleanup_result = lifecycle_service.cleanup_deleted_streams(
-                    group.id, current_streams, matched_streams=matched_streams
+                    group.id,
+                    current_streams,
+                    matched_streams=matched_streams,
+                    is_channel_source=bool(getattr(group, "is_channel_source", False)),
                 )
                 combined_result.merge(cleanup_result)
                 if cleanup_result.deleted:

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -9,6 +9,29 @@ from teamarr.services.stream_filter import FilterResult, StreamFilter, StreamFil
 logger = logging.getLogger(__name__)
 
 
+def managed_channel_ids(db_factory: Any) -> set[int]:
+    """Dispatcharr ids of Teamarr's own output channels.
+
+    These are OUTPUT, never EPG-match input — callers pass them as
+    ``exclude_channel_ids`` to the stream->channel map builders so they
+    can't claim slots for streams shared with curated channels (#512).
+    Module-level (not a mixin method) so both StreamFetcher and
+    StreamMatching can use it without cross-mixin attribute access.
+    """
+    try:
+        from teamarr.database.channels import get_all_managed_channels
+
+        with db_factory() as conn:
+            return {
+                mc.dispatcharr_channel_id
+                for mc in get_all_managed_channels(conn, include_deleted=False)
+                if mc.dispatcharr_channel_id
+            }
+    except Exception as e:
+        logger.warning("[CHANNEL_SOURCE] Failed to load managed channel ids: %s", e)
+        return set()
+
+
 class StreamFetcher:
     """Fetches and filters M3U streams from Dispatcharr for event groups.
 
@@ -141,26 +164,6 @@ class StreamFetcher:
                     streams.append(s)
         return streams
 
-    def _managed_channel_ids(self) -> set[int]:
-        """Dispatcharr ids of Teamarr's own output channels.
-
-        These are OUTPUT, never EPG-match input — callers pass them as
-        ``exclude_channel_ids`` to the stream->channel map builders so they
-        can't claim slots for streams shared with curated channels (#512).
-        """
-        try:
-            from teamarr.database.channels import get_all_managed_channels
-
-            with self._db_factory() as conn:
-                return {
-                    mc.dispatcharr_channel_id
-                    for mc in get_all_managed_channels(conn, include_deleted=False)
-                    if mc.dispatcharr_channel_id
-                }
-        except Exception as e:
-            logger.warning("[CHANNEL_SOURCE] Failed to load managed channel ids: %s", e)
-            return set()
-
     def _fetch_channel_source_streams(self) -> list[dict]:
         """Build EPG-match candidates from streams curated onto Dispatcharr channels.
 
@@ -179,7 +182,7 @@ class StreamFetcher:
         # opens a Teamarr event channel would steal a shared stream's slot from
         # the curated channel, dropping it from this pool and cascading into
         # delete/recreate churn on alternating runs.
-        managed_ids = self._managed_channel_ids()
+        managed_ids = managed_channel_ids(self._db_factory)
 
         try:
             stream_channel_map = client.channels.get_stream_channel_map(

--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -141,6 +141,26 @@ class StreamFetcher:
                     streams.append(s)
         return streams
 
+    def _managed_channel_ids(self) -> set[int]:
+        """Dispatcharr ids of Teamarr's own output channels.
+
+        These are OUTPUT, never EPG-match input — callers pass them as
+        ``exclude_channel_ids`` to the stream->channel map builders so they
+        can't claim slots for streams shared with curated channels (#512).
+        """
+        try:
+            from teamarr.database.channels import get_all_managed_channels
+
+            with self._db_factory() as conn:
+                return {
+                    mc.dispatcharr_channel_id
+                    for mc in get_all_managed_channels(conn, include_deleted=False)
+                    if mc.dispatcharr_channel_id
+                }
+        except Exception as e:
+            logger.warning("[CHANNEL_SOURCE] Failed to load managed channel ids: %s", e)
+            return set()
+
     def _fetch_channel_source_streams(self) -> list[dict]:
         """Build EPG-match candidates from streams curated onto Dispatcharr channels.
 
@@ -152,8 +172,19 @@ class StreamFetcher:
         channels are OUTPUT, not INPUT, so they are excluded.
         """
         client = self._dispatcharr_client
+
+        # Teamarr's own managed channels are OUTPUT — never treat them as a source.
+        # Loaded BEFORE the channel-map fetch so they can be excluded from slot
+        # claiming (#512): the map is last-write-wins, so once the attach window
+        # opens a Teamarr event channel would steal a shared stream's slot from
+        # the curated channel, dropping it from this pool and cascading into
+        # delete/recreate churn on alternating runs.
+        managed_ids = self._managed_channel_ids()
+
         try:
-            stream_channel_map = client.channels.get_stream_channel_map()
+            stream_channel_map = client.channels.get_stream_channel_map(
+                exclude_channel_ids=managed_ids
+            )
             epg_data_list = client.channels.get_epg_data_list()
         except Exception as e:
             logger.warning("[CHANNEL_SOURCE] Failed to load channel/EPG data: %s", e)
@@ -162,29 +193,21 @@ class StreamFetcher:
         active_source_ids = self._active_epg_source_ids()
         epg_by_id = {e["id"]: e for e in epg_data_list if e.get("id") is not None}
 
-        # Teamarr's own managed channels are OUTPUT — never treat them as a source.
-        # Also collect the M3U group ids already covered by an EPG-match-enabled
-        # group: streams in those groups are matched by the per-group path (whose
-        # tier-1 resolution uses the same channel EPG), so including them here would
-        # double-process the identical match. Consolidation would dedupe the result
-        # anyway, but skipping avoids wasted work and inflated source-group stats.
-        managed_ids: set[int] = set()
+        # M3U group ids already covered by an EPG-match-enabled group: streams in
+        # those groups are matched by the per-group path (whose tier-1 resolution
+        # uses the same channel EPG), so including them here would double-process
+        # the identical match. Consolidation would dedupe the result anyway, but
+        # skipping avoids wasted work and inflated source-group stats.
         epg_group_m3u_ids: set[int] = set()
         # User-selected DP channel groups to scope the scan (ybt.2). Empty = all.
         # Scoping skips the expensive EPG-resolution/matching for channels in
         # groups the user didn't pick — a generation-time saving.
         selected_groups: set[int] = set()
         try:
-            from teamarr.database.channels import get_all_managed_channels
             from teamarr.database.groups import get_all_groups
             from teamarr.database.settings import get_epg_settings
 
             with self._db_factory() as conn:
-                managed_ids = {
-                    mc.dispatcharr_channel_id
-                    for mc in get_all_managed_channels(conn, include_deleted=False)
-                    if mc.dispatcharr_channel_id
-                }
                 epg_group_m3u_ids = {
                     g.m3u_group_id
                     for g in get_all_groups(conn, include_disabled=False)
@@ -194,7 +217,7 @@ class StreamFetcher:
                     int(gid) for gid in get_epg_settings(conn).epg_channel_source_groups
                 }
         except Exception as e:
-            logger.warning("[CHANNEL_SOURCE] Failed to load managed/group ids: %s", e)
+            logger.warning("[CHANNEL_SOURCE] Failed to load group ids: %s", e)
 
         # Stream detail (name, account) keyed by id — listed once.
         try:

--- a/teamarr/consumers/lifecycle/cleanup.py
+++ b/teamarr/consumers/lifecycle/cleanup.py
@@ -261,6 +261,8 @@ class ChannelCleanup(_LifecycleHost):
         group_id: int,
         current_streams: dict[int, dict],
         matched_streams: list[dict] | None = None,
+        *,
+        is_channel_source: bool = False,
     ) -> StreamProcessResult:
         """Clean up channels for streams that no longer exist, changed content, or rotated events.
 
@@ -278,6 +280,12 @@ class ChannelCleanup(_LifecycleHost):
             group_id: Event EPG group ID
             current_streams: Dict mapping stream_id -> stream_data with 'name' field
             matched_streams: Optional list of matched stream dicts with event data
+            is_channel_source: True for the hidden Dispatcharr-channels source
+                group. Its "pool" is DERIVED from the stream->channel map, not
+                an M3U listing, so absence from it must never be read as
+                "removed from source" (#512) — a pool-construction gap would
+                cascade into channel deletion. Rotation checks still apply;
+                stale channels fall to their scheduled event-end deletion.
 
         Returns:
             StreamProcessResult with deleted channels and errors
@@ -361,8 +369,10 @@ class ChannelCleanup(_LifecycleHost):
                             s.source_group_id is not None and s.source_group_id != group_id
                         )
 
-                        if is_cross_group:
-                            # Cross-group stream: skip "missing from M3U" check
+                        if is_cross_group or is_channel_source:
+                            # No authoritative M3U pool for this stream (other
+                            # group's stream, or channel-source derived pool):
+                            # skip the "missing from M3U" check.
                             # But still check event rotation if we have match data
                             if stream_event_map and channel_event_id:
                                 matched_events = stream_event_map.get(stream_id)

--- a/teamarr/dispatcharr/managers/channels.py
+++ b/teamarr/dispatcharr/managers/channels.py
@@ -748,7 +748,9 @@ class ChannelManager:
 
         return None
 
-    def get_stream_channel_map(self) -> dict[int, dict]:
+    def get_stream_channel_map(
+        self, exclude_channel_ids: set[int] | None = None
+    ) -> dict[int, dict]:
         """Map each assigned stream id -> the Dispatcharr channel that carries it.
 
         A raw M3U stream's ``tvg_id`` lives in a different namespace from EPG
@@ -763,15 +765,24 @@ class ChannelManager:
             Dict mapping stream id -> channel dict (id, epg_data_id, etc.).
             A stream assigned to multiple channels keeps the last one seen.
         """
-        return self.get_channel_maps()[0]
+        return self.get_channel_maps(exclude_channel_ids=exclude_channel_ids)[0]
 
-    def get_channel_maps(self) -> tuple[dict[int, dict], dict[str, dict]]:
+    def get_channel_maps(
+        self, exclude_channel_ids: set[int] | None = None
+    ) -> tuple[dict[int, dict], dict[str, dict]]:
         """One paginated channel fetch -> (stream id -> channel, uuid -> channel).
 
         Superset of ``get_stream_channel_map`` for callers that also need the
         uuid index (loopback-stream EPG resolution: a Dispatcharr-loopback M3U
         stream's URL names its source channel by uuid) without paying for a
         second fetch. Uuid keys are lowercased.
+
+        ``exclude_channel_ids`` keeps those channels from claiming stream->
+        channel slots (#512): the map is single-slot last-write-wins, so
+        Teamarr's own OUTPUT channels would otherwise steal a shared stream's
+        slot from the curated channel once the attach window opens — which
+        self-poisons the channel-source candidate pool and degrades curated
+        EPG resolution. Excluded channels still appear in the uuid map.
         """
         channels = self._client.paginated_get(
             "/api/channels/channels/?page_size=500",
@@ -780,8 +791,9 @@ class ChannelManager:
         stream_map: dict[int, dict] = {}
         uuid_map: dict[str, dict] = {}
         for ch in channels:
-            for stream_id in ch.get("streams") or []:
-                stream_map[stream_id] = ch
+            if not (exclude_channel_ids and ch.get("id") in exclude_channel_ids):
+                for stream_id in ch.get("streams") or []:
+                    stream_map[stream_id] = ch
             uuid = ch.get("uuid")
             if uuid:
                 uuid_map[str(uuid).lower()] = ch

--- a/tests/lifecycle/test_channel_source.py
+++ b/tests/lifecycle/test_channel_source.py
@@ -36,10 +36,26 @@ def _make_processor(
     stream_channel_map, epg_data_list, streams, managed, epg_groups, monkeypatch,
     dp_groups=None,
 ):
-    """Build a processor with mocked Dispatcharr client + DB lookups."""
+    """Build a processor with mocked Dispatcharr client + DB lookups.
+
+    The map mock honors exclude_channel_ids (#512) like the real builder and
+    records the passed set on ``client.map_exclusions`` for assertions.
+    """
+
+    def _map(exclude_channel_ids=None):
+        client.map_exclusions.append(exclude_channel_ids)
+        if not exclude_channel_ids:
+            return dict(stream_channel_map)
+        return {
+            sid: ch
+            for sid, ch in stream_channel_map.items()
+            if ch.get("id") not in exclude_channel_ids
+        }
+
     client = SimpleNamespace(
+        map_exclusions=[],
         channels=SimpleNamespace(
-            get_stream_channel_map=lambda: stream_channel_map,
+            get_stream_channel_map=_map,
             get_epg_data_list=lambda: epg_data_list,
         ),
         m3u=SimpleNamespace(
@@ -242,6 +258,23 @@ def test_channel_source_group_hidden_from_ui_list(db_conn):
     # Processing path (no exclusion) still sees it.
     everything = get_all_groups(db_conn, include_disabled=True)
     assert gid in {g.id for g in everything}
+
+
+def test_managed_ids_passed_as_map_exclusion(monkeypatch):
+    # #512: the fetcher must hand Teamarr's own channel ids to the map builder
+    # so they can't claim slots for streams shared with curated channels.
+    proc = _make_processor(
+        stream_channel_map={500: {"id": 100, "epg_data_id": 1, "name": "ESPN"}},
+        epg_data_list=[{"id": 1, "tvg_id": "ESPN.us", "epg_source": 10}],
+        streams=[_stream(500, "ESPN HD", group_id=42)],
+        managed=[SimpleNamespace(dispatcharr_channel_id=900)],
+        epg_groups=[],
+        monkeypatch=monkeypatch,
+    )
+    out = proc._fetch_channel_source_streams()
+    assert proc._dispatcharr_client.map_exclusions == [{900}]
+    # Curated channel 100 is not managed → its stream stays a candidate.
+    assert [c["id"] for c in out] == [500]
 
 
 if __name__ == "__main__":

--- a/tests/lifecycle/test_channel_source_cleanup.py
+++ b/tests/lifecycle/test_channel_source_cleanup.py
@@ -1,0 +1,133 @@
+"""Regression tests for #512: channel-source cleanup must not read pool
+absence as "removed from source".
+
+The hidden Dispatcharr-channels group's candidate pool is DERIVED from the
+stream->channel map, not an authoritative M3U listing. When the pool builder
+lost a stream (a Teamarr channel had stolen its map slot inside the attach
+window), cleanup treated it as missing-from-M3U, deleted the channel, and the
+recreate seeded from the other provider — an A/B oscillation every cycle.
+With is_channel_source=True the missing-branch is skipped entirely; rotation
+detection still applies.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GROUP_ID = 1
+
+
+@pytest.fixture
+def service():
+    from teamarr.consumers.lifecycle.service import ChannelLifecycleService
+
+    svc = ChannelLifecycleService(
+        db_factory=MagicMock(),
+        sports_service=MagicMock(),
+        channel_manager=MagicMock(),
+    )
+    svc._remove_stream_from_dispatcharr_channel = MagicMock(return_value=True)
+    svc.delete_managed_channel = MagicMock(return_value=True)
+    return svc
+
+
+def _channel(cid, event_id, name="Ch"):
+    return SimpleNamespace(
+        id=cid,
+        dispatcharr_channel_id=1000 + cid,
+        channel_number=cid,
+        channel_name=name,
+        event_id=event_id,
+        primary_stream_id=None,
+    )
+
+
+def _stream(sid, name):
+    return SimpleNamespace(
+        dispatcharr_stream_id=sid,
+        source_group_id=GROUP_ID,
+        stream_name=name,
+    )
+
+
+def _run_cleanup(service, channels, streams_by_channel, current_streams, matched, **kwargs):
+    with (
+        patch(
+            "teamarr.database.channels.get_managed_channels_for_group",
+            return_value=channels,
+        ),
+        patch(
+            "teamarr.database.channels.get_channel_streams",
+            side_effect=lambda conn, cid, include_removed=False: streams_by_channel.get(cid, []),
+        ),
+        patch("teamarr.database.channels.remove_stream_from_channel"),
+        patch("teamarr.database.channels.update_stream_name"),
+        patch("teamarr.database.channels.log_channel_history"),
+    ):
+        return service.cleanup_deleted_streams(
+            GROUP_ID, current_streams, matched_streams=matched, **kwargs
+        )
+
+
+def _match(sid, event_id, name):
+    return {
+        "stream": {"id": sid, "name": name},
+        "event": SimpleNamespace(id=event_id),
+    }
+
+
+def test_pool_absence_does_not_delete_channel_source_channel(service):
+    """The #512 flap: all of a channel's streams vanish from the derived pool
+    (their map slots were stolen by the in-window attachment) — the channel
+    must survive."""
+    channel = _channel(7, "38659", "Carlton vs Gold Coast")
+    streams = [_stream(100, "Fox Sports 504"), _stream(101, "Fox Footy")]
+
+    result = _run_cleanup(
+        service,
+        channels=[channel],
+        streams_by_channel={7: streams},
+        current_streams={},  # pool lost every stream this cycle
+        matched=[],
+        is_channel_source=True,
+    )
+
+    service.delete_managed_channel.assert_not_called()
+    assert result.deleted == []
+
+
+def test_same_pool_absence_still_deletes_for_regular_group(service):
+    """Regular M3U groups keep missing-from-M3U semantics unchanged."""
+    channel = _channel(7, "38659", "Carlton vs Gold Coast")
+    streams = [_stream(100, "Fox Sports 504")]
+
+    result = _run_cleanup(
+        service,
+        channels=[channel],
+        streams_by_channel={7: streams},
+        current_streams={},
+        matched=[],
+    )
+
+    service.delete_managed_channel.assert_called_once()
+    assert len(result.deleted) == 1
+
+
+def test_channel_source_rotation_still_detected(service):
+    """Skipping the missing-branch must not disable rotation cleanup."""
+    channel = _channel(8, "38659", "Carlton vs Gold Coast")
+    streams = [_stream(100, "Fox Sports 504")]
+
+    result = _run_cleanup(
+        service,
+        channels=[channel],
+        streams_by_channel={8: streams},
+        current_streams={100: {"name": "Fox Sports 504"}},
+        matched=[_match(100, "99999", "Fox Sports 504")],  # moved to another event
+        is_channel_source=True,
+    )
+
+    service.delete_managed_channel.assert_called_once()
+    assert len(result.deleted) == 1
+    assert "rotated" in result.deleted[0]["reason"]

--- a/tests/test_dispatcharr_channel_maps.py
+++ b/tests/test_dispatcharr_channel_maps.py
@@ -1,0 +1,54 @@
+"""Tests for ChannelManager.get_channel_maps slot-claiming exclusion (#512).
+
+The stream->channel map is single-slot last-write-wins. Teamarr's own output
+channels must not claim slots for streams they share with curated channels —
+otherwise, once the attach window opens and Teamarr attaches a shared stream,
+the next run's channel-source pool loses the stream ("Teamarr-managed") and
+cleanup cascades into delete/recreate churn on alternating cycles.
+"""
+
+from types import SimpleNamespace
+
+from teamarr.dispatcharr.managers.channels import ChannelManager
+
+
+def _manager(channels: list[dict]) -> ChannelManager:
+    client = SimpleNamespace(
+        _base_url="http://fake:9191",
+        paginated_get=lambda path, error_context=None: channels,
+    )
+    return ChannelManager(client)
+
+
+CURATED = {"id": 10, "uuid": "aa-bb", "epg_data_id": 1, "streams": [500, 501]}
+MANAGED = {"id": 900, "uuid": "cc-dd", "epg_data_id": None, "streams": [500]}
+
+
+def test_excluded_channel_does_not_claim_shared_stream_slot():
+    # Managed channel paginates AFTER the curated one → last-write-wins would
+    # normally hand stream 500's slot to it. Exclusion keeps the curated claim.
+    mgr = _manager([CURATED, MANAGED])
+    stream_map, uuid_map = mgr.get_channel_maps(exclude_channel_ids={900})
+
+    assert stream_map[500]["id"] == 10
+    assert stream_map[501]["id"] == 10
+    # Excluded channels still appear in the uuid index (loopback resolution).
+    assert uuid_map["cc-dd"]["id"] == 900
+
+
+def test_stream_only_on_excluded_channel_absent_from_map():
+    mgr = _manager([{"id": 900, "uuid": "cc-dd", "streams": [777]}])
+    stream_map, _ = mgr.get_channel_maps(exclude_channel_ids={900})
+    assert 777 not in stream_map
+
+
+def test_no_exclusion_keeps_last_write_wins():
+    mgr = _manager([CURATED, MANAGED])
+    stream_map, _ = mgr.get_channel_maps()
+    assert stream_map[500]["id"] == 900  # documented pre-existing behavior
+
+
+def test_get_stream_channel_map_passes_exclusion_through():
+    mgr = _manager([CURATED, MANAGED])
+    stream_map = mgr.get_stream_channel_map(exclude_channel_ids={900})
+    assert stream_map[500]["id"] == 10


### PR DESCRIPTION
Fixes #512. Confirmed against the reporter's log: once an event entered the pre-event attach window, each generation cycle alternated the channel between one provider's full stream set and the other's, deleting and recreating the channel every ~30 min (`5 missing` → `2 missing` → `5 missing` …).

**Mechanism:** the channel-source candidate pool drops streams whose slot in Dispatcharr's stream→channel map points at a Teamarr-managed channel — and that map is single-slot, last-write-wins. The in-window attachment made the Teamarr event channel steal the shared streams' slots from the curated linear channels, so the next run's pool lost them; cleanup read pool-absence as "removed from source", deleted the channel (and detached the shared streams from every other channel time-sharing them), and the recreate re-seeded from the other provider's still-pooled match. A/B forever.

**Fix — two independent breaks in the chain:**
1. `get_channel_maps`/`get_stream_channel_map` gain `exclude_channel_ids`; the channel-source fetcher and the EPG-resolver map fetch pass Teamarr's managed channel ids, so output channels can never claim slots (excluded channels stay in the uuid map for loopback resolution). Bonus: tier-1 curated EPG resolution no longer degrades for shared streams.
2. Defense in depth: `cleanup_deleted_streams(is_channel_source=True)` — the derived pool is not an authoritative M3U listing, so the missing-from-M3U branch is skipped for the channel-source group (rotation detection unchanged; stale channels still fall to scheduled event-end deletion). A future pool-construction gap can no longer cascade into channel deletion.

**Tests:** map-exclusion semantics incl. shared-slot survival and uuid-map completeness (`tests/test_dispatcharr_channel_maps.py`), fetcher passes managed ids (`test_channel_source.py`), pool-absence survival + regular-group semantics unchanged + rotation still fires (`tests/lifecycle/test_channel_source_cleanup.py`).

Gates: ruff clean · 2096 passed.