### PR TITLE
fix: separator earliest-match, numeric event_id sort, generalized mojibake repair

### DIFF
--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -79,8 +79,54 @@ MOJIBAKE_PATTERNS = [
 ]
 
 
+def try_fix_double_encoded(text: str) -> str:
+    """Attempt to repair double-encoded UTF-8 text via a latin-1/utf-8 round trip.
+
+    Mojibake like "MÃ¼nchen" (for "München") typically happens when UTF-8
+    bytes get mis-decoded as latin-1 somewhere upstream (latin-1 is a
+    lossless 1:1 byte<->codepoint mapping, so no information is lost -- it
+    can be reversed). Reversing it means re-encoding the broken text back to
+    latin-1 bytes, then decoding those bytes as UTF-8.
+
+    This is intentionally conservative and safe to call on arbitrary,
+    possibly-already-correct text: if the round trip raises (the text wasn't
+    actually latin-1-of-utf8, e.g. legitimate "SÃO PAULO FC") or produces a
+    U+FFFD replacement character (a silently swallowed decode error), the
+    original text is returned unchanged rather than mangled. It is also
+    idempotent -- re-running it on already-correct text is a no-op, since
+    re-encoding proper unicode text as latin-1 generally fails or decoding
+    the result as UTF-8 does.
+
+    Args:
+        text: Potentially double-encoded text
+
+    Returns:
+        The repaired text, or the original text unchanged if the round trip
+        wasn't safely reversible.
+    """
+    if not text:
+        return text
+
+    try:
+        candidate = text.encode("latin-1").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return text
+
+    if "�" in candidate:
+        return text
+
+    return candidate
+
+
 def fix_mojibake(text: str) -> str:
-    """Fix common mojibake patterns from double-encoded UTF-8.
+    """Fix mojibake (double-encoded UTF-8) in text.
+
+    Tries the generic, guarded latin-1/utf-8 round trip first
+    (``try_fix_double_encoded``), which covers any double-encoded script
+    (Nordic, Polish, etc.), not just the hard-coded patterns below. Falls
+    back to the hard-coded MOJIBAKE_PATTERNS replacements when the generic
+    round trip doesn't change anything, to preserve any prior behavior it
+    doesn't cover.
 
     Args:
         text: Potentially mojibake'd text
@@ -91,9 +137,10 @@ def fix_mojibake(text: str) -> str:
     if not text:
         return text
 
-    result = text
-    for pattern, replacement in MOJIBAKE_PATTERNS:
-        result = result.replace(pattern, replacement)
+    result = try_fix_double_encoded(text)
+    if result == text:
+        for pattern, replacement in MOJIBAKE_PATTERNS:
+            result = result.replace(pattern, replacement)
 
     if result != text:
         logger.debug("[MOJIBAKE] Fixed: '%s' -> '%s'", text[:40], result[:40])

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -519,6 +519,24 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
             }
         )
 
+    def _event_id_sort_key(event_id) -> tuple:
+        """Build a tie-break sort key for an event_id.
+
+        Numeric event_ids compare numerically ("2" sorts before "10", not
+        after it as plain string comparison would give). A numeric event_id
+        always sorts before a non-numeric one (e.g. a provider slug id).
+        Two non-numeric event_ids fall back to plain string comparison.
+
+        Returns a tuple of (is_non_numeric, numeric_value, string_value):
+        numeric ids get (0, <int>, "") so they compare numerically amongst
+        themselves and sort ahead of the (1, 0, <str>) non-numeric tier.
+        """
+        s = str(event_id)
+        try:
+            return (0, int(s), "")
+        except ValueError:
+            return (1, 0, s)
+
     # 3. Sort by: priority team → sport priority → league priority → time → event_id → keyword
     def sort_key(ch):
         sport = ch.get("sport") or ""
@@ -556,7 +574,14 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
         # Main channel (no keyword) sorts before keyword channels
         keyword_sort = (0, "") if not keyword else (1, keyword)
 
