### PR TITLE
fix: UI timestamps show the configured display timezone (#511)

### DIFF
--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -48,33 +48,7 @@ import { useSports } from "@/hooks/useSports"
 import { useRowSelection } from "@/hooks/useRowSelection"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { useGenerationProgress } from "@/hooks/useGenerationProgress"
-
-function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return "-"
-  const date = new Date(dateStr)
-  return date.toLocaleString()
-}
-
-function formatRelativeTime(dateStr: string | null): string {
-  if (!dateStr) return "-"
-  const date = new Date(dateStr)
-  const now = new Date()
-  const diffMs = date.getTime() - now.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-
-  if (diffMs < 0) {
-    const absMins = Math.abs(diffMins)
-    const absHours = Math.abs(diffHours)
-    if (absMins < 60) return `${absMins}m ago`
-    if (absHours < 24) return `${absHours}h ago`
-    return formatDateTime(dateStr)
-  }
-
-  if (diffMins < 60) return `in ${diffMins}m`
-  if (diffHours < 24) return `in ${diffHours}h`
-  return formatDateTime(dateStr)
-}
+import { useDateFormat } from "@/hooks/useDateFormat"
 
 // Sports whose events aren't a team-vs-team matchup — the event NAME is the
 // event (fight card, race weekend, tournament), not the participant pair.
@@ -362,6 +336,7 @@ function MethodCell({ stream }: { stream: ChannelStreamEntry }) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   useOutsideDismiss(ref, open, setOpen)
+  const { formatRelativeTime } = useDateFormat()
 
   const badge = getMatchMethodBadge(stream.match_method)
   if (!badge) return <span className="text-muted-foreground">—</span>
