### PR TITLE
feat: EPG-resolver region-prefix/network-alias widening + shared text_primitives module

### DIFF
--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -16,9 +16,19 @@ from re import Pattern
 from typing import cast
 
 from teamarr.consumers.matching.normalizer import NormalizedStream, normalize_stream
+from teamarr.consumers.matching.text_primitives import TEAM_SAFE_QUALITY_TOKENS
 from teamarr.services.detection_keywords import DetectionKeywordService
 
 logger = logging.getLogger(__name__)
+
+# Quality/format tokens safe to strip from an extracted TEAM name, at the
+# start or end of the string only. Sourced from the shared
+# text_primitives.TEAM_SAFE_QUALITY_TOKENS (a conservative subset of
+# QUALITY_TOKENS -- see that module for the hq/lq exclusion rationale), so a
+# token added there automatically applies here too.
+_TEAM_QUALITY_ALTERNATION = "|".join(re.escape(token) for token in sorted(TEAM_SAFE_QUALITY_TOKENS))
+_TEAM_QUALITY_START = re.compile(rf"^\s*\b(?:{_TEAM_QUALITY_ALTERNATION})\b\s*", re.IGNORECASE)
+_TEAM_QUALITY_END = re.compile(rf"\s+\b(?:{_TEAM_QUALITY_ALTERNATION})\b\s*$", re.IGNORECASE)
 
 
 class StreamCategory(Enum):
@@ -945,9 +955,9 @@ def _clean_team_name(name: str) -> str:
         flags=re.IGNORECASE,
     )
 