-        return (priority_tier, sport_pri, league_pri, event_date, str(event_id), keyword_sort)
+        return (
+            priority_tier,
+            sport_pri,
+            league_pri,
+            event_date,
+            _event_id_sort_key(event_id),
+            keyword_sort,
+        )
 
     sorted_channels = sorted(channels, key=sort_key)
 

--- a/teamarr/dispatcharr/managers/m3u.py
+++ b/teamarr/dispatcharr/managers/m3u.py
@@ -25,7 +25,9 @@ def _fix_double_encoded_utf8(text: str) -> str:
     """Fix double-encoded UTF-8 strings.
 
     Some M3U sources have UTF-8 text that was decoded as Latin-1 then re-encoded,
-    resulting in characters like 'Ã±' instead of 'ñ'.
+    resulting in characters like 'Ã±' instead of 'ñ'. Delegates the actual
+    guarded latin-1/utf-8 round trip to
+    ``teamarr.consumers.matching.normalizer.try_fix_double_encoded``.
 
     Args:
         text: Potentially double-encoded string
@@ -40,11 +42,13 @@ def _fix_double_encoded_utf8(text: str) -> str:
     if "Ã" not in text:
         return text
 
-    try:
-        # Try to fix: encode as Latin-1 (to get original bytes), decode as UTF-8
-        return text.encode("latin-1").decode("utf-8")
-    except (UnicodeDecodeError, UnicodeEncodeError):
-        return text
+    # Deferred import: teamarr.consumers.matching.normalizer sits behind an
+    # import chain that eventually reaches back to teamarr.dispatcharr.factory
+    # (which imports this module at load time), so this can't be hoisted to
+    # module scope without creating a circular import.
+    from teamarr.consumers.matching.normalizer import try_fix_double_encoded
+
+    return try_fix_double_encoded(text)
 
 
 class M3UManager:

--- a/teamarr/services/detection_keywords.py
+++ b/teamarr/services/detection_keywords.py
@@ -631,6 +631,14 @@ class DetectionKeywordService:
     def find_separator(cls, text: str) -> tuple[str | None, int]:
         """Find game separator in text.
 
+        Scans every known separator and keeps the one whose match starts
+        EARLIEST in the string, since a low-priority separator occurring
+        early in the text should win over a high-priority one that only
+        occurs much later. ``get_separators()`` list order (priority) is
+        used only to break a genuine same-position tie, and even then the
+        LONGER match wins first (e.g. " vs. " beats " vs " when both start
+        at the same index) -- list order only matters if lengths also tie.
+
         Args:
             text: Stream name to search
 