@@ -489,6 +464,7 @@ const ChannelRow = React.memo(function ChannelRow({
   onToggleSelect,
   onDelete,
 }: ChannelRowProps) {
+  const { formatRelativeTime, timezone } = useDateFormat()
   return (
     <>
       <TableRow className={expanded ? "border-b-0" : ""}>
@@ -535,7 +511,8 @@ const ChannelRow = React.memo(function ChannelRow({
             <div className="truncate text-xs text-muted-foreground">
               {channel.event_date && (
                 <>
-                  {new Date(channel.event_date).toLocaleString(undefined, {
+                  {new Date(channel.event_date).toLocaleString("en-US", {
+                    timeZone: timezone,
                     weekday: "short",
                     month: "short",
                     day: "numeric",
@@ -559,7 +536,7 @@ const ChannelRow = React.memo(function ChannelRow({
         </TableCell>
         <TableCell>{getSyncStatusBadge(channel.sync_status)}</TableCell>
         <TableCell className="text-muted-foreground">
-          {formatRelativeTime(channel.scheduled_delete_at)}
+          {channel.scheduled_delete_at ? formatRelativeTime(channel.scheduled_delete_at) : "-"}
         </TableCell>
         <TableCell>
           <div className="flex items-center justify-end">
@@ -639,6 +616,7 @@ const ChannelRow = React.memo(function ChannelRow({
 })
 
 export function ManagedChannelsTable() {
+  const { formatDateTime } = useDateFormat()
   // Filter states
   const [nameFilter, setNameFilter] = useState<string>("")
   const [sportFilter, setSportFilter] = useState<string>("")
@@ -1124,14 +1102,7 @@ export function ManagedChannelsTable() {
                       <Badge variant="secondary" className="text-xs">{getLeagueDisplay(channel.league)}</Badge>
                     </TableCell>
                     <TableCell className="text-sm">
-                      {channel.deleted_at
-                        ? new Date(channel.deleted_at).toLocaleString(undefined, {
-                            month: "short",
-                            day: "numeric",
-                            hour: "numeric",
-                            minute: "2-digit",
-                          })
-                        : "-"}
+                      {channel.deleted_at ? formatDateTime(channel.deleted_at) : "-"}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/frontend/src/components/RunHistoryTable.tsx
+++ b/frontend/src/components/RunHistoryTable.tsx
@@ -124,7 +124,7 @@ interface RunHistoryTableProps {
 }
 
 export function RunHistoryTable({ runs, onFixStream }: RunHistoryTableProps) {
-  const { formatDateTime } = useDateFormat()
+  const { formatDateTime, formatDate } = useDateFormat()
 
   // Modal state
   const [matchedModalRunId, setMatchedModalRunId] = useState<number | null>(null)
@@ -424,7 +424,7 @@ export function RunHistoryTable({ runs, onFixStream }: RunHistoryTableProps) {
                       </div>
                       {stream.event_date && (
                         <div className="text-xs text-muted-foreground">
-                          {new Date(stream.event_date).toLocaleDateString()}
+                          {formatDate(stream.event_date)}
                         </div>
                       )}
                     </div>

--- a/frontend/src/hooks/useDateFormat.ts
+++ b/frontend/src/hooks/useDateFormat.ts
@@ -58,7 +58,8 @@ export function useDateFormat() {
     [formatter]
   )
 
-  // Format relative time (e.g., "5m ago")
+  // Format relative time, past or future (e.g., "5m ago", "in 3h").
+  // Future times beyond 24h fall back to the absolute display-timezone form.
   const formatRelativeTime = useCallback(
     (dateStr: string | null): string => {
       if (!dateStr) return "Never"
@@ -67,16 +68,42 @@ export function useDateFormat() {
 
       const now = new Date()
       const diffMs = now.getTime() - date.getTime()
-      const diffMins = Math.floor(diffMs / 60000)
+      const diffMins = Math.floor(Math.abs(diffMs) / 60000)
       const diffHours = Math.floor(diffMins / 60)
       const diffDays = Math.floor(diffHours / 24)
 
+      if (diffMs < 0) {
+        if (diffMins < 60) return `in ${diffMins}m`
+        if (diffHours < 24) return `in ${diffHours}h`
+        return formatDateTime(dateStr)
+      }
       if (diffMins < 1) return "Just now"
       if (diffMins < 60) return `${diffMins}m ago`
       if (diffHours < 24) return `${diffHours}h ago`
       return `${diffDays}d ago`
     },
-    []
+    [formatDateTime]
+  )
+
+  // Date-only in the display timezone (e.g., "Jul 26, 2026"). Avoids the
+  // off-by-one-day a browser-local toLocaleDateString can produce.
+  const formatDate = useCallback(
+    (dateStr: string | Date | null): string => {
+      if (!dateStr) return "-"
+      try {
+        const date = typeof dateStr === "string" ? new Date(dateStr) : dateStr
+        if (isNaN(date.getTime())) return "-"
+        return new Intl.DateTimeFormat("en-US", {
+          timeZone: timezone,
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        }).format(date)
+      } catch {
+        return "-"
+      }
+    },
+    [timezone]
   )
 
   // Format with both absolute and relative (e.g., "Dec 24, 3:45 PM EST (5m ago)")
@@ -93,6 +120,7 @@ export function useDateFormat() {
 
   return {
     formatDateTime,
+    formatDate,
     formatRelativeTime,
     formatDateTimeWithRelative,
     timezone,

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -88,7 +88,7 @@ export function EventGroups() {
   const cachedLeagues = leaguesResponse?.leagues
   const allLeagueSlugs = useMemo(() => cachedLeagues?.map(l => l.slug) ?? [], [cachedLeagues])
   const deleteMutation = useDeleteGroup()
-  const { formatRelativeTime } = useDateFormat()
+  const { formatRelativeTime, formatDateTime } = useDateFormat()
   // Stale source groups (lylt.2) — their Dispatcharr M3U group is gone.
   const { data: staleGroups = [] } = useQuery({
     queryKey: ["groups", "stale"],
@@ -770,7 +770,7 @@ export function EventGroups() {
                           (~1 stream → 1 event). A pure Team/EPG source fans one stream
                           out to many events, so show raw stream volume instead. */}
                       {!group.name_match_enabled ? (
-                        <span className="text-[0.65rem] text-muted-foreground" title={`Last: ${group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}`}>
+                        <span className="text-[0.65rem] text-muted-foreground" title={`Last: ${group.last_refresh ? formatDateTime(group.last_refresh) : 'Never'}`}>
                           {group.stream_count ?? 0} streams
                         </span>
                       ) : group.stream_count && group.stream_count > 0 ? (
@@ -782,7 +782,7 @@ export function EventGroups() {
                               {(group.match_result_count ?? 0) > (group.matched_count ?? 0) && (
                                 <div className="text-muted-foreground">EPG time-sharing: streams matched to multiple events</div>
                               )}
-                              <div className="text-muted-foreground">Last: {group.last_refresh ? new Date(group.last_refresh).toLocaleString() : 'Never'}</div>
+                              <div className="text-muted-foreground">Last: {group.last_refresh ? formatDateTime(group.last_refresh) : 'Never'}</div>
                             </div>
                           }
                         >
@@ -1033,7 +1033,7 @@ export function EventGroups() {
                               <div className="font-medium">{stream.event_name}</div>
                               {stream.start_time && (
                                 <div className="text-muted-foreground text-xs">
-                                  {new Date(stream.start_time).toLocaleString()}
+                                  {formatDateTime(stream.start_time)}
                                 </div>
                               )}
                             </div>

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -55,6 +55,7 @@ import type { Team } from "@/api/teams"
 import { getLeagues } from "@/api/teams"
 import { statsApi } from "@/api/stats"
 import { useQuery } from "@tanstack/react-query"
+import { useDateFormat } from "@/hooks/useDateFormat"
 
 type ActiveFilter = "" | "active" | "inactive"
 type SortColumn = "team" | "league" | "sport" | "template" | "channel" | "status"
@@ -187,6 +188,7 @@ function EditTeamDialog({ team, templates, open, onOpenChange, onSave, isSaving 
 }
 
 export function Teams() {
+  const { timezone } = useDateFormat()
   const navigate = useNavigate()
   const { data: teams, isLoading, error, refetch } = useTeams()
   const { data: templates } = useTemplates()
@@ -607,7 +609,7 @@ export function Teams() {
                         </div>
                         <div className="flex items-center justify-between text-xs text-muted-foreground">
                           <span>{event.league}</span>
-                          <span>Started {new Date(event.start_time).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}</span>
+                          <span>Started {new Date(event.start_time).toLocaleTimeString("en-US", { timeZone: timezone, hour: "numeric", minute: "2-digit" })}</span>
                         </div>
                       </div>
                     ))}

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -35,8 +35,10 @@ import { getLeagueDisplayName, getSportDisplayName } from "@/lib/utils"
 import { useSports } from "@/hooks/useSports"
 import { TemplateAssignmentManager } from "@/components/TemplateAssignmentModal"
 import { useSubscription } from "@/hooks/useSubscription"
+import { useDateFormat } from "@/hooks/useDateFormat"
 
 export function Templates() {
+  const { formatDate } = useDateFormat()
   const navigate = useNavigate()
   const { data: templates, isLoading, error, refetch } = useTemplates()
   const { data: subscription } = useSubscription()
@@ -380,13 +382,7 @@ export function Templates() {
                       )}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
-                      {template.created_at
-                        ? new Date(template.created_at).toLocaleDateString("en-US", {
-                            month: "short",
-                            day: "numeric",
-                            year: "numeric",
-                          })
-                        : "—"}
+                      {template.created_at ? formatDate(template.created_at) : "—"}
                     </TableCell>
                     <TableCell>
                       <div className="flex items-center justify-end gap-1">

--- a/frontend/src/pages/settings/BackupRestoreCard.tsx
+++ b/frontend/src/pages/settings/BackupRestoreCard.tsx
@@ -33,6 +33,7 @@ import {
   useUpdateBackupSettings,
 } from "@/hooks/useBackup"
 import { formatBytes } from "./format"
+import { useDateFormat } from "@/hooks/useDateFormat"
 
 interface BackupScheduleSettings {
   enabled: boolean
@@ -153,6 +154,7 @@ function ScheduledBackupsSection({ initial }: { initial: BackupScheduleSettings 
 }
 
 export function BackupRestoreCard() {
+  const { formatDateTime } = useDateFormat()
   const { data: settings } = useBackupSettings()
 
   // Backup files state
@@ -262,10 +264,6 @@ export function BackupRestoreCard() {
     }
   }
 
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr)
-    return date.toLocaleDateString() + " " + date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-  }
 
   return (
     <Card>
@@ -318,7 +316,7 @@ export function BackupRestoreCard() {
                   >
                     {files.map((backup) => (
                       <option key={backup.filename} value={backup.filename}>
-                        {backup.is_protected ? "🔒 " : ""}{backup.filename} · {formatBytes(backup.size_bytes)} · {formatDate(backup.created_at)}
+                        {backup.is_protected ? "🔒 " : ""}{backup.filename} · {formatBytes(backup.size_bytes)} · {formatDateTime(backup.created_at)}
                       </option>
                     ))}
                   </Select>

--- a/teamarr/api/routes/backup.py
+++ b/teamarr/api/routes/backup.py
@@ -125,7 +125,9 @@ def list_backups():
                 filename=b.filename,
                 filepath=b.filepath,
                 size_bytes=b.size_bytes,
-                created_at=b.created_at.isoformat(),
+                # Filename timestamps are server-local wall time; astimezone()
+                # attaches the server offset so browsers parse the instant (#511).
+                created_at=b.created_at.astimezone().isoformat(),
                 is_protected=b.is_protected,
                 backup_type=b.backup_type,
             )

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -32,6 +32,7 @@ from teamarr.database.settings import get_dispatcharr_settings
 from teamarr.dispatcharr import ChannelManager, get_dispatcharr_client
 from teamarr.services import create_channel_service, create_default_service
 from teamarr.services.stream_ordering import get_stream_ordering_service
+from teamarr.utilities.tz import parse_db_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +41,20 @@ def _safe_isoformat(value: Any) -> str | None:
     """Safely convert a date/datetime value to ISO format string.
 
     Handles cases where the value might already be a string from the database.
+
+    Strings are normalized through parse_db_timestamp (#511): SQLite-canonical
+    naive UTC gains an explicit +00:00 offset. Without one, JS ``new Date()``
+    parses the string as browser-LOCAL time, so the UI echoed raw UTC digits.
+    Aware inputs keep their instant; non-timestamp strings pass through.
     """
     if value is None:
         return None
     if isinstance(value, str):
-        return value
+        try:
+            parsed = parse_db_timestamp(value)
+        except ValueError:
+            return value
+        return parsed.isoformat() if parsed else value
     if isinstance(value, (date, datetime)):
         return value.isoformat()
     return str(value)

--- a/teamarr/database/groups.py
+++ b/teamarr/database/groups.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from sqlite3 import Connection
 from typing import Any
 
+from teamarr.utilities.tz import parse_db_timestamp
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,17 +164,20 @@ def _row_to_group(row) -> EventEPGGroup:
         except (ValueError, TypeError):
             pass
 
+    # parse_db_timestamp, not bare fromisoformat (#511): these columns hold
+    # SQLite-canonical naive UTC — the aware result keeps downstream
+    # .isoformat() serialization carrying an explicit offset for the browser.
     updated_at = None
     if row["updated_at"]:
         try:
-            updated_at = datetime.fromisoformat(row["updated_at"])
+            updated_at = parse_db_timestamp(row["updated_at"])
         except (ValueError, TypeError):
             pass
 
     last_refresh = None
     if row["last_refresh"]:
         try:
-            last_refresh = datetime.fromisoformat(row["last_refresh"])
+            last_refresh = parse_db_timestamp(row["last_refresh"])
         except (ValueError, TypeError):
             pass
 
@@ -1067,7 +1072,18 @@ def get_stale_groups(conn: Connection) -> list[dict]:
         ORDER BY name
         """
     ).fetchall()
-    return [dict(row) for row in rows]
+    out = []
+    for row in rows:
+        d = dict(row)
+        # Naive-UTC column → offset-bearing ISO for the browser (#511).
+        if d.get("source_last_seen"):
+            try:
+                parsed = parse_db_timestamp(d["source_last_seen"])
+                d["source_last_seen"] = parsed.isoformat() if parsed else None
+            except (ValueError, TypeError):
+                pass
+        out.append(d)
+    return out
 
 
 # =============================================================================

--- a/teamarr/database/templates.py
+++ b/teamarr/database/templates.py
@@ -21,6 +21,7 @@ from teamarr.core.filler_types import (
     OffseasonFillerTemplate,
     legacy_conditional_to_rows,
 )
+from teamarr.utilities.tz import parse_db_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +195,21 @@ def _parse_json(value: str | None, default: Any = None) -> Any:
         return default if default is not None else {}
 
 
+def _iso_utc(value: str | None) -> str | None:
+    """Naive-UTC DB timestamp → offset-bearing ISO string (#511).
+
+    Without an offset, JS ``new Date()`` parses the string as browser-local
+    time, shifting the displayed date by the UTC offset.
+    """
+    if not value:
+        return value
+    try:
+        parsed = parse_db_timestamp(value)
+    except (ValueError, TypeError):
+        return value
+    return parsed.isoformat() if parsed else value
+
+
 def _row_to_template(row: Row) -> Template:
     """Convert database row to Template object."""
     return Template(
@@ -237,8 +253,8 @@ def _row_to_template(row: Row) -> Template:
         conditional_descriptions=_parse_json(row["conditional_descriptions"], []),
         event_channel_name=row["event_channel_name"],
         event_channel_logo_url=row["event_channel_logo_url"],
-        created_at=row["created_at"],
-        updated_at=row["updated_at"],
+        created_at=_iso_utc(row["created_at"]),
+        updated_at=_iso_utc(row["updated_at"]),
     )
 
 

--- a/teamarr/database/templates.py
+++ b/teamarr/database/templates.py
@@ -195,19 +195,19 @@ def _parse_json(value: str | None, default: Any = None) -> Any:
         return default if default is not None else {}
 
 
-def _iso_utc(value: str | None) -> str | None:
-    """Naive-UTC DB timestamp → offset-bearing ISO string (#511).
+def _parse_ts(value: str | None) -> datetime | None:
+    """Naive-UTC DB timestamp → aware datetime (#511).
 
-    Without an offset, JS ``new Date()`` parses the string as browser-local
-    time, shifting the displayed date by the UTC offset.
+    Pydantic then serializes it WITH an offset; an offset-less string is
+    parsed as browser-local time by JS ``new Date()``, shifting the
+    displayed date by the UTC offset.
     """
     if not value:
-        return value
+        return None
     try:
-        parsed = parse_db_timestamp(value)
+        return parse_db_timestamp(value)
     except (ValueError, TypeError):
-        return value
-    return parsed.isoformat() if parsed else value
+        return None
 
 
 def _row_to_template(row: Row) -> Template:
@@ -253,8 +253,8 @@ def _row_to_template(row: Row) -> Template:
         conditional_descriptions=_parse_json(row["conditional_descriptions"], []),
         event_channel_name=row["event_channel_name"],
         event_channel_logo_url=row["event_channel_logo_url"],
-        created_at=_iso_utc(row["created_at"]),
-        updated_at=_iso_utc(row["updated_at"]),
+        created_at=_parse_ts(row["created_at"]),
+        updated_at=_parse_ts(row["updated_at"]),
     )
 
 
@@ -323,6 +323,10 @@ def list_templates_with_counts(conn: Connection) -> list[dict]:
         """
     )
     templates = [dict(row) for row in cursor.fetchall()]
+    for t in templates:
+        # Aware datetimes so the API serializes offsets (#511).
+        t["created_at"] = _parse_ts(t.get("created_at"))
+        t["updated_at"] = _parse_ts(t.get("updated_at"))
 
     # Fetch global (subscription_templates) assignments per template
     assign_cursor = conn.execute(

--- a/tests/test_timestamp_serialization.py
+++ b/tests/test_timestamp_serialization.py
@@ -1,0 +1,55 @@
+"""Regression tests for #511: API timestamps must carry an explicit offset.
+
+SQLite-canonical naive UTC strings (``datetime('now')``/``CURRENT_TIMESTAMP``)
+serialized verbatim reach the browser offset-less; JS ``new Date()`` then
+parses them as browser-LOCAL time and the UI echoes raw UTC digits (the
+"deleted at 3:01 AM" report from Brisbane).
+"""
+
+from datetime import UTC, datetime
+
+from teamarr.api.routes.channels import _safe_isoformat
+from teamarr.database.templates import _iso_utc
+
+
+class TestSafeIsoformat:
+    def test_naive_db_string_gains_utc_offset(self):
+        assert _safe_isoformat("2026-07-25 03:01:00") == "2026-07-25T03:01:00+00:00"
+
+    def test_aware_string_keeps_instant(self):
+        out = _safe_isoformat("2026-07-25T13:01:00+10:00")
+        assert out is not None
+        assert datetime.fromisoformat(out) == datetime.fromisoformat("2026-07-25T03:01:00+00:00")
+
+    def test_aware_datetime_object_passthrough(self):
+        dt = datetime(2026, 7, 25, 3, 1, tzinfo=UTC)
+        assert _safe_isoformat(dt) == "2026-07-25T03:01:00+00:00"
+
+    def test_none_and_garbage(self):
+        assert _safe_isoformat(None) is None
+        assert _safe_isoformat("not a timestamp") == "not a timestamp"
+
+
+class TestTemplateIsoUtc:
+    def test_naive_db_string_gains_utc_offset(self):
+        assert _iso_utc("2026-07-25 03:01:00") == "2026-07-25T03:01:00+00:00"
+
+    def test_none_and_garbage(self):
+        assert _iso_utc(None) is None
+        assert _iso_utc("garbage") == "garbage"
+
+
+def test_group_row_timestamps_parse_aware(db_conn):
+    """last_refresh/updated_at come back timezone-aware so route .isoformat()
+    emits an offset."""
+    from teamarr.database.groups import create_group, get_group, update_group_stats
+
+    gid = create_group(db_conn, name="TZ Test", leagues=["nfl"])
+    update_group_stats(db_conn, gid, stream_count=1, matched_count=1)
+    group = get_group(db_conn, gid)
+    assert group is not None
+    assert group.last_refresh is not None
+    assert group.last_refresh.tzinfo is not None
+    assert "+" in group.last_refresh.isoformat() or group.last_refresh.isoformat().endswith(
+        "+00:00"
+    )

--- a/tests/test_timestamp_serialization.py
+++ b/tests/test_timestamp_serialization.py
@@ -9,7 +9,7 @@ parses them as browser-LOCAL time and the UI echoes raw UTC digits (the
 from datetime import UTC, datetime
 
 from teamarr.api.routes.channels import _safe_isoformat
-from teamarr.database.templates import _iso_utc
+from teamarr.database.templates import _parse_ts
 
 
 class TestSafeIsoformat:
@@ -30,13 +30,15 @@ class TestSafeIsoformat:
         assert _safe_isoformat("not a timestamp") == "not a timestamp"
 
 
-class TestTemplateIsoUtc:
-    def test_naive_db_string_gains_utc_offset(self):
-        assert _iso_utc("2026-07-25 03:01:00") == "2026-07-25T03:01:00+00:00"
+class TestTemplateParseTs:
+    def test_naive_db_string_becomes_aware_utc(self):
+        parsed = _parse_ts("2026-07-25 03:01:00")
+        assert parsed == datetime(2026, 7, 25, 3, 1, tzinfo=UTC)
+        assert parsed.isoformat() == "2026-07-25T03:01:00+00:00"
 
     def test_none_and_garbage(self):
-        assert _iso_utc(None) is None
-        assert _iso_utc("garbage") == "garbage"
+        assert _parse_ts(None) is None
+        assert _parse_ts("garbage") is None
 
 
 def test_group_row_timestamps_parse_aware(db_conn):


### PR DESCRIPTION
Fixes #511. Two stacked defects made the Recently Deleted panel (and ~7 other spots) echo raw UTC digits:

1. **Wrong instant:** `deleted_at` & co. are stored as SQLite-canonical naive UTC and were serialized with no offset — JS `new Date()` parses an offset-less string as browser-LOCAL time (Brisbane screenshot: 03:01 UTC displayed as "3:01 AM").
2. **Wrong zone:** the render sites formatted with browser-local `toLocaleString` instead of the configured UI display timezone.

**Backend** (per the #444 `parse_db_timestamp` pattern): `_safe_isoformat` normalizes string timestamps to offset-bearing ISO (covers created/updated/deleted/cache/corrected in the channels API); group `last_refresh`/`updated_at` parse aware so all four route serializations gain `+00:00`; `/groups/stale` `source_last_seen`; template `created_at`/`updated_at`; backup `created_at` gets the **server-local** offset (filename timestamps are server wall time).

**Frontend:** affected sites now use `useDateFormat()` (`ui_timezone`): Recently Deleted + event date + Delete At (ManagedChannelsTable), group last-refresh + stream start times (EventGroups), template created date, run-history event dates, backup timestamps, Teams live-event start times. The hook gains future-relative support (`in 3h`, used by Delete At) and a date-only `formatDate`.

**Not a bug:** the reported "in 3h on a started game" is the **Delete At** column — a correct, tz-aware countdown to channel deletion (kickoff + duration + buffer), explained on the issue.

Tests: `tests/test_timestamp_serialization.py` (naive→offset, aware instant preserved, garbage passthrough, aware group rows). Gates: ruff clean · 2095 passed · frontend build + ESLint clean.