### PR TITLE
chore: upgrade react-router 7 → 8, Node 22 build baseline (#523)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build frontend
-FROM node:20-slim AS frontend-builder
+FROM node:22-slim AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "lucide-react": "^1.24.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0"
       },
@@ -1404,9 +1404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1444,9 +1438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1464,9 +1455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2069,16 +2057,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2164,18 +2152,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cronstrue": {
       "version": "3.24.0",
@@ -3301,41 +3282,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/rolldown": {
@@ -3387,12 +3351,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "lucide-react": "^1.24.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from "react-router-dom"
+import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from "react-router"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MainLayout } from "@/layouts/MainLayout"
 import { EpgLayout } from "@/components/EpgLayout"

--- a/frontend/src/components/ChannelsLayout.tsx
+++ b/frontend/src/components/ChannelsLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom"
+import { Outlet } from "react-router"
 import { ChannelsSubNav } from "@/components/ChannelsSubNav"
 
 export function ChannelsLayout() {

--- a/frontend/src/components/EpgLayout.tsx
+++ b/frontend/src/components/EpgLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom"
+import { Outlet } from "react-router"
 import { EpgSubNav } from "@/components/EpgSubNav"
 
 export function EpgLayout() {

--- a/frontend/src/components/ui/sub-nav.tsx
+++ b/frontend/src/components/ui/sub-nav.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from "react"
-import { NavLink } from "react-router-dom"
+import { NavLink } from "react-router"
 import { cn } from "@/lib/utils"
 
 export interface SubNavItem {

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, Outlet, useLocation } from "react-router-dom"
+import { Link, NavLink, Outlet, useLocation } from "react-router"
 import {
   Moon,
   Sun,

--- a/frontend/src/pages/EventGroupForm.tsx
+++ b/frontend/src/pages/EventGroupForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from "react"
-import { useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { useNavigate, useParams, useSearchParams } from "react-router"
 import { toast } from "sonner"
 import { ArrowLeft, LoaderCircle, FlaskConical } from "lucide-react"
 import { useQuery } from "@tanstack/react-query"

--- a/frontend/src/pages/EventGroupImport.tsx
+++ b/frontend/src/pages/EventGroupImport.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useNavigate } from "react-router-dom"
+import { useNavigate } from "react-router"
 import { api } from "@/api/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate } from "react-router"
 import { toast } from "sonner"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import {

--- a/frontend/src/pages/Teams.tsx
+++ b/frontend/src/pages/Teams.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate } from "react-router"
 import { toast } from "sonner"
 import {
   Plus,

--- a/frontend/src/pages/TemplateForm.tsx
+++ b/frontend/src/pages/TemplateForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useMemo, type ReactNode } from "react"
-import { useNavigate, useParams } from "react-router-dom"
+import { useNavigate, useParams } from "react-router"
 import { toast } from "sonner"
 import { ArrowLeft, User, Tv, ArrowRight, Check } from "lucide-react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react"
-import { useNavigate } from "react-router-dom"
+import { useNavigate } from "react-router"
 import { toast } from "sonner"
 import { Plus, Trash2, Pencil, LoaderCircle, Copy, Download, Upload, Tv, User, RotateCcw } from "lucide-react"
 import { Alert } from "@/components/ui/alert"

--- a/frontend/src/pages/template-form/tabs/AssignmentsTab.tsx
+++ b/frontend/src/pages/template-form/tabs/AssignmentsTab.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useMemo, useState, useCallback } from "react"
-import { Link } from "react-router-dom"
+import { Link } from "react-router"
 import { useQuery } from "@tanstack/react-query"
 import { Plus, Pencil, Trash2, ExternalLink, LoaderCircle, Info } from "lucide-react"
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
Closes Dependabot alert #32; implements #523.

## What
- `react-router-dom` 7.18.1 → `react-router` 8.3.0 (`react-router-dom` is removed upstream in v8; import swap across 12 files — every API we use is unchanged in core)
- Node build baseline 20 → 22 (`Dockerfile`, CI `test.yml`) — v8 requires Node ≥ 22.22
- `npm audit fix` picked up the transitive `brace-expansion` DoS fix; **npm audit now reports 0 vulnerabilities**

## Why now
Alert #32 (high, RSC-mode CSRF) has no 7.x patch. Not exploitable in Teamarr (client-only SPA, `BrowserRouter`, no RSC/server actions), but the fix turned out to be a trivial import swap — all other v8 breaking changes (middleware, loaders, meta, pre-rendering, ESM-only under Vite) are framework-mode surface we don't touch. React ≥ 19.2.7 and Vite 7+ baselines were already met.

## Verification
- `tsc -b && vite build` ✓ (2068 modules)
- eslint: 0 errors (2 pre-existing React Compiler warnings, unrelated)
- `ruff` ✓, `pytest` 2113 passed
- Runtime smoke on the live dev server: nested routes (`/channels/stream-priority`) render with working sub-nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)