@@ -638,11 +646,18 @@ class DetectionKeywordService:
             Tuple of (separator_found, position) or (None, -1) if not found
         """
         text_lower = text.lower()
+        best_sep: str | None = None
+        best_pos = -1
+        best_len = -1
         for sep in cls.get_separators():
             pos = text_lower.find(sep.lower())
-            if pos != -1:
-                return sep, pos
-        return None, -1
+            if pos == -1:
+                continue
+            if best_sep is None or pos < best_pos or (pos == best_pos and len(sep) > best_len):
+                best_sep = sep
+                best_pos = pos
+                best_len = len(sep)
+        return (best_sep, best_pos) if best_sep is not None else (None, -1)
 
     # ==========================================================================
     # Cache Management

--- a/tests/test_channel_event_id_sort.py
+++ b/tests/test_channel_event_id_sort.py
@@ -1,0 +1,77 @@
+"""Tests for numeric-aware event_id tie-break in global channel sort (Phase 3a, item 14).
+
+``get_all_channels_sorted``'s internal ``sort_key`` currently tie-breaks on
+``str(event_id)``, so lexicographic ordering makes "10" sort before "2".
+New contract: numeric event_ids compare numerically ("2" before "10"); a
+numeric event_id sorts before a non-numeric one; two non-numeric ids fall
+back to string comparison. This mirrors the existing db-fixture pattern in
+test_priority_teams.py (in-memory sqlite + schema.sql).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from teamarr.database.channel_numbers import get_all_channels_sorted
+
+SCHEMA = Path(__file__).resolve().parents[1] / "teamarr" / "database" / "schema.sql"
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(SCHEMA.read_text())
+    db.commit()
+    return db
+
+
+def _add_channel(conn, *, ch_id, event_id, date="2026-02-01T12:00:00Z"):
+    # Same sport/league/date for every row in these tests, so the only thing
+    # that can break the tie between channels is the event_id comparison.
+    conn.execute(
+        """
+        INSERT INTO managed_channels
+        (id, event_id, event_provider, tvg_id, channel_name, sport, league,
+         home_team, away_team, event_date)
+        VALUES (?, ?, 'espn', ?, ?, 'soccer', 'eng.1', 'A', 'B', ?)
+        """,
+        (ch_id, event_id, f"tvg{ch_id}", f"chan{ch_id}", date),
+    )
+
+
+def test_numeric_event_ids_sort_numerically_not_lexicographically(conn):
+    # "10" sorts before "2" lexicographically (string compare), but 2 < 10
+    # numerically. Everything else about the two channels is identical, so
+    # only the event_id tie-break can decide the order.
+    _add_channel(conn, ch_id=1, event_id="10")
+    _add_channel(conn, ch_id=2, event_id="2")
+    conn.commit()
+    assert [c["id"] for c in get_all_channels_sorted(conn)] == [2, 1]
+
+
+def test_numeric_event_id_sorts_before_non_numeric(conn):
+    # Documented choice: a purely numeric event_id sorts ahead of a
+    # non-numeric one (e.g. a provider-specific slug id), regardless of the
+    # non-numeric id's string value.
+    #
+    # These specific values are chosen so plain string comparison disagrees
+    # with the desired outcome: "30x" < "4" lexicographically (since '3' <
+    # '4' as characters), so the OLD str(event_id) tie-break would put the
+    # non-numeric "30x" first. The new numeric-before-non-numeric rule must
+    # override that and put the numeric "4" first regardless.
+    assert "30x" < "4"  # sanity: confirms the old string order would disagree
+    _add_channel(conn, ch_id=1, event_id="30x")
+    _add_channel(conn, ch_id=2, event_id="4")
+    conn.commit()
+    assert [c["id"] for c in get_all_channels_sorted(conn)] == [2, 1]
+
+
+def test_two_non_numeric_event_ids_fall_back_to_string_compare(conn):
+    _add_channel(conn, ch_id=1, event_id="zeta")
+    _add_channel(conn, ch_id=2, event_id="alpha")
+    conn.commit()
+    assert [c["id"] for c in get_all_channels_sorted(conn)] == [2, 1]

