### PR TITLE
fix: combat template variables work for boxing (#510)

### DIFF
--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -524,7 +524,10 @@ Soccer teams often play in multiple competitions (domestic league, cups, Champio
 
 ## Combat Sports
 
-UFC and MMA-specific variables for event templates. These are **event-only** (no `.next`/`.last` suffixes) since each UFC event is independent.
+Variables for combat-sport event templates (UFC/MMA and boxing). These are **event-only** (no `.next`/`.last` suffixes) since each event is independent.
+
+{: .note }
+**Boxing support:** the fighter/matchup/title variables in this section work for boxing events too. Card segments, bout lists, fight results, records, and weight class only populate for UFC — that data comes from ESPN's UFC feed and TheSportsDB (which serves boxing) doesn't provide it. `{event_number}` is UFC-only by definition.
 
 ### Fighters & Matchup
 

--- a/teamarr/providers/tsdb/provider.py
+++ b/teamarr/providers/tsdb/provider.py
@@ -23,6 +23,10 @@ from teamarr.providers.tsdb.racing import parse_racing_events
 
 logger = logging.getLogger(__name__)
 
+# Fighter separators in combat-event names ("A vs. B" / "A vs B" / "A v B").
+# " vs. " must come first so the bare " vs " variant can't half-match it (#510).
+_VS_SEPARATORS = (" vs. ", " vs ", " v ")
+
 # Type alias for team name resolver callback
 # Takes (team_id, league) -> team_name or None
 TeamNameResolver = Callable[[str, str], str | None]
@@ -482,7 +486,9 @@ class TSDBProvider(SportsProvider):
             home_name = data.get("strHomeTeam")
             away_name = data.get("strAwayTeam")
 
-            if not home_name and not away_name and " vs " in event_name:
+            if not home_name and not away_name and any(
+                sep in event_name for sep in _VS_SEPARATORS
+            ):
                 # Parse fighters from event name: "Fighter A vs Fighter B"
                 home_team, away_team = self._parse_fighters_from_event_name(
                     event_name, event_id, league, sport
@@ -564,11 +570,12 @@ class TSDBProvider(SportsProvider):
 
         Returns (home_team, away_team) - first fighter is "home".
         """
-        # Split on " vs " (case insensitive)
-        parts = event_name.split(" vs ")
-        if len(parts) != 2:
-            # Try " v " as fallback
-            parts = event_name.split(" v ")
+        # Try each separator in order (" vs. " first — " vs " never matches it).
+        parts = [event_name]
+        for sep in _VS_SEPARATORS:
+            parts = event_name.split(sep)
+            if len(parts) == 2:
+                break
 
         if len(parts) == 2:
             fighter1 = parts[0].strip()

--- a/teamarr/templates/conditions.py
+++ b/teamarr/templates/conditions.py
@@ -58,6 +58,7 @@ from typing import Any
 
 from teamarr.core import SEASON_POSTSEASON, SEASON_PRESEASON
 from teamarr.templates.context import GameContext, TemplateContext
+from teamarr.templates.variables.combat import COMBAT_SPORTS
 from teamarr.utilities.event_status import is_event_final
 
 logger = logging.getLogger(__name__)
@@ -397,7 +398,7 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if fight ended by KO or TKO."""
         event = game_ctx.event
-        if not event or event.sport != "mma":
+        if not event or event.sport not in COMBAT_SPORTS:
             return False
         method = event.fight_result_method
         return method in ("ko", "tko")
@@ -407,7 +408,7 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if fight ended by submission."""
         event = game_ctx.event
-        if not event or event.sport != "mma":
+        if not event or event.sport not in COMBAT_SPORTS:
             return False
         return event.fight_result_method == "submission"
 
@@ -416,7 +417,7 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if fight went to decision."""
         event = game_ctx.event
-        if not event or event.sport != "mma":
+        if not event or event.sport not in COMBAT_SPORTS:
             return False
         method = event.fight_result_method
         return method is not None and "decision" in method
@@ -426,7 +427,7 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if fight ended by finish (KO/TKO/Submission, not decision)."""
         event = game_ctx.event
-        if not event or event.sport != "mma":
+        if not event or event.sport not in COMBAT_SPORTS:
             return False
         method = event.fight_result_method
         return method in ("ko", "tko", "submission")
@@ -436,7 +437,7 @@ class ConditionEvaluator:
     ) -> bool:
         """Check if fight went all scheduled rounds."""
         event = game_ctx.event
-        if not event or event.sport != "mma":
+        if not event or event.sport not in COMBAT_SPORTS:
             return False
         method = event.fight_result_method
         # If it went to decision, it went the distance

--- a/teamarr/templates/variables/combat.py
+++ b/teamarr/templates/variables/combat.py
@@ -54,6 +54,12 @@ from teamarr.templates.variables.registry import (
 )
 from teamarr.utilities.tz import format_time
 
+# Sports whose events are fight cards with home/away = headline-bout fighters.
+# Card composition, results, records, and weight class only exist for ESPN UFC
+# data — for boxing (TSDB) those variables stay empty, but fighter/matchup/
+# title variables read fields the provider does populate (#510).
+COMBAT_SPORTS = frozenset({"mma", "boxing"})
+
 
 @register_variable(
     name="fighter1",
@@ -70,7 +76,7 @@ def extract_fighter1(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     if event.home_team and event.home_team.name:
@@ -91,7 +97,7 @@ def extract_fighter2(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     if event.away_team and event.away_team.name:
@@ -134,7 +140,7 @@ def extract_matchup_combat(ctx: TemplateContext, game_ctx: GameContext | None) -
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     fighter1 = event.home_team.name if event.home_team else ""
@@ -164,7 +170,7 @@ def extract_event_number(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     # Try to extract number from event name
@@ -193,7 +199,7 @@ def extract_event_title(ctx: TemplateContext, game_ctx: GameContext | None) -> s
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     return event.name
@@ -268,7 +274,7 @@ def extract_main_card_time(ctx: TemplateContext, game_ctx: GameContext | None) -
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.segment_times:
+    if event.sport not in COMBAT_SPORTS or not event.segment_times:
         return ""
 
     main_card_dt = event.segment_times.get("main_card")
@@ -291,7 +297,7 @@ def extract_prelims_time(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.segment_times:
+    if event.sport not in COMBAT_SPORTS or not event.segment_times:
         return ""
 
     prelims_dt = event.segment_times.get("prelims")
@@ -314,7 +320,7 @@ def extract_early_prelims_time(ctx: TemplateContext, game_ctx: GameContext | Non
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.segment_times:
+    if event.sport not in COMBAT_SPORTS or not event.segment_times:
         return ""
 
     early_dt = event.segment_times.get("early_prelims")
@@ -341,7 +347,7 @@ def extract_bout_count(ctx: TemplateContext, game_ctx: GameContext | None) -> st
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     return str(len(event.bouts)) if event.bouts else ""
@@ -362,7 +368,7 @@ def extract_fight_card(ctx: TemplateContext, game_ctx: GameContext | None) -> st
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.bouts:
+    if event.sport not in COMBAT_SPORTS or not event.bouts:
         return ""
 
     return "\n".join(f"{b.fighter1} vs {b.fighter2}" for b in event.bouts)
@@ -380,7 +386,7 @@ def extract_main_card_bouts(ctx: TemplateContext, game_ctx: GameContext | None) 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.bouts:
+    if event.sport not in COMBAT_SPORTS or not event.bouts:
         return ""
 
     main_bouts = [b for b in event.bouts if b.segment == "main_card"]
@@ -399,7 +405,7 @@ def extract_prelims_bouts(ctx: TemplateContext, game_ctx: GameContext | None) ->
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.bouts:
+    if event.sport not in COMBAT_SPORTS or not event.bouts:
         return ""
 
     prelim_bouts = [b for b in event.bouts if b.segment == "prelims"]
@@ -418,7 +424,7 @@ def extract_early_prelims_bouts(ctx: TemplateContext, game_ctx: GameContext | No
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.bouts:
+    if event.sport not in COMBAT_SPORTS or not event.bouts:
         return ""
 
     early_bouts = [b for b in event.bouts if b.segment == "early_prelims"]
@@ -478,7 +484,7 @@ def extract_fight_result(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.fight_result_method:
+    if event.sport not in COMBAT_SPORTS or not event.fight_result_method:
         return ""
 
     return RESULT_DISPLAY_NAMES.get(event.fight_result_method, event.fight_result_method)
@@ -496,7 +502,7 @@ def extract_fight_result_short(ctx: TemplateContext, game_ctx: GameContext | Non
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.fight_result_method:
+    if event.sport not in COMBAT_SPORTS or not event.fight_result_method:
         return ""
 
     return RESULT_SHORT_NAMES.get(event.fight_result_method, event.fight_result_method.upper())
@@ -514,7 +520,7 @@ def extract_finish_round(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or event.finish_round is None:
+    if event.sport not in COMBAT_SPORTS or event.finish_round is None:
         return ""
 
     return str(event.finish_round)
@@ -532,7 +538,7 @@ def extract_finish_time(ctx: TemplateContext, game_ctx: GameContext | None) -> s
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.finish_time:
+    if event.sport not in COMBAT_SPORTS or not event.finish_time:
         return ""
 
     return event.finish_time
@@ -550,7 +556,7 @@ def extract_finish_info(ctx: TemplateContext, game_ctx: GameContext | None) -> s
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     parts = []
@@ -574,7 +580,7 @@ def extract_weight_class(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.weight_class:
+    if event.sport not in COMBAT_SPORTS or not event.weight_class:
         return ""
 
     return event.weight_class
@@ -592,7 +598,7 @@ def extract_weight_class_short(ctx: TemplateContext, game_ctx: GameContext | Non
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.weight_class:
+    if event.sport not in COMBAT_SPORTS or not event.weight_class:
         return ""
 
     return WEIGHT_CLASS_ABBREV.get(event.weight_class, event.weight_class[:2].upper())
@@ -610,7 +616,7 @@ def extract_fighter1_record(ctx: TemplateContext, game_ctx: GameContext | None) 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     if event.home_team and event.home_team.record_summary:
@@ -631,7 +637,7 @@ def extract_fighter2_record(ctx: TemplateContext, game_ctx: GameContext | None) 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     if event.away_team and event.away_team.record_summary:
@@ -656,7 +662,7 @@ def extract_judge_scores(ctx: TemplateContext, game_ctx: GameContext | None) -> 
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma":
+    if event.sport not in COMBAT_SPORTS:
         return ""
 
     # Only show scores for decisions
@@ -697,7 +703,7 @@ def extract_fight_summary(ctx: TemplateContext, game_ctx: GameContext | None) ->
         return ""
 
     event = game_ctx.event
-    if event.sport != "mma" or not event.fight_result_method:
+    if event.sport not in COMBAT_SPORTS or not event.fight_result_method:
         return ""
 
     method = RESULT_SHORT_NAMES.get(event.fight_result_method, event.fight_result_method.upper())

--- a/tests/providers/test_tsdb.py
+++ b/tests/providers/test_tsdb.py
@@ -475,3 +475,44 @@ class TestSeasonCandidates:
         assert result is good
         client._request.assert_called_once()
         assert "-" in client._request.call_args.args[1]["s"]
+
+
+class TestFighterParsing:
+    """#510: fighters parsed from combat event names (boxing has no home/away)."""
+
+    def _provider(self):
+        from unittest.mock import MagicMock
+
+        return TSDBProvider(client=MagicMock())
+
+    def test_vs_with_period(self):
+        p = self._provider()
+        home, away = p._parse_fighters_from_event_name(
+            "Canelo Alvarez vs. Terence Crawford", "1", "boxing", "boxing"
+        )
+        assert home.name == "Canelo Alvarez"
+        assert away.name == "Terence Crawford"
+
+    def test_plain_vs(self):
+        p = self._provider()
+        home, away = p._parse_fighters_from_event_name(
+            "Errol Spence Jr. vs Tim Tszyu", "2", "boxing", "boxing"
+        )
+        assert home.name == "Errol Spence Jr."
+        assert away.name == "Tim Tszyu"
+
+    def test_single_v(self):
+        p = self._provider()
+        home, away = p._parse_fighters_from_event_name(
+            "Fury v Usyk", "3", "boxing", "boxing"
+        )
+        assert home.name == "Fury"
+        assert away.name == "Usyk"
+
+    def test_unparseable_falls_back_to_tbd(self):
+        p = self._provider()
+        home, away = p._parse_fighters_from_event_name(
+            "Zuffa Boxing 9", "4", "boxing", "boxing"
+        )
+        assert home.name == "Zuffa Boxing 9"
+        assert away.name == "TBD"

--- a/tests/templates/test_combat_boxing_vars.py
+++ b/tests/templates/test_combat_boxing_vars.py
@@ -1,0 +1,95 @@
+"""Regression tests for #510: combat variables must work for boxing.
+
+Every combat extractor and condition was hard-gated on ``sport == "mma"``,
+so boxing events (sport == "boxing", served by TSDB) rendered ALL combat
+variables empty — even fighter/matchup/title, whose backing fields the TSDB
+provider populates by parsing fighters out of the event name. The gate is now
+the COMBAT_SPORTS set; card/result variables stay empty for boxing because
+only ESPN UFC data carries bouts/results.
+"""
+
+from datetime import UTC, datetime
+
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.templates.conditions import ConditionEvaluator
+from teamarr.templates.context import GameContext, TeamChannelContext, TemplateContext
+from teamarr.templates.variables import get_registry
+
+
+def _fighter(name: str, id_: str) -> Team:
+    return Team(
+        id=id_,
+        provider="tsdb",
+        name=name,
+        short_name=name.split()[-1],
+        abbreviation=name.split()[-1][:3].upper(),
+        league="boxing",
+        sport="boxing",
+    )
+
+
+def _boxing_event() -> Event:
+    # Shape the TSDB provider produces for boxing: fighters parsed from the
+    # event name into home/away; no bouts, results, records, or weight class.
+    return Event(
+        id="2070000",
+        provider="tsdb",
+        name="Errol Spence Jr. vs Tim Tszyu",
+        short_name="SPE vs TSZ",
+        start_time=datetime(2026, 8, 1, 2, 0, tzinfo=UTC),
+        home_team=_fighter("Errol Spence Jr.", "2070000_1"),
+        away_team=_fighter("Tim Tszyu", "2070000_2"),
+        status=EventStatus(state="pre"),
+        league="boxing",
+        sport="boxing",
+    )
+
+
+def _ctx(event: Event) -> tuple[TemplateContext, GameContext]:
+    game = GameContext(
+        event=event, is_home=True, team=event.home_team, opponent=event.away_team
+    )
+    ctx = TemplateContext(
+        game_context=game,
+        team_config=TeamChannelContext(
+            team_id="2070000_1",
+            league="boxing",
+            sport="boxing",
+            team_name="Errol Spence Jr.",
+        ),
+        team_stats=None,
+        team=event.home_team,
+    )
+    return ctx, game
+
+
+def _extract(name: str, ctx, game_ctx) -> str:
+    definition = get_registry().get(name)
+    assert definition is not None, f"variable {name} not registered"
+    return definition.extractor(ctx, game_ctx)
+
+
+def test_fighter_and_title_vars_populate_for_boxing():
+    ctx, game = _ctx(_boxing_event())
+    assert _extract("fighter1", ctx, game) == "Errol Spence Jr."
+    assert _extract("fighter2", ctx, game) == "Tim Tszyu"
+    assert _extract("event_title", ctx, game) == "Errol Spence Jr. vs Tim Tszyu"
+    assert _extract("matchup_combat", ctx, game) == "Errol Spence Jr. vs Tim Tszyu"
+    assert _extract("fighter1_last", ctx, game) != ""
+    assert _extract("fighter2_last", ctx, game) != ""
+
+
+def test_dataless_combat_vars_stay_empty_for_boxing():
+    # TSDB has no card composition/result data — these must degrade to "".
+    ctx, game = _ctx(_boxing_event())
+    for var in ("fight_card", "bout_count", "weight_class", "fight_result", "judge_scores"):
+        assert _extract(var, ctx, game) == ""
+    # UFC-specific numbering must not misfire on boxing names.
+    assert _extract("event_number", ctx, game) == ""
+
+
+def test_combat_conditions_safe_for_boxing():
+    ctx, game = _ctx(_boxing_event())
+    evaluator = ConditionEvaluator()
+    for cond in ("is_knockout", "is_submission", "is_decision", "is_finish", "went_distance"):
+        assert getattr(evaluator, f"_eval_{cond}")(None, ctx, game) is False


### PR DESCRIPTION
Fixes #510.

Every combat variable (`{fighter1}`, `{fighter2}`, `{event_title}`, `{matchup_combat}`, …) and all 5 combat conditions hard-gated on `event.sport != "mma"` → boxing events rendered them all empty, even though the TSDB provider populates the fighter fields (parsed out of the event name when the API has no home/away teams). The template preview made it worse by showing canned UFC sample values for boxing templates.

- `COMBAT_SPORTS = {"mma", "boxing"}` replaces the 24 variable gates and 5 condition gates. Data-dependent variables (card segments, bout lists, results, records, weight class) already null-check their fields, so they degrade to empty for boxing — that data only exists in ESPN's UFC feed. `{event_number}` stays UFC-only via its internal `UFC (\d+)` regex.
- TSDB fighter parsing now handles `"A vs. B"` (with period) in addition to `" vs "`/`" v "`, in both the entry condition and the splitter.
- Docs: combat section notes boxing support and which variables are UFC-only.

Known limitation (not in scope): the sample-preview system still shows UFC-shaped sample data for boxing templates, so UFC-only variables preview non-empty; and TSDB card-prefixed names ("Zuffa Boxing 9 Berlanga vs Butler") leave the prefix on fighter1. Noted on the issue.

Tests: fighter/title vars populate for a TSDB-shaped boxing event, data-less vars stay empty, conditions safe (`tests/templates/test_combat_boxing_vars.py`); separator variants incl. fallback (`tests/providers/test_tsdb.py::TestFighterParsing`).

Gates: ruff clean · 2095 passed.