### PR TITLE
feat: suspect-duplicate detection safety net for channel reconciliation (Phase 3b, item 12)

### DIFF
--- a/teamarr/consumers/enforcement/__init__.py
+++ b/teamarr/consumers/enforcement/__init__.py
@@ -12,6 +12,10 @@ consistency across channels:
 3. KeywordOrderingEnforcer: Ensures main channel has lower number than
    keyword channels for the same event (main before Spanish/French)
 
+4. find_suspect_duplicates: Detection-only safety net for channels that
+   the DB unique index can't catch -- two differently-formatted streams of
+   the same real game that never got the same event_id.
+
 Usage:
     from teamarr.consumers.enforcement import (
         KeywordEnforcer,
@@ -31,6 +35,7 @@ Usage:
 """
 
 from .cross_group import CrossGroupEnforcer, CrossGroupResult
+from .duplicate_detector import find_suspect_duplicates
 from .keywords import KeywordEnforcementResult, KeywordEnforcer
 from .ordering import KeywordOrderingEnforcer, OrderingResult
 
@@ -41,4 +46,5 @@ __all__ = [
     "CrossGroupResult",
     "KeywordOrderingEnforcer",
     "OrderingResult",
+    "find_suspect_duplicates",
 ]

--- a/teamarr/consumers/enforcement/duplicate_detector.py
+++ b/teamarr/consumers/enforcement/duplicate_detector.py
@@ -1,0 +1,114 @@
+"""Duplicate-channel detection safety net (Phase 3b, item 12).
+
+Teamarr dedupes channels only via a DB unique index on ``(event_id,
+provider, keyword, stream_id)``. When name normalization or fuzzy matching
+fails to resolve two differently-formatted streams of the SAME real game to
+one ``event_id``, a duplicate channel is created with no detection anywhere.
+``find_suspect_duplicates`` adds DETECTION (for logging/reporting) -- it does
+NOT auto-merge anything.
+
+See ``tests/test_duplicate_detector.py`` for the full behavioral contract
+this module implements.
+"""
+
+from itertools import combinations
+
+from rapidfuzz import fuzz
+
+from teamarr.utilities.fuzzy_match import normalize_text
+
+
+def _windows_overlap_or_unavailable(channel_a: dict, channel_b: dict) -> bool:
+    """Half-open overlap check, bypassed when either window is unavailable.
+
+    A channel's window is "available" only when BOTH event_start and
+    event_end are non-None. When either channel's window is unavailable, the
+    overlap requirement is treated as satisfied (there's nothing to disprove
+    overlap with) -- the decision falls through to the other checks.
+    """
+    a_start = channel_a.get("event_start")
+    a_end = channel_a.get("event_end")
+    b_start = channel_b.get("event_start")
+    b_end = channel_b.get("event_end")
+
+    if a_start is None or a_end is None or b_start is None or b_end is None:
+        return True
+
+    return a_start < b_end and b_start < a_end
+
+
+def find_suspect_duplicates(
+    channels: list[dict],
+    threshold: float = 85.0,
+) -> list[dict]:
+    """Find pairs of channels that are probably duplicates of the same event.
+
+    Each input channel is a dict with keys ``id``, ``name``, ``sport``,
+    ``league`` (accepted but not used in the decision), ``event_start``,
+    ``event_end``, ``event_id``. Two channels are two-way compared and a pair
+    is flagged iff ALL of:
+
+    1. event_id: not (both non-None AND equal). None never counts as equal
+       to anything, including another None.
+    2. sport: equal and non-None. A None sport matches nothing.
+    3. window overlap: half-open ``[event_start, event_end)`` overlap, or
+       bypassed entirely if either channel's window is unavailable (either
+       timestamp missing).
+    4. name similarity: ``rapidfuzz.fuzz.token_set_ratio`` over each name run
+       through ``normalize_text`` is >= ``threshold``.
+
+    Args:
+        channels: Channel dicts to pairwise-compare.
+        threshold: Minimum token_set_ratio similarity score (0-100) to flag
+            a pair.
+
+    Returns:
+        A list of dicts (one per flagged unordered pair), each with keys
+        ``channel_id_a`` (smaller id), ``channel_id_b`` (larger id),
+        ``channel_a_name``, ``channel_b_name``, ``similarity``, ``sport``.
+        Sorted ascending by ``(channel_id_a, channel_id_b)``. For a group of
+        3+ mutually-similar channels, every pairwise combination is emitted
+        independently.
+    """
+    results: list[dict] = []
+
+    for channel_a, channel_b in combinations(channels, 2):
+        event_id_a = channel_a.get("event_id")
+        event_id_b = channel_b.get("event_id")
+        if event_id_a is not None and event_id_a == event_id_b:
+            continue
+
+        sport_a = channel_a.get("sport")
+        sport_b = channel_b.get("sport")
+        if sport_a is None or sport_a != sport_b:
+            continue
+
+        if not _windows_overlap_or_unavailable(channel_a, channel_b):
+            continue
+
+        name_a = channel_a["name"]
+        name_b = channel_b["name"]
+        similarity = fuzz.token_set_ratio(normalize_text(name_a), normalize_text(name_b))
+        if similarity < threshold:
+            continue
+
+        id_a, id_b = channel_a["id"], channel_b["id"]
+        if id_a < id_b:
+            ordered_name_a, ordered_name_b = name_a, name_b
+        else:
+            id_a, id_b = id_b, id_a
+            ordered_name_a, ordered_name_b = name_b, name_a
+
+        results.append(
+            {
+                "channel_id_a": id_a,
+                "channel_id_b": id_b,
+                "channel_a_name": ordered_name_a,
+                "channel_b_name": ordered_name_b,
+                "similarity": similarity,
+                "sport": sport_a,
+            }
+        )
+
+    results.sort(key=lambda pair: (pair["channel_id_a"], pair["channel_id_b"]))
+    return results

--- a/teamarr/consumers/reconciliation.py
+++ b/teamarr/consumers/reconciliation.py
@@ -85,6 +85,7 @@ class ReconciliationResult:
             "orphan_teamarr": 0,
             "orphan_dispatcharr": 0,
             "duplicate": 0,
+            "suspect_duplicate": 0,
             "drift": 0,
             "total": len(self.issues_found),
             "fixed": len(self.issues_fixed),
@@ -194,6 +195,12 @@ class ChannelReconciler:
                 # Step 3: Detect duplicates
                 duplicates = self._detect_duplicates(conn)
                 result.issues_found.extend(duplicates)
+
+                # Step 3b: Detect suspect duplicates (fuzzy safety net -- see
+                # _detect_suspect_duplicates for why this is separate from
+                # _detect_duplicates above).
+                suspect_duplicates = self._detect_suspect_duplicates(conn)
+                result.issues_found.extend(suspect_duplicates)
 
                 # Step 4: Detect drift (setting mismatches)
                 drift_issues = self._detect_drift(conn)
@@ -414,6 +421,102 @@ class ChannelReconciler:
 
         if issues:
             logger.info("[DUPLICATE] Found %d duplicate event(s)", len(issues))
+
+        return issues
+
+    def _detect_suspect_duplicates(
+        self,
+        conn: Connection,
+    ) -> list[ReconciliationIssue]:
+        """Detect probable duplicate channels the exact-match check can't see.
+
+        ``_detect_duplicates`` above only catches channels that already
+        share the SAME ``event_id`` -- exactly the case the DB unique index
+        also prevents, so in practice it rarely fires. The real blind spot
+        is two channels for the SAME real game that never got the same
+        ``event_id`` because name/team matching resolved one of the streams
+        differently (or not at all). ``find_suspect_duplicates`` (Phase 3b,
+        item 12) catches that case via sport + window + fuzzy-name heuristics
+        applied across ALL active channels, independent of event_id.
+
+        This is DETECTION only -- flagged pairs are reported (as "info"
+        severity, never auto-fixable) for a human to review; nothing is
+        merged automatically. Defensive by design: any failure here must
+        never break the rest of reconciliation, and the check is skipped
+        entirely for the common case of fewer than 2 active channels.
+
+        Channel windows: managed_channels only stores a single event_date,
+        not a start/end range, so ``event_end`` is passed as None. Per
+        find_suspect_duplicates' contract that makes the window
+        "unavailable" and bypasses the overlap check (falls through to the
+        sport/event_id/similarity gates instead of using window overlap to
+        narrow candidates).
+        """
+        issues: list[ReconciliationIssue] = []
+
+        try:
+            from teamarr.consumers.enforcement.duplicate_detector import (
+                find_suspect_duplicates,
+            )
+            from teamarr.database.channels import get_all_managed_channels
+
+            channels = get_all_managed_channels(conn, include_deleted=False)
+            if len(channels) < 2:
+                return issues
+
+            channels_by_id = {channel.id: channel for channel in channels}
+            candidates = [
+                {
+                    "id": channel.id,
+                    "name": channel.channel_name,
+                    "sport": channel.sport,
+                    "league": channel.league,
+                    "event_start": channel.event_date,
+                    "event_end": None,
+                    "event_id": channel.event_id,
+                }
+                for channel in channels
+            ]
+
+            for pair in find_suspect_duplicates(candidates):
+                channel_a = channels_by_id.get(pair["channel_id_a"])
+                channel_b = channels_by_id.get(pair["channel_id_b"])
+
+                logger.warning(
+                    "[SUSPECT_DUPLICATE] '%s' (id=%s) ~ '%s' (id=%s) similarity=%.1f sport=%s",
+                    pair["channel_a_name"],
+                    pair["channel_id_a"],
+                    pair["channel_b_name"],
+                    pair["channel_id_b"],
+                    pair["similarity"],
+                    pair["sport"],
+                )
+
+                issues.append(
+                    ReconciliationIssue(
+                        issue_type="suspect_duplicate",
+                        severity="info",
+                        managed_channel_id=pair["channel_id_a"],
+                        channel_name=pair["channel_a_name"],
+                        event_id=channel_a.event_id if channel_a else None,
+                        details={
+                            "channel_id_b": pair["channel_id_b"],
+                            "channel_b_name": pair["channel_b_name"],
+                            "event_id_b": channel_b.event_id if channel_b else None,
+                            "similarity": pair["similarity"],
+                            "sport": pair["sport"],
+                        },
+                        suggested_action="review",
+                        auto_fixable=False,
+                    )
+                )
+
+            if issues:
+                logger.info("[SUSPECT_DUPLICATE] Found %d suspect pair(s)", len(issues))
+
+        except Exception:
+            logger.exception("[SUSPECT_DUPLICATE] Detection failed; skipping")
+            return []
 
         return issues
 

--- a/tests/test_duplicate_detector.py
+++ b/tests/test_duplicate_detector.py
@@ -1,0 +1,380 @@
+"""Tests for the duplicate-channel detection safety net (Phase 3b, item 12).
+
+Context: Teamarr dedupes channels only via a DB unique index on
+``(event_id, provider, keyword, stream_id)``. When name normalization or
+fuzzy matching fails to resolve two differently-formatted streams of the
+SAME real game to one ``event_id``, a duplicate channel is created with no
+detection anywhere. ``find_suspect_duplicates`` adds DETECTION (for
+logging/reporting) -- it does NOT auto-merge anything.
+
+--------------------------------------------------------------------------
+CONTRACT (as implemented by ``teamarr.consumers.enforcement.duplicate_detector``)
+--------------------------------------------------------------------------
+
+``find_suspect_duplicates(channels, threshold=85.0) -> list[dict]``
+
+Each input channel is a dict::
+
+    {
+        "id": int,
+        "name": str,
+        "sport": str | None,
+        "league": str | None,
+        "event_start": datetime | None,
+        "event_end": datetime | None,
+        "event_id": str | None,
+    }
+
+``league`` is accepted (part of the channel shape used elsewhere in the
+codebase) but is NOT part of the flagging decision -- only ``sport`` is.
+Two channels are two-way compared and a pair is flagged iff ALL of:
+
+1. **event_id**: not (both non-None AND equal). i.e. a pair sharing the
+   same non-None ``event_id`` is NEVER flagged (legitimate multi-stream
+   one-channel handling upstream owns that case). Two channels that are
+   BOTH missing an ``event_id`` (``None``) are NOT considered "the same"
+   for this check -- ``None`` never counts as equal to anything, including
+   another ``None`` -- so that pair remains eligible for the other checks.
+2. **sport**: ``channel_a["sport"] == channel_b["sport"]``, AND that value
+   is not ``None``. A ``None`` sport matches nothing, not even another
+   ``None`` (spec: "None matches nothing") -- so a pair with either side's
+   sport missing is never flagged.
+3. **window overlap**: a channel's window is "available" only when BOTH
+   ``event_start`` and ``event_end`` are non-None. When both channels'
+   windows are available, overlap uses half-open interval semantics
+   (``[event_start, event_end)``): ``a.start < b.end and b.start < a.end``.
+   When EITHER channel's window is unavailable (either timestamp is
+   ``None``), the overlap check is BYPASSED (treated as satisfied) --
+   there is nothing to disprove overlap with, so the decision falls
+   through entirely to the sport/event_id/similarity checks. This means a
+   missing window never blocks a flag on its own, but it also never
+   rescues a pair whose names don't clear the similarity bar.
+4. **name similarity**: ``rapidfuzz.fuzz.token_set_ratio`` over each name
+   run through ``teamarr.utilities.fuzzy_match.normalize_text`` (NOT
+   ``consumers.matching.normalizer.normalize_for_matching``) is >=
+   ``threshold``. ``normalize_text`` is chosen because channel names here
+   are event-display-name-shaped ("Lakers vs Celtics"), the same shape
+   ``normalize_text``/``match_event_name`` already normalize for
+   whole-name comparison in ``fuzzy_match.py``. ``normalize_for_matching``
+   additionally strips broadcast-network tokens (ESPN, FOX, ...), which is
+   tailored to noisy raw stream text, not already-clean channel names, so
+   it is the wrong tool here.
+
+Output shape: a list of dicts, one per flagged unordered pair (never both
+orderings of the same pair)::
+
+    {
+        "channel_id_a": int,   # smaller id
+        "channel_id_b": int,   # larger id
+        "channel_a_name": str,
+        "channel_b_name": str,
+        "similarity": float,
+        "sport": str,
+    }
+
+Ordering is deterministic: sorted ascending by ``(channel_id_a,
+channel_id_b)``, and within each dict ``channel_id_a < channel_id_b``
+(canonical pair orientation) regardless of input order.
+
+For a group of 3+ mutually-similar channels ("three-way duplicate"), the
+chosen representation is: emit EVERY pairwise flagged combination
+independently (not a single grouped record) -- e.g. 3 channels all
+pairwise over threshold produce 3 dicts, one per pair. This keeps the
+function's contract uniform (always pairs) and lets a caller do its own
+grouping/union-find on top if it wants clusters.
+"""
+
+from datetime import datetime, timedelta
+
+from teamarr.consumers.enforcement.duplicate_detector import find_suspect_duplicates
+
+# A fixed reference start time so window arithmetic in tests is readable.
+_T0 = datetime(2026, 3, 1, 19, 0)
+
+
+def _channel(
+    id: int,
+    name: str,
+    sport: str | None = "Basketball",
+    league: str | None = "NBA",
+    event_id: str | None = None,
+    start: datetime | None = _T0,
+    end: datetime | None = None,
+) -> dict:
+    """Build a channel dict with sane defaults for a 2.5 hour game window."""
+    if end is None and start is not None:
+        end = start + timedelta(hours=2, minutes=30)
+    return {
+        "id": id,
+        "name": name,
+        "sport": sport,
+        "league": league,
+        "event_start": start,
+        "event_end": end,
+        "event_id": event_id,
+    }
+
+
+# ============================================================== basic flagging
+
+
+def test_similar_names_overlapping_windows_different_event_ids_flagged():
+    """Same real game, two differently-formatted stream names, no shared
+    event_id -- exactly the case the DB unique index cannot catch."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-abc")
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-xyz")
+
+    result = find_suspect_duplicates([a, b])
+
+    assert len(result) == 1
+    pair = result[0]
+    assert pair["channel_id_a"] == 1
+    assert pair["channel_id_b"] == 2
+    assert pair["channel_a_name"] == "Lakers vs Celtics"
+    assert pair["channel_b_name"] == "LA Lakers v Boston Celtics"
+    assert pair["sport"] == "Basketball"
+    assert pair["similarity"] >= 85.0
+
+
+def test_same_event_id_never_flagged_even_with_identical_names():
+    """Legitimate multi-stream-one-channel case: same event_id must never
+    be reported, no matter how similar (even identical) the names are."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-shared")
+    b = _channel(2, "Lakers vs Celtics", event_id="evt-shared")
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_both_event_ids_none_still_eligible():
+    """None is not 'equal' to another None for this check -- two channels
+    that both simply lack an event_id are NOT treated as 'the same
+    event_id' and remain eligible for flagging on the other criteria."""
+    a = _channel(1, "Lakers vs Celtics", event_id=None)
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id=None)
+
+    result = find_suspect_duplicates([a, b])
+
+    assert len(result) == 1
+    assert result[0]["channel_id_a"] == 1
+    assert result[0]["channel_id_b"] == 2
+
+
+def test_one_event_id_none_other_set_still_eligible():
+    a = _channel(1, "Lakers vs Celtics", event_id=None)
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-xyz")
+
+    result = find_suspect_duplicates([a, b])
+
+    assert len(result) == 1
+
+
+# ==================================================================== sport
+
+
+def test_different_sports_never_flagged_even_at_perfect_similarity():
+    """Identical names, identical windows, different event_ids -- but
+    different sports means these are NOT the same real-world event."""
+    a = _channel(1, "Lakers vs Celtics", sport="Basketball", event_id="evt-1")
+    b = _channel(2, "Lakers vs Celtics", sport="Hockey", event_id="evt-2")
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_sport_none_on_either_side_never_flagged():
+    """'None matches nothing' -- a missing sport can't be assumed to match
+    another missing (or present) sport."""
+    a = _channel(1, "Lakers vs Celtics", sport=None, event_id="evt-1")
+    b = _channel(2, "LA Lakers v Boston Celtics", sport="Basketball", event_id="evt-2")
+
+    assert find_suspect_duplicates([a, b]) == []
+
+    c = _channel(3, "Lakers vs Celtics", sport=None, event_id="evt-3")
+    d = _channel(4, "LA Lakers v Boston Celtics", sport=None, event_id="evt-4")
+
+    assert find_suspect_duplicates([c, d]) == []
+
+
+# =================================================================== windows
+
+
+def test_non_overlapping_windows_a_week_apart_not_flagged():
+    """Same teams, same sport, similar-enough names -- but a week apart is
+    two different games, not one mis-split duplicate."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=_T0)
+    b = _channel(
+        2,
+        "LA Lakers v Boston Celtics",
+        event_id="evt-2",
+        start=_T0 + timedelta(days=7),
+    )
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_overlapping_windows_flagged():
+    """Half-open overlap: game A [19:00, 21:30), game B [19:15, 21:45) --
+    B starts before A ends and A starts before B ends, so they overlap."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=_T0)
+    b = _channel(
+        2,
+        "LA Lakers v Boston Celtics",
+        event_id="evt-2",
+        start=_T0 + timedelta(minutes=15),
+        end=_T0 + timedelta(hours=2, minutes=45),
+    )
+
+    result = find_suspect_duplicates([a, b])
+    assert len(result) == 1
+
+
+def test_adjacent_non_overlapping_windows_not_flagged():
+    """Half-open boundary case: game A ends exactly when game B starts --
+    [start_a, end_a) and [end_a, end_b) share only the boundary instant,
+    which is NOT an overlap under half-open semantics."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=_T0, end=_T0 + timedelta(hours=2))
+    b = _channel(
+        2,
+        "LA Lakers v Boston Celtics",
+        event_id="evt-2",
+        start=_T0 + timedelta(hours=2),
+        end=_T0 + timedelta(hours=4),
+    )
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_missing_window_on_both_channels_does_not_block_flag():
+    """Neither channel has window data at all -- the overlap check is
+    bypassed entirely, so a high-similarity, same-sport, different-event-id
+    pair still gets flagged."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=None, end=None)
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-2", start=None, end=None)
+
+    result = find_suspect_duplicates([a, b])
+    assert len(result) == 1
+
+
+def test_missing_window_on_one_channel_does_not_block_flag():
+    """Mixed availability: one channel has a full window, the other has
+    none -- still bypassed, same outcome as both-missing."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=_T0)
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-2", start=None, end=None)
+
+    result = find_suspect_duplicates([a, b])
+    assert len(result) == 1
+
+
+def test_missing_window_does_not_rescue_low_similarity():
+    """A missing window bypasses the OVERLAP check, but similarity is a
+    separate, still-mandatory condition -- it isn't rescued by missing
+    window data."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=None, end=None)
+    b = _channel(2, "Warriors vs Nuggets", event_id="evt-2", start=None, end=None)
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_partial_window_missing_end_only_does_not_block_flag():
+    """A channel's window counts as 'unavailable' if EITHER timestamp is
+    None, not just when both are -- here event_end is missing."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1", start=_T0, end=None)
+    a["event_end"] = None  # override the _channel() auto-fill of end
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-2", start=_T0)
+
+    result = find_suspect_duplicates([a, b])
+    assert len(result) == 1
+
+
+# ================================================================ similarity
+
+
+def test_similarity_below_threshold_not_flagged():
+    """Clearly-different team names, same sport, overlapping windows,
+    different event_ids -- but the names just don't describe the same
+    game, so no flag."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1")
+    b = _channel(2, "Warriors vs Nuggets", event_id="evt-2")
+
+    assert find_suspect_duplicates([a, b]) == []
+
+
+def test_custom_threshold_is_respected():
+    """The default threshold (85.0) rejects a mid-similarity pair, but a
+    caller-supplied lower threshold accepts it."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1")
+    b = _channel(2, "Warriors vs Nuggets", event_id="evt-2")
+
+    assert find_suspect_duplicates([a, b], threshold=85.0) == []
+    assert find_suspect_duplicates([a, b], threshold=40.0) != []
+
+
+# ============================================================ multi-channel
+
+
+def test_three_way_duplicate_emits_all_three_pairs():
+    """Three mutually-similar formattings of the same real game emit one
+    dict per pairwise combination (3 channels -> 3 pairs), not a single
+    grouped record."""
+    a = _channel(10, "Lakers vs Celtics", event_id="evt-a")
+    b = _channel(20, "LA Lakers v Boston Celtics", event_id="evt-b")
+    c = _channel(30, "Los Angeles Lakers vs Boston Celtics", event_id="evt-c")
+
+    result = find_suspect_duplicates([a, b, c])
+
+    pairs = {(r["channel_id_a"], r["channel_id_b"]) for r in result}
+    assert pairs == {(10, 20), (10, 30), (20, 30)}
+    assert len(result) == 3
+
+
+def test_unrelated_channel_in_larger_list_is_not_flagged():
+    """A third, unrelated channel in the input must not spuriously pair
+    with either of a genuine duplicate pair."""
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1")
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-2")
+    unrelated = _channel(3, "Warriors vs Nuggets", event_id="evt-3")
+
+    result = find_suspect_duplicates([a, b, unrelated])
+
+    pairs = {(r["channel_id_a"], r["channel_id_b"]) for r in result}
+    assert pairs == {(1, 2)}
+
+
+# ================================================================= ordering
+
+
+def test_output_ordered_by_id_pair_ascending_regardless_of_input_order():
+    """Feeding channels in descending id order must not change the
+    canonical pair orientation or the sort order of the output."""
+    a = _channel(5, "Lakers vs Celtics", event_id="evt-a")
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-b")
+    c = _channel(9, "Los Angeles Lakers vs Boston Celtics", event_id="evt-c")
+
+    # Deliberately unsorted input order.
+    result = find_suspect_duplicates([c, a, b])
+
+    ordered_pairs = [(r["channel_id_a"], r["channel_id_b"]) for r in result]
+    assert ordered_pairs == sorted(ordered_pairs)
+    for id_a, id_b in ordered_pairs:
+        assert id_a < id_b
+
+
+def test_each_unordered_pair_appears_at_most_once():
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1")
+    b = _channel(2, "LA Lakers v Boston Celtics", event_id="evt-2")
+
+    result = find_suspect_duplicates([a, b])
+    pairs_seen = [(r["channel_id_a"], r["channel_id_b"]) for r in result]
+
+    assert len(pairs_seen) == len(set(pairs_seen))
+
+
+# ===================================================================== empty
+
+
+def test_empty_list_returns_empty_list():
+    assert find_suspect_duplicates([]) == []
+
+
+def test_single_channel_returns_empty_list():
+    a = _channel(1, "Lakers vs Celtics", event_id="evt-1")
+    assert find_suspect_duplicates([a]) == []


### PR DESCRIPTION
Teamarr dedupes channels only via a DB unique index on `(event_id, provider, keyword, stream_id)`. When name/team matching resolves two differently formatted streams of the same real game to different (or missing) event_ids, no duplicate-channel detection exists anywhere. This PR adds `find_suspect_duplicates`, a pairwise scan over active channels that flags a pair when: sport matches, event_id doesn't already tie them together, event windows overlap (or are unavailable, in which case the check is bypassed rather than blocking), and normalized-name similarity (via `rapidfuzz.fuzz.token_set_ratio` on `fuzzy_match.normalize_text`) clears a threshold (default 85.0).

This is **detection only** — a pure function, no DB access, no auto-merge. It's wired into `ChannelReconciler` as a new Step 3b alongside the existing exact-event_id duplicate check, reported as info-severity, non-auto-fixable `ReconciliationIssue`s (`issue_type="suspect_duplicate"`), wrapped in try/except so a detection bug can never break the rest of reconciliation, and skipped outright for fewer than 2 active channels.

## Motivation

Closes a real blind spot in duplicate detection that the DB unique index structurally cannot catch (two differently-named/keyworded streams of one game will always get distinct DB rows even if they're the same broadcast). Deliberately scoped to detection/reporting only for this PR — auto-merge is explicitly deferred to a later item, called out in the module docstring.

## What changed

- `teamarr/consumers/enforcement/duplicate_detector.py` — new `find_suspect_duplicates()`
- `teamarr/consumers/enforcement/__init__.py` — export `find_suspect_duplicates`
- `teamarr/consumers/reconciliation.py` — new `ChannelReconciler._detect_suspect_duplicates`, wired in as Step 3b; `"suspect_duplicate"` added to the issue-count summary dict

## Behavior-change callouts

- Purely additive/detection-only — no existing behavior changes, no auto-fix, no dry-run posture needed (nothing is mutated). The only observable change is new `info`-severity log lines (`issue_type="suspect_duplicate"`) appearing in reconciliation runs where a suspect pair is found; flagging this so it's not mistaken for noise by anyone monitoring reconciliation log volume.
- The similarity threshold (85.0) is a judgment call, not derived from any real-world false-positive/negative measurement — happy to tune it based on maintainer feedback.

This branch is file-disjoint from the other two Teamarr PRs I'm opening alongside this one and can be merged independently in any order.

Tests: `tests/test_duplicate_detector.py` — full behavioral contract covering event_id equality exclusion, sport equality, half-open window overlap with documented bypass, similarity threshold, deterministic pair ordering. `pytest tests/ -q`: 2056 passed (2035 baseline + 21 new); `ruff check teamarr/ tests/`: clean.