--- a/tests/test_mojibake_repair.py
+++ b/tests/test_mojibake_repair.py
@@ -1,0 +1,75 @@
+"""Tests for the safer, generic double-encoded-UTF-8 repair (Phase 3a, item 15).
+
+Today, ``fix_mojibake`` in normalizer.py only fixes a hard-coded list of
+German/Spanish/French character patterns (MOJIBAKE_PATTERNS), and
+``_fix_double_encoded_utf8`` in m3u.py does a bare latin-1-encode /
+utf-8-decode round trip with no guard against producing U+FFFD replacement
+characters.
+
+New contract: a new pure function ``try_fix_double_encoded(text)`` in
+normalizer.py generalizes the round-trip repair (so Nordic/Polish characters
+work, not just the hard-coded list), while guaranteeing it never returns text
+containing U+FFFD and leaves legitimate non-mojibake text alone. Per the
+spec, ``_fix_double_encoded_utf8`` should delegate to this new function
+instead of duplicating the recode logic.
+
+We import the ``normalizer`` module (not the name) so a currently-missing
+``try_fix_double_encoded`` fails each test individually via AttributeError
+rather than blowing up collection for the whole file.
+"""
+
+from teamarr.consumers.matching import normalizer
+
+
+def test_fixes_german_umlaut_round_trip():
+    mojibake = "München".encode().decode("latin-1")
+    assert normalizer.try_fix_double_encoded(mojibake) == "München"
+
+
+def test_fixes_nordic_o_slash_round_trip():
+    # Danish/Norwegian "ø" -- NOT in the current MOJIBAKE_PATTERNS list, so
+    # fix_mojibake() cannot handle it today. The new generic function must.
+    mojibake = "København".encode().decode("latin-1")
+    assert normalizer.try_fix_double_encoded(mojibake) == "København"
+
+
+def test_fixes_polish_n_acute_round_trip():
+    # Compute the double-encoded fixture from the correct string itself (per
+    # spec) so the test input is provably a genuine double-encoding of
+    # "Gdańsk", not a hand-typed guess.
+    correct = "Gdańsk"
+    mojibake = correct.encode("utf-8").decode("latin-1")
+    assert normalizer.try_fix_double_encoded(mojibake) == correct
+
+
+def test_leaves_legitimate_capital_a_tilde_text_unchanged():
+    # "SÃO PAULO FC": capital Ã (U+00C3) followed by capital O is not a valid
+    # UTF-8 continuation byte sequence when re-encoded as latin-1 and decoded
+    # as UTF-8, so the recode must fail cleanly and the safer implementation
+    # must return the original text rather than mangling it.
+    text = "SÃO PAULO FC"
+    assert normalizer.try_fix_double_encoded(text) == text
+
+
+def test_result_never_contains_replacement_character():
+    candidates = [
+        "München".encode().decode("latin-1"),
+        "SÃO PAULO FC",
+        "Plain ASCII text",
+        "Gdańsk".encode().decode("latin-1"),
+    ]
+    for text in candidates:
+        assert "�" not in normalizer.try_fix_double_encoded(text)
+
+
+def test_idempotent_on_already_fixed_text():
+    # Applying the repair to already-correct text must be a no-op, and
+    # applying it twice must equal applying it once.
+    once = normalizer.try_fix_double_encoded("München")
+    twice = normalizer.try_fix_double_encoded(once)
+    assert once == "München"
+    assert twice == once
+
+
+def test_plain_ascii_unchanged():
+    assert normalizer.try_fix_double_encoded("ESPN HD") == "ESPN HD"

--- a/tests/test_separator_position_priority.py
+++ b/tests/test_separator_position_priority.py
@@ -1,0 +1,68 @@
+"""Tests for position-first separator selection (Phase 3a, item 9).
+
+``DetectionKeywordService.find_separator`` currently walks ``GAME_SEPARATORS``
+in priority order and returns the first pattern found ANYWHERE in the text —
+so a low-priority separator that occurs early can lose to a high-priority one
+that occurs much later. New contract: the separator whose match position is
+EARLIEST in the string wins; list order (i.e. GAME_SEPARATORS priority) only
+breaks ties when two separators start at the exact same index, and among
+same-position ties the LONGER match wins (" vs. " beats " vs ").
+"""
+
+from teamarr.services.detection_keywords import DetectionKeywordService
+
+
+def setup_function(_fn):
+    # Pattern caches are class-level; clear them so DB-less test runs see the
+    # built-in GAME_SEPARATORS list deterministically (matches existing
+    # convention in test_multi_sport_hints.py / test_ncaab_gender_classification.py).
+    DetectionKeywordService.invalidate_cache()
+
+
+def test_simple_vs_unchanged():
+    # Only one separator present at all -- earliest-position and
+    # priority-order agree, so this must keep working exactly as before.
+    assert DetectionKeywordService.find_separator("Lakers vs Celtics") == (" vs ", 6)
+
+
+def test_simple_at_unchanged():
+    assert DetectionKeywordService.find_separator("TeamA at TeamB") == (" at ", 5)
+
+
+def test_earliest_position_wins_over_higher_priority_separator():
+    # " vs " (priority index 1) occurs at 15; " at " (priority index 5, i.e.
+    # lower priority) occurs earlier, at 7. Old code returns " vs " because it
+    # is checked first in GAME_SEPARATORS and matches "anywhere". New contract:
+    # the earliest occurring separator must win regardless of list order.
+    text = "Norwich at Home vs Ipswich"
+    assert text.lower().find(" at ") == 7
+    assert text.lower().find(" vs ") == 15
+    assert DetectionKeywordService.find_separator(text) == (" at ", 7)
+
+
+def test_same_position_tie_prefers_longer_match(monkeypatch):
+    # Construct a genuine same-start-index tie: " vs" is a literal prefix of
+    # " vs ", so both match starting at the same index in "A vs B". List order
+    # here deliberately puts the SHORTER pattern first (as if it were the
+    # higher "priority" separator) to prove the tie-break -- not list order --
+    # decides the winner: the longer match (" vs ") must win even though it is
+    # second in priority.
+    #
+    # (The real GAME_SEPARATORS entries are NOT mutually prefixes of each
+    # other -- " vs. " vs " vs " diverge at the character right after "vs",
+    # so they can never match at the same start index against real input.
+    # A same-position tie can only be demonstrated with a synthetic list, so
+    # this test patches get_separators() to construct one directly.)
+    monkeypatch.setattr(
+        DetectionKeywordService,
+        "get_separators",
+        classmethod(lambda cls: [" vs", " vs "]),
+    )
+    text = "A vs B"
+    assert text.lower().find(" vs") == 1
+    assert text.lower().find(" vs ") == 1
+    assert DetectionKeywordService.find_separator(text) == (" vs ", 1)
+
+
+def test_no_separator_returns_none_and_negative_one():
+    assert DetectionKeywordService.find_separator("No separator here") == (None, -1)