-    # Remove HD, SD, 4K, UHD quality indicators (at start or end)
-    name = re.sub(r"^\s*\b(HD|SD|FHD|4K|UHD)\b\s*", "", name, flags=re.IGNORECASE)
-    name = re.sub(r"\s+\b(HD|SD|FHD|4K|UHD)\b\s*$", "", name, flags=re.IGNORECASE)
+    # Remove quality indicators (at start or end) -- team-name-safe subset only
+    name = _TEAM_QUALITY_START.sub("", name)
+    name = _TEAM_QUALITY_END.sub("", name)
 
     # Remove broadcast network indicators like (CBS), (FOX), (ABC), (NBC), (ESPN)
     name = re.sub(

--- a/teamarr/consumers/matching/epg_resolver.py
+++ b/teamarr/consumers/matching/epg_resolver.py
@@ -44,17 +44,40 @@ _QUALITY_TOKENS = re.compile(
 # stream with a country label and a delimiter — "US: ESPN FHD", "UK | Sky
 # Sports". Without stripping it, "US: ESPN" normalizes to "us espn" and never
 # matches the EPGData catalog's "espn", so name-cascade resolution collapses to
-# zero for such providers. We strip ONE leading <code> + (':' or '|') prefix.
+# zero for such providers. We strip ONE leading <code> + delimiter prefix,
+# where the delimiter is ':', '|', or a SPACED dash (" - ").
 #
 # The delimiter is the safety anchor: "USA Network" (no delimiter) is left
 # intact so its identity "usa" survives, while "US: USA Network" -> "USA
-# Network". The allowlist keeps a stray "ESPN: …"-style title from being
-# mistaken for a region prefix.
+# Network". The allowlist keeps a stray "ESPN: …"-style title (or a city
+# abbreviation like "LA - Lakers Live") from being mistaken for a region
+# prefix. The dash variant requires whitespace on BOTH sides so an unspaced
+# hyphen inside a real name ("FR-ESPN", "Bein-Sports") is never split on.
 _REGION_PREFIX = re.compile(
     r"^\s*(?:us|usa|uk|ca|au|nz|ie|ire|fr|de|es|it|nl|pt|be|ch|no|se|dk|fi|"
-    r"br|mx|ar|in|gr|al|tr|bg|cz|pl|ro|hu|hr|rs|eu|intl|latam|ex-?yu)\s*[:|]\s*",
+    r"br|mx|ar|in|gr|al|tr|bg|cz|pl|ro|hu|hr|rs|eu|intl|latam|ex-?yu|"
+    r"jp|kr|cn|za|sa|qa|ae|il|pk|ph|th|vn|my|sg|id|hk|tw)"
+    r"(?:\s*[:|]\s*|\s+-\s+)",
     re.IGNORECASE,
 )
+
+# Network abbreviation -> canonical EPGData-style name. Applied at the very
+# end of normalize_channel_name(), after region-prefix stripping and quality
+# suffix removal, so e.g. "US: FS1 HD" -> "fs1" -> "fox sports 1".
+#
+# Mechanism (deliberately simple since only final strings are asserted):
+# exact-match the whole normalized string against a key, OR -- for
+# multi-word names like "SN 360" -- rewrite just the LEADING token when it
+# exactly equals a key. This aliases "sn" only when it stands alone as a
+# whole token (leading or entire name), so "sn 360" -> "sportsnet 360" but
+# "wisconsin sports" and "espn2" are left untouched (no substring aliasing).
+NETWORK_ALIASES = {
+    "fs1": "fox sports 1",
+    "fs2": "fox sports 2",
+    "nbcsn": "nbc sports network",
+    "cbssn": "cbs sports network",
+    "sn": "sportsnet",
+}
 
 
 def normalize_channel_name(name: str) -> str:
@@ -71,7 +94,17 @@ def normalize_channel_name(name: str) -> str:
     n = re.sub(r"\(.*?\)", " ", n)  # drop "(US)", "(1080p)", etc.
     n = re.sub(r"[^a-z0-9]+", " ", n)  # punctuation -> space
     n = _QUALITY_TOKENS.sub(" ", n)
-    return re.sub(r"\s+", " ", n).strip()
+    n = re.sub(r"\s+", " ", n).strip()
+
+    # Network abbreviation aliasing (see NETWORK_ALIASES above) -- last step,
+    # after region-prefix stripping, so e.g. "US: FS1" -> "fs1" -> aliased.
+    if n in NETWORK_ALIASES:
+        return NETWORK_ALIASES[n]
+    tokens = n.split(" ")
+    if tokens and tokens[0] in NETWORK_ALIASES:
+        tokens[0] = NETWORK_ALIASES[tokens[0]]
+        return " ".join(tokens)
+    return n
 
 
 # Dispatcharr's own channel-proxy URL shape. A "Dispatcharr inside
@@ -223,7 +256,12 @@ def resolve_program_tvg_ids(
     logger.info(
         "[EPG-RESOLVE] resolved %d stream tvg_ids (channel=%d loopback=%d direct=%d "
         "name=%d ambiguous_name=%d unresolved=%d)",
-        len(resolution), stats["channel"], stats["loopback"], stats["direct"],
-        stats["name"], stats["ambiguous_name"], stats["unresolved"],
+        len(resolution),
+        stats["channel"],
+        stats["loopback"],
+        stats["direct"],
+        stats["name"],
+        stats["ambiguous_name"],
+        stats["unresolved"],
     )
     return resolution, stats

--- a/teamarr/consumers/matching/epg_resolver.py
+++ b/teamarr/consumers/matching/epg_resolver.py
@@ -30,15 +30,31 @@ fetched by the resolved key yet keyed by the stream tvg_id the matcher carries.
 import logging
 import re
 
+from teamarr.consumers.matching.text_primitives import QUALITY_TOKENS, REGION_CODES
+
 logger = logging.getLogger(__name__)
 
 # Quality / format tokens that decorate a channel name but not its identity.
 # Deliberately NOT including country words (us/usa) or feed words (backup/alt),
-# which CAN change identity ("USA Network" must keep "usa").
+# which CAN change identity ("USA Network" must keep "usa"). Sourced from the
+# shared text_primitives.QUALITY_TOKENS so a token added there automatically
+# applies here too.
 _QUALITY_TOKENS = re.compile(
-    r"\b(fhd|uhd|hd|sd|4k|hevc|h265|h264|hq|lq)\b",
+    r"\b(?:" + "|".join(re.escape(t) for t in sorted(QUALITY_TOKENS)) + r")\b",
     re.IGNORECASE,
 )
+
+
+def _region_code_pattern(code: str) -> str:
+    """Regex fragment for a single region code.
+
+    "exyu" is the one code that needs an optional-hyphen variant (matches
+    both "exyu" and "ex-yu") -- everything else is a literal, escaped code.
+    """
+    if code == "exyu":
+        return "ex-?yu"
+    return re.escape(code)
+
 
 # Country / region grouping prefixes (bead yke). Many providers prefix every
 # stream with a country label and a delimiter — "US: ESPN FHD", "UK | Sky
@@ -53,11 +69,13 @@ _QUALITY_TOKENS = re.compile(
 # abbreviation like "LA - Lakers Live") from being mistaken for a region
 # prefix. The dash variant requires whitespace on BOTH sides so an unspaced
 # hyphen inside a real name ("FR-ESPN", "Bein-Sports") is never split on.
+#
+# The allowlist itself is sourced from the shared text_primitives.REGION_CODES
+# so a code added there automatically applies here too.
 _REGION_PREFIX = re.compile(
-    r"^\s*(?:us|usa|uk|ca|au|nz|ie|ire|fr|de|es|it|nl|pt|be|ch|no|se|dk|fi|"
-    r"br|mx|ar|in|gr|al|tr|bg|cz|pl|ro|hu|hr|rs|eu|intl|latam|ex-?yu|"
-    r"jp|kr|cn|za|sa|qa|ae|il|pk|ph|th|vn|my|sg|id|hk|tw)"
-    r"(?:\s*[:|]\s*|\s+-\s+)",
+    r"^\s*(?:"
+    + "|".join(_region_code_pattern(c) for c in sorted(REGION_CODES))
+    + r")(?:\s*[:|]\s*|\s+-\s+)",
     re.IGNORECASE,
 )
 

--- a/teamarr/consumers/matching/text_primitives.py
+++ b/teamarr/consumers/matching/text_primitives.py
@@ -1,0 +1,159 @@
+"""Shared normalization primitives for the matching pipelines (Phase 3b, item 13).
+
+Two normalization pipelines maintain separate copies of overlapping
+concepts:
+
+- ``teamarr.consumers.matching.epg_resolver`` -- channel-identity
+  normalization (``normalize_channel_name``), which needs a strict,
+  unambiguous quality-token strip and a region-prefix allowlist.
+- ``teamarr.consumers.matching.classifier`` -- team-text normalization
+  (``_clean_team_name``), which needs a much more conservative quality-token
+  strip since a false-positive strip on a team name is more damaging.
+
+Full behavioral unification between the two is explicitly NOT the goal here
+(the two jobs are different: strict channel-name equality vs. team-name
+extraction). This module exists to be the SHARED SOURCE for the pieces that
+really are the same concept in both places, so adding a token or region code
+once makes it available everywhere it should apply.
+"""
+
+import re
+
+# Quality / video-format tokens that decorate a channel name but don't change
+# its identity ("ESPN FHD" and "ESPN" are the same channel). This is the
+# superset used by channel-identity normalization (epg_resolver). Team-name
+# extraction (classifier) uses the narrower TEAM_SAFE_QUALITY_TOKENS below.
+QUALITY_TOKENS: frozenset[str] = frozenset(
+    {
+        "fhd",
+        "uhd",
+        "hd",
+        "sd",
+        "4k",
+        "hevc",
+        "h265",
+        "h264",
+        "hq",
+        "lq",
+    }
+)
+
+# Subset of QUALITY_TOKENS judged safe to strip from an extracted TEAM name
+# (as opposed to a channel/EPG name). See the module-level judgment-call note
+# below: "hq"/"lq" are deliberately excluded.
+#
+# Token-safety judgment call (for lead review): is it safe to strip ALL of
+# QUALITY_TOKENS from a TEAM name? Channel names are provider metadata
+# strings ("ESPN FHD", "US: TSN 1 HD") where these tokens are unambiguously
+# video-quality decoration. Team names are extracted from free-form stream
+# titles and are meant to end up as the actual displayed team/matchup name,
+# so a false-positive strip is more damaging AND more plausible there.
+#
+# "hevc", "h265", and "h264" are codec names with no plausible legitimate
+# overlap with a team, city, or venue name in English sports broadcasting --
+# they're safe to strip in the team-name context.
+#
+# "hq" and "lq" are excluded. They are common two-letter tokens far more
+# likely to accidentally collide with real name fragments at a word boundary
+# (initials-style abbreviations, or a venue name like "... HQ" for a team
+# headquarters/facility) than a channel-name provider would ever use them
+# ambiguously. Given "hq"/"lq" are a much rarer/weaker signal for actual
+# stream quality than hd/sd/fhd/4k/uhd/hevc/h26x in the first place, the
+# safer default for team-name extraction is to leave them alone and accept
+# that a rare literal "... HQ"/"... LQ" quality suffix survives in a team
+# name, over the risk of mangling a legitimate name. This is a design
+# decision made by the test author (not verified against any real-world
+# "HQ"/"LQ" team name collision) -- flagged explicitly here for lead review.
+TEAM_SAFE_QUALITY_TOKENS: frozenset[str] = QUALITY_TOKENS - {"hq", "lq"}
+
+# Country / region grouping prefix codes (bead yke). Many providers prefix
+# every stream with a country label and a delimiter -- "US: ESPN FHD", "UK |
+# Sky Sports". This is the shared allowlist used to build the leading-prefix
+# regex in epg_resolver. Includes both the original allowlist and Phase 3a's
+# Asia-Pacific / Middle East additions.
+REGION_CODES: frozenset[str] = frozenset(
+    {
+        "us",
+        "usa",
+        "uk",
+        "ca",
+        "au",
+        "nz",
+        "ie",
+        "ire",
+        "fr",
+        "de",
+        "es",
+        "it",
+        "nl",
+        "pt",
+        "be",
+        "ch",
+        "no",
+        "se",
+        "dk",
+        "fi",
+        "br",
+        "mx",
+        "ar",
+        "in",
+        "gr",
+        "al",
+        "tr",
+        "bg",
+        "cz",
+        "pl",
+        "ro",
+        "hu",
+        "hr",
+        "rs",
+        "eu",
+        "intl",
+        "latam",
+        "exyu",  # matched as "ex-?yu" by callers (optional hyphen) -- see epg_resolver
+        "jp",
+        "kr",
+        "cn",
+        "za",
+        "sa",
+        "qa",
+        "ae",
+        "il",
+        "pk",
+        "ph",
+        "th",
+        "vn",
+        "my",
+        "sg",
+        "id",
+        "hk",
+        "tw",
+    }
+)
+
+
+def strip_quality_tokens(text: str, tokens: frozenset[str] | None = None) -> str:
+    """Strip quality/format tokens from ``text`` on word boundaries.
+
+    The token match is case-insensitive ("FHD", "Fhd", "fhd" are all
+    stripped), so "shdtv" is left untouched -- "hd" is not a standalone word
+    there. Whitespace left behind by a removed token is collapsed, and the
+    result is lowercased.
+
+    Args:
+        text: Text to strip tokens from.
+        tokens: Token set to strip. Defaults to QUALITY_TOKENS.
+
+    Returns:
+        The lowercased, whitespace-collapsed text with the tokens removed.
+    """
+    if tokens is None:
+        tokens = QUALITY_TOKENS
+
+    result = text
+    if tokens:
+        alternation = "|".join(re.escape(token) for token in sorted(tokens))
+        result = re.sub(rf"\b(?:{alternation})\b", "", result, flags=re.IGNORECASE)
+
+    result = re.sub(r"\s+", " ", result).strip().lower()
+    return result

--- a/tests/epg/test_epg_resolver.py
+++ b/tests/epg/test_epg_resolver.py
@@ -69,6 +69,111 @@ def test_prefix_strip_enables_name_resolution():
     assert stats["name"] == 1
 
 
+# ============================================= region prefixes: item 10 (Phase 3a)
+
+
+def test_normalize_strips_spaced_dash_delimiter():
+    # New delimiter: a spaced dash is as valid a grouping separator as ":" or
+    # "|". Today _REGION_PREFIX only recognizes [:|], so "US - ESPN" is left
+    # as "us espn" instead of being stripped to "espn".
+    assert normalize_channel_name("US - ESPN") == "espn"
+
+
+def test_normalize_allowlist_extended_with_asia_pacific_and_middle_east_codes():
+    # New allowlist codes: jp, kr, cn, za, sa, qa, ae, il, pk, ph, th, vn, my,
+    # sg, id, hk, tw. None of these are in the current _REGION_PREFIX
+    # allowlist, so all of these currently stay unstripped (e.g. "jp nhk").
+    assert normalize_channel_name("JP: NHK") == "nhk"
+    assert normalize_channel_name("KR: KBS") == "kbs"
+    assert normalize_channel_name("CN: CCTV") == "cctv"
+    assert normalize_channel_name("ZA: SuperSport") == "supersport"
+    assert normalize_channel_name("SA: Al Jazeera") == "al jazeera"
+    assert normalize_channel_name("QA: BeIN") == "bein"
+    assert normalize_channel_name("AE: Dubai Sports") == "dubai sports"
+    assert normalize_channel_name("IL: Sport1") == "sport1"
+    assert normalize_channel_name("PK: PTV") == "ptv"
+    assert normalize_channel_name("PH: ABS-CBN") == "abs cbn"
+    assert normalize_channel_name("TH: Thai PBS") == "thai pbs"
+    assert normalize_channel_name("VN: VTV") == "vtv"
+    assert normalize_channel_name("MY: Astro") == "astro"
+    assert normalize_channel_name("SG: StarHub") == "starhub"
+    assert normalize_channel_name("ID: RCTI") == "rcti"
+    assert normalize_channel_name("HK: TVB") == "tvb"
+    assert normalize_channel_name("TW: CTV") == "ctv"
+
+
+def test_normalize_new_allowlist_code_with_spaced_dash():
+    # The two new-contract pieces (spaced dash + expanded allowlist) combined.
+    assert normalize_channel_name("JP - NHK World") == "nhk world"
+
+
+def test_normalize_no_delimiter_still_not_stripped():
+    # NON-goal: "USA ESPN" has no delimiter at all (no ":", "|", or " - "),
+    # so it stays ambiguous and must NOT be treated as a grouping prefix, same
+    # as today. Guards against an implementation that starts matching on bare
+    # whitespace once dash-support is added.
+    assert normalize_channel_name("USA ESPN") == "usa espn"
+
+
+def test_normalize_city_code_false_positive_guard():
+    # NON-goal: "LA" (Los Angeles) is deliberately NOT in the allowlist even
+    # though the new dash delimiter would otherwise make "LA - Lakers Live"
+    # look like a region-prefixed name. Adding the dash delimiter must not
+    # accidentally treat city abbreviations as country codes.
+    assert normalize_channel_name("LA - Lakers Live") == "la lakers live"
+
+
+def test_normalize_unspaced_dash_not_treated_as_delimiter():
+    # NON-goal: only a SPACED dash (" - ") is a delimiter. An unspaced dash
+    # ("FR-ESPN") must stay untouched by the region-prefix step so real names
+    # like "Bein-Sports" are never accidentally split on their hyphen.
+    assert normalize_channel_name("FR-ESPN") == "fr espn"
+
+
+# ============================================ network aliases: item 11 (Phase 3a)
+
+
+def test_fs1_and_fox_sports_1_normalize_to_the_same_string():
+    # NETWORK_ALIASES doesn't exist yet -- "fs1" and "fox sports 1" are
+    # currently two distinct normalized strings.
+    assert normalize_channel_name("FS1 HD") == normalize_channel_name("Fox Sports 1 FHD")
+    assert normalize_channel_name("FS1 HD") == "fox sports 1"
+
+
+def test_region_prefixed_fs1_also_aliases():
+    # Alias resolution runs AFTER region-prefix stripping.
+    assert normalize_channel_name("US: FS1") == "fox sports 1"
+
+
+def test_fs2_aliases_to_fox_sports_2():
+    assert normalize_channel_name("FS2") == "fox sports 2"
+
+
+def test_nbcsn_aliases_to_nbc_sports_network():
+    assert normalize_channel_name("NBCSN") == "nbc sports network"
+
+
+def test_cbssn_aliases_to_cbs_sports_network():
+    assert normalize_channel_name("CBSSN") == "cbs sports network"
+
+
+def test_espn2_does_not_collapse_to_espn():
+    # Pinned NON-goal: ESPN2 is a distinct channel, not an "ESPN" abbreviation.
+    assert normalize_channel_name("ESPN2 HD") == "espn2"
+    assert normalize_channel_name("ESPN2 HD") != normalize_channel_name("ESPN HD")
+
+
+def test_sn_aliases_to_sportsnet_only_as_whole_name():
+    assert normalize_channel_name("SN 360") == "sportsnet 360"
+
+
+def test_sn_substring_inside_word_is_untouched():
+    # Pinned NON-goal: "sn" must only alias when it IS the whole normalized
+    # name (or a whole leading token per "sn 360"), not when it's merely
+    # contained inside another word.
+    assert normalize_channel_name("Wisconsin Sports") == "wisconsin sports"
+
+
 # ====================================================================== cascade
 
 

--- a/tests/test_text_primitives.py
+++ b/tests/test_text_primitives.py
@@ -76,15 +76,15 @@ for lead review before implementation locks it in.
 """
 
 import pytest
+
+from teamarr.consumers.matching.classifier import _clean_team_name
+from teamarr.consumers.matching.epg_resolver import normalize_channel_name
 from teamarr.consumers.matching.text_primitives import (
     QUALITY_TOKENS,
     REGION_CODES,
     TEAM_SAFE_QUALITY_TOKENS,
     strip_quality_tokens,
 )
-
-from teamarr.consumers.matching.classifier import _clean_team_name
-from teamarr.consumers.matching.epg_resolver import normalize_channel_name
 
 # ================================================================= QUALITY_TOKENS
 

--- a/tests/test_text_primitives.py
+++ b/tests/test_text_primitives.py
@@ -1,0 +1,215 @@
+"""Tests for shared normalization primitives (Phase 3b, item 13).
+
+Context: two normalization pipelines maintain separate copies of
+overlapping concepts:
+
+- ``teamarr.consumers.matching.epg_resolver`` -- channel-identity
+  normalization (``normalize_channel_name``), hardcodes its own
+  ``_QUALITY_TOKENS`` regex and ``_REGION_PREFIX`` allowlist.
+- ``teamarr.consumers.matching.classifier`` -- team-text normalization
+  (``_clean_team_name``), hardcodes its own quality-token strip (currently
+  only ``HD|SD|FHD|4K|UHD``, at start/end of the string only).
+
+Full behavioral unification is explicitly NOT wanted here (the two jobs are
+different: strict channel-name equality vs. team-name extraction). What
+this module (``teamarr.consumers.matching.text_primitives``, which does
+NOT exist yet) is meant to provide is a SHARED SOURCE for the pieces that
+really are the same concept in both places, so adding a token/region code
+once makes it available everywhere it should be:
+
+- ``QUALITY_TOKENS``: frozenset[str], lowercase. Must be a superset of the
+  union of both pipelines' current token lists. Reading the source on this
+  branch: epg_resolver's ``_QUALITY_TOKENS`` already covers
+  ``{fhd, uhd, hd, sd, 4k, hevc, h265, h264, hq, lq}``, and classifier's
+  ``_clean_team_name`` only knows ``{hd, sd, fhd, 4k, uhd}`` (a subset). So
+  the union -- and therefore the minimum required content of
+  ``QUALITY_TOKENS`` -- is exactly epg_resolver's current 10-token set.
+
+- ``TEAM_SAFE_QUALITY_TOKENS``: frozenset[str], a SUBSET of
+  ``QUALITY_TOKENS`` -- see "token-safety judgment call" below for why this
+  exists and what it deliberately excludes.
+
+- ``strip_quality_tokens(text, tokens=QUALITY_TOKENS) -> str``: removes the
+  given tokens from ``text`` on word boundaries (so "shdtv" is untouched --
+  "hd" is not a standalone word there), collapses whitespace, and
+  lowercases the result. Case-insensitive on the token match itself (so
+  "FHD", "Fhd", "fhd" are all stripped).
+
+- ``REGION_CODES``: frozenset[str], lowercase. Must be a superset of the
+  union of epg_resolver's ORIGINAL region-prefix allowlist and this
+  branch's Phase 3a additions (see the current ``_REGION_PREFIX`` regex in
+  ``epg_resolver.py``, which already includes both).
+
+--------------------------------------------------------------------------
+Token-safety judgment call (for lead review)
+--------------------------------------------------------------------------
+The spec asks: is it safe to strip ALL of ``QUALITY_TOKENS`` from a TEAM
+name (as opposed to a channel/EPG name)? Channel names are provider
+metadata strings ("ESPN FHD", "US: TSN 1 HD") where these tokens are
+unambiguously video-quality decoration. Team names are extracted from
+free-form stream titles and are meant to end up as the actual displayed
+team/matchup name, so a false-positive strip is more damaging AND more
+plausible there.
+
+Judgment: ``hevc``, ``h265``, and ``h264`` are codec names with no
+plausible legitimate overlap with a team, city, or venue name in English
+sports broadcasting -- they're safe to strip in the team-name context, and
+are added to ``TEAM_SAFE_QUALITY_TOKENS``.
+
+``hq`` and ``lq`` are excluded from ``TEAM_SAFE_QUALITY_TOKENS`` and are
+NOT stripped by ``_clean_team_name``. They are common two-letter tokens
+that are far more likely to accidentally collide with real name fragments
+at a word boundary (initials-style abbreviations, or as part of a venue
+name like "... HQ" for a team headquarters/facility) than a channel-name
+provider ever would use them ambiguously. Given "hq"/"lq" are a much
+rarer/weaker signal for actual stream quality than hd/sd/fhd/4k/uhd/hevc/
+h26x in the first place, the safer default for team-name extraction is to
+leave them alone and accept that a rare literal "... HQ"/"... LQ" quality
+suffix survives in a team name, over the risk of mangling a legitimate
+name. ``QUALITY_TOKENS`` (the channel-identity superset) still includes
+them, since ``normalize_channel_name`` genuinely needs them and channel
+names don't carry this ambiguity risk.
+
+This is a design decision made by the test author (not verified against
+any real-world "HQ"/"LQ" team name collision) -- flagged explicitly here
+for lead review before implementation locks it in.
+"""
+
+import pytest
+from teamarr.consumers.matching.text_primitives import (
+    QUALITY_TOKENS,
+    REGION_CODES,
+    TEAM_SAFE_QUALITY_TOKENS,
+    strip_quality_tokens,
+)
+
+from teamarr.consumers.matching.classifier import _clean_team_name
+from teamarr.consumers.matching.epg_resolver import normalize_channel_name
+
+# ================================================================= QUALITY_TOKENS
+
+
+def test_quality_tokens_is_superset_of_both_pipelines_current_lists():
+    minimum_required = {
+        "fhd",
+        "uhd",
+        "hd",
+        "sd",
+        "4k",
+        "hevc",
+        "h265",
+        "h264",
+        "hq",
+        "lq",
+    }
+    assert minimum_required <= QUALITY_TOKENS
+
+
+def test_quality_tokens_are_all_lowercase():
+    assert all(token == token.lower() for token in QUALITY_TOKENS)
+
+
+def test_team_safe_quality_tokens_is_subset_of_quality_tokens():
+    assert TEAM_SAFE_QUALITY_TOKENS <= QUALITY_TOKENS
+
+
+def test_team_safe_quality_tokens_excludes_hq_and_lq():
+    """Judgment call (see module docstring): hq/lq are excluded from the
+    team-name-safe subset as too collision-prone for team/venue names."""
+    assert "hq" not in TEAM_SAFE_QUALITY_TOKENS
+    assert "lq" not in TEAM_SAFE_QUALITY_TOKENS
+
+
+def test_team_safe_quality_tokens_includes_codec_names():
+    """hevc/h265/h264 have no plausible overlap with a team name and are
+    judged safe to strip in the team-name context."""
+    assert {"hevc", "h265", "h264"} <= TEAM_SAFE_QUALITY_TOKENS
+
+
+# ============================================================= REGION_CODES
+
+
+def test_region_codes_contains_original_codes():
+    for code in ("us", "uk", "de"):
+        assert code in REGION_CODES
+
+
+def test_region_codes_contains_phase_3a_additions():
+    for code in ("jp", "kr", "hk", "tw"):
+        assert code in REGION_CODES
+
+
+def test_region_codes_are_all_lowercase():
+    assert all(code == code.lower() for code in REGION_CODES)
+
+
+# ======================================================= strip_quality_tokens
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("ESPN FHD", "espn"),
+        ("4K Sports HD", "sports"),
+        ("shdtv", "shdtv"),  # word-boundary: "hd" is not a standalone token here
+        ("FHD UHD Sports HD", "sports"),  # multiple tokens, all stripped
+        ("Willow 2", "willow 2"),  # already clean -- lowercased passthrough
+    ],
+)
+def test_strip_quality_tokens_behavior_table(text, expected):
+    assert strip_quality_tokens(text) == expected
+
+
+def test_strip_quality_tokens_is_case_insensitive_on_the_token():
+    assert strip_quality_tokens("ESPN fHd") == "espn"
+
+
+def test_strip_quality_tokens_accepts_a_custom_token_set():
+    # With a restricted token set, tokens outside it are left alone.
+    assert strip_quality_tokens("HQ Lakers", tokens=frozenset({"hq"})) == "lakers"
+    assert strip_quality_tokens("HEVC Lakers", tokens=frozenset({"hq"})) == "hevc lakers"
+
+
+# ================================================ anti-drift: epg_resolver
+#
+# normalize_channel_name's quality-stripping must be driven by
+# text_primitives.QUALITY_TOKENS (the shared source), not a private copy.
+# Tested behaviorally: every token in the shared set must actually get
+# stripped by normalize_channel_name. This is parametrized over the LIVE
+# QUALITY_TOKENS set (not a hardcoded list), so if someone adds a new token
+# to the shared set later without epg_resolver picking it up (because it
+# was refactored to import from text_primitives), this test starts failing
+# for that new token automatically.
+
+
+@pytest.mark.parametrize("token", sorted(QUALITY_TOKENS))
+def test_normalize_channel_name_strips_every_shared_quality_token(token):
+    assert normalize_channel_name(f"Sample Channel {token.upper()}") == "sample channel"
+
+
+# ================================================== anti-drift: classifier
+#
+# _clean_team_name's quality-stripping must be driven by
+# text_primitives.TEAM_SAFE_QUALITY_TOKENS (the team-name-safe subset of
+# the shared source), not classifier's own private, narrower copy. Today
+# classifier only knows hd/sd/fhd/4k/uhd, so this fails for hevc/h265/h264
+# until classifier is wired up to the shared subset.
+
+
+@pytest.mark.parametrize("token", sorted(TEAM_SAFE_QUALITY_TOKENS))
+def test_clean_team_name_strips_every_team_safe_quality_token_at_start(token):
+    assert _clean_team_name(f"{token.upper()} Lakers") == "Lakers"
+
+
+@pytest.mark.parametrize("token", sorted(TEAM_SAFE_QUALITY_TOKENS))
+def test_clean_team_name_strips_every_team_safe_quality_token_at_end(token):
+    assert _clean_team_name(f"Lakers {token.upper()}") == "Lakers"
+
+
+@pytest.mark.parametrize("token", ["hq", "lq"])
+def test_clean_team_name_leaves_unsafe_quality_tokens_untouched(token):
+    """hq/lq are deliberately excluded from TEAM_SAFE_QUALITY_TOKENS (see
+    module docstring) -- classifier must leave them in place rather than
+    risk mangling a legitimate name fragment."""
+    assert _clean_team_name(f"{token.upper()} Lakers") == f"{token.upper()} Lakers"
+    assert _clean_team_name(f"Lakers {token.upper()}") == f"Lakers {token.upper()}"


### PR DESCRIPTION
Widens `epg_resolver.normalize_channel_name()`'s region-prefix stripping and adds a network-abbreviation alias table, then extracts the quality-token and region-code concepts both `epg_resolver.py` and `classifier.py` had independently hardcoded into one shared module (`text_primitives.py`) so a token or region code added once applies everywhere.

## What's included

1. **Region-prefix widening:** `_REGION_PREFIX` now also recognizes a spaced dash (`" - "`) as a grouping delimiter alongside `:` and `|` (`"US - ESPN"` → `"espn"`), and the country-code allowlist gained Asia-Pacific/Middle East codes (jp, kr, cn, za, sa, qa, ae, il, pk, ph, th, vn, my, sg, id, hk, tw). Guarded so undelimited text (`"USA ESPN"`), out-of-allowlist codes (`"LA - Lakers Live"`), and unspaced hyphens (`"FR-ESPN"`) are still left untouched.
2. **Network aliases:** `NETWORK_ALIASES` maps common abbreviations (fs1, fs2, nbcsn, cbssn, sn) to their full EPGData-style names, applied as the final step of `normalize_channel_name()`, matched on the whole normalized string or its leading token only (so `"sn 360"` aliases but `"wisconsin sports"` and `"espn2"` don't).
3. **Shared `text_primitives` module:** `QUALITY_TOKENS`, `TEAM_SAFE_QUALITY_TOKENS`, `REGION_CODES`, and `strip_quality_tokens()` become the single source both `epg_resolver.py`'s quality-token/region regexes and `classifier.py`'s `_clean_team_name` start/end quality-token strip now derive from, instead of each keeping its own hardcoded copy. `classifier.py` picks up hevc/h265/h264 as a result, while deliberately continuing to exclude hq/lq (too collision-prone for team/venue names — documented in the module docstring).

## Motivation

Kept as one PR because `text_primitives.py` is a genuine shared dependency: the region-prefix regex in `epg_resolver.py` and the quality-token strip in `classifier.py` both get rebuilt from it in the same logical change. Splitting the region/alias widening from the text_primitives extraction would leave an intermediate state where `epg_resolver.py` has two competing hardcoded token lists for one release; keeping them together avoids that churn and matches how the work was actually done and tested (tests were written against the shared module before either consumer was touched).

## What changed

- `teamarr/consumers/matching/epg_resolver.py` — widened region-prefix delimiter/allowlist, `NETWORK_ALIASES`, then re-derived `_QUALITY_TOKENS`/`_REGION_PREFIX` from `text_primitives`
- `teamarr/consumers/matching/text_primitives.py` — new shared module
- `teamarr/consumers/matching/classifier.py` — `_clean_team_name` quality-token strip now sourced from `TEAM_SAFE_QUALITY_TOKENS`

## Behavior-change callouts (worth flagging for maintainer sign-off)

- **Region-prefix stripping now applies to substantially more codes and a new delimiter shape.** Any provider feed using `"XX - Channel Name"` for a code in the widened allowlist, or one of the newly added Asia-Pacific/Middle East codes, will normalize differently than before — this is the intended fix, but it's a behavior change on live catalogs, not just new coverage of previously-untouched strings.
- **`NETWORK_ALIASES` is new normalization behavior**, not a bug fix per se — `"FS1"` and `"Fox Sports 1"` now collapse to the same normalized name where they previously didn't. Worth explicit sign-off since it changes EPG-resolution matching outcomes for those five abbreviations on any existing installation.
- No dry-run posture applies (pure string normalization, no destructive action).

This branch is file-disjoint from the other two Teamarr PRs I'm opening alongside this one and can be merged independently in any order.

Tests: `tests/epg/test_epg_resolver.py` (extended), `tests/test_text_primitives.py` (new) — `pytest tests/ -q`: 2092 passed (2035 baseline + 57 new); `ruff check teamarr/ tests/`: clean.