### PR DESCRIPTION
Three small, independent correctness fixes in the stream-matching pipeline, each landed behind its own failing-tests-first commit.

## What's fixed

1. **`DetectionKeywordService.find_separator` now picks the earliest-position separator match** instead of the first one found by walking `GAME_SEPARATORS` in priority order. `"Norwich at Home vs Ipswich"` was wrongly splitting on `" vs "` (later in the string, but higher priority) instead of `" at "` (earlier). List order and match length now only break same-position ties.
2. **`get_all_channels_sorted`'s tie-break sorted `event_id` as a string**, so `"10"` sorted before `"2"`. Added `_event_id_sort_key()`: numeric ids compare numerically and sort ahead of non-numeric ids; two non-numeric ids still fall back to string comparison.
3. **`fix_mojibake()` only repaired a hard-coded list of German/Spanish/French double-encoding patterns**, missing Nordic/Polish characters entirely, and `m3u.py`'s `_fix_double_encoded_utf8()` duplicated an *unguarded* latin-1/UTF-8 round trip with no protection against producing U+FFFD. Added `try_fix_double_encoded()`: a guarded, generic round-trip repair that rejects on exception or a U+FFFD in the result. `fix_mojibake()` tries it first, falling back to the old pattern list only as a no-op guard; `m3u.py` now delegates to the same function instead of re-implementing the recode.

## Motivation

All three are real-world stream-name defects found while working the matching pipeline: separator misdetection produces wrong team splits, lexicographic event_id sort produces a visibly wrong channel-number order once ids hit double digits, and narrow mojibake patterns leave Nordic/Polish provider feeds garbled. None change any public API shape — same inputs/outputs, corrected internal logic.

## What changed

- `teamarr/services/detection_keywords.py` — `find_separator` earliest-match selection
- `teamarr/database/channel_numbers.py` — `_event_id_sort_key()` helper, numeric-aware tie-break
- `teamarr/consumers/matching/normalizer.py` — `try_fix_double_encoded()`, `fix_mojibake()` now tries it first
- `teamarr/dispatcharr/managers/m3u.py` — `_fix_double_encoded_utf8()` delegates to the shared function

## Behavior-change callouts

- Separator selection can change which text a stream name is split on for names where a lower-priority separator occurs earlier than a higher-priority one — intentional, but worth a maintainer's eyes since it changes team-extraction output for that (narrow) case shape.
- No dry-run/preview posture applies here (these are pure-function matching fixes, not destructive operations).

This branch is file-disjoint from the other two Teamarr PRs I'm opening alongside this one and can be merged independently in any order.

Tests: `tests/test_separator_position_priority.py`, `tests/test_channel_event_id_sort.py`, `tests/test_mojibake_repair.py` — `pytest tests/ -q`: 2050 passed (2035 baseline + 15 new); `ruff check teamarr/ tests/`: clean.
