### PR TITLE
fix: decouple feed-team identification from feed separation (#527)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -724,3 +724,4 @@
 {"id":"int-9fb032c14658571a651fbe209e009b30","kind":"field_change","created_at":"2026-07-29T13:41:14.235262658Z","actor":"egyptiangio","issue_id":"teamarrv2-x4vf","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d374c9cd7287f764dcd17020175e71af","kind":"field_change","created_at":"2026-07-30T02:59:44.475180907Z","actor":"egyptiangio","issue_id":"teamarrv2-lwq7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-3f6a218fc7893297be92396a912a3c84","kind":"field_change","created_at":"2026-07-30T17:27:39.596952256Z","actor":"egyptiangio","issue_id":"teamarrv2-x4vf","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-f3fd810de8fffd332892b836044e7ea5","kind":"field_change","created_at":"2026-07-30T19:30:31.37164498Z","actor":"egyptiangio","issue_id":"teamarrv2-a0nq","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -60,7 +60,7 @@ Detection checks the stream **name, tvg-id, and tvg-name** — a stream whose tv
 
 ### Settings
 
-All detection (including broadcast-market) runs only when the master **Feed Separation** toggle is on.
+Feed **identification** always runs — every stream's resolved feed team is stored and drives the [Home/Away Feed stream-priority rule](stream-priority#how-homeaway-feed-detection-works) even with the feature off. The master **Feed Separation** toggle gates only the channel *splitting*: whether resolved feeds get their own channels.
 
 | Setting | Default | Description |
 |---------|---------|-------------|

--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -60,7 +60,7 @@ Both **Stream Type** (team streams) and **Home/Away Feed** rules let you pick sp
 
 ### How Home/Away Feed detection works
 
-The rule first checks the **resolved feed team** stored during matching — the [Feed Separation](consolidation#feed-separation) engine's verdict from broadcast-market listings, team-branded names, and tvg-id/tvg-name (those detections require Feed Separation to be enabled; the team-stream fallback — `MLB | Milwaukee Brewers` resolving to the Brewers — works regardless). When no team was resolved, it falls back to scanning the stream name for your selected teams plus a feed indicator — a matchup (`vs`, `at`, `@`), a side (`home`/`away`), a camera label, or a `(Team feed)` marker. Generic streams with neither are left for other rules.
+The rule first checks the **resolved feed team** stored during matching — the [Feed Separation](consolidation#feed-separation) engine's verdict from broadcast-market listings, team-branded names (`Brewers.TV`), and tvg-id/tvg-name. Identification always runs, whether or not the Feed Separation toggle is on (the toggle only controls channel splitting), and team streams (`MLB | Milwaukee Brewers`) carry their matched team the same way. When no team was resolved, it falls back to scanning the stream name for your selected teams plus a feed indicator — a matchup (`vs`, `at`, `@`), a side (`home`/`away`), a camera label, or a `(Team feed)` marker. Generic streams with neither are left for other rules.
 
 ## Live events keep their #1 stream
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -80,10 +80,13 @@ class StreamMatching:
             match_days_ahead = (row["event_match_days_ahead"] if row else 3) or 3
             tennis_majors_only = bool(row["tennis_majors_only"]) if row else False
 
-            # Load feed separation settings
+            # Load feed separation settings. Terms always reach the matcher:
+            # feed identification is unconditional (#527) — the
+            # feed_separation.enabled toggle gates only channel splitting
+            # (see _resolve_feed_teams / processor Step 4a).
             feed_settings = get_feed_separation_settings(conn)
-            feed_home_terms = feed_settings.home_terms if feed_settings.enabled else None
-            feed_away_terms = feed_settings.away_terms if feed_settings.enabled else None
+            feed_home_terms = feed_settings.home_terms
+            feed_away_terms = feed_settings.away_terms
 
         sport_durations = self._load_sport_durations_cached()
 
@@ -417,6 +420,7 @@ class StreamMatching:
         self,
         matched_streams: list[dict],
         detect_team_names: bool,
+        separation_enabled: bool,
     ) -> list[dict]:
         """Resolve feed hints to actual teams (Phase 2 feed separation).
 
@@ -434,9 +438,17 @@ class StreamMatching:
         a stream whose tvg-id is 'Brewers.TV' is the Brewers feed even when
         the display name alone gives no signal.
 
+        Identification is decoupled from feed separation (#527): resolution
+        always runs and the result always lands in 'stream_feed_team' (per-
+        stream feed_team_id → team_feed/not_team_feed ordering rules). The
+        channel-level 'feed_team' key — which splits channels per feed and
+        keys tvg_ids/naming — is populated only when separation_enabled.
+
         Args:
             matched_streams: List of matched stream dicts with 'event', 'stream', 'feed_hint'
             detect_team_names: Whether to scan stream names for team name patterns
+            separation_enabled: Whether resolved teams also create feed-separated
+                channels (feed_separation.enabled master toggle)
         """
         for entry in matched_streams:
             event = entry.get("event")
@@ -469,14 +481,16 @@ class StreamMatching:
                             source = "team_name_detect"
                             break
 
-            entry["feed_team"] = feed_team
+            entry["stream_feed_team"] = feed_team
+            entry["feed_team"] = feed_team if separation_enabled else None
 
             if feed_team:
                 logger.info(
-                    "[FEED] Stream '%s' → feed_team=%s (hint=%s)",
+                    "[FEED] Stream '%s' → feed_team=%s (hint=%s, separation=%s)",
                     entry["stream"]["name"][:50],
                     feed_team.name,
                     source,
+                    "on" if separation_enabled else "off",
                 )
 
         return matched_streams

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -713,12 +713,15 @@ class EventGroupProcessor(
                 streams, match_result, stream_timezone=group.stream_timezone
             )
 
-            # Step 4a: Resolve feed hints to actual teams
+            # Step 4a: Resolve feed hints to actual teams. Always runs (#527):
+            # identification persists per-stream for team_feed ordering rules;
+            # feed_separation.enabled gates only channel splitting.
             feed_settings = get_feed_separation_settings(conn)
-            if feed_settings.enabled:
-                matched_streams = self._resolve_feed_teams(
-                    matched_streams, feed_settings.detect_team_names
-                )
+            matched_streams = self._resolve_feed_teams(
+                matched_streams,
+                feed_settings.detect_team_names,
+                feed_settings.enabled,
+            )
 
             # Sort channels: sport → league → time → event_id (fixed order since v59)
             matched_streams = self._sort_matched_streams(matched_streams)

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -144,13 +144,17 @@ class ChannelCreator(_LifecycleHost):
                         feed_team = matched.get("feed_team")
                         feed_team_id = feed_team.id if feed_team else None
 
-                        # Per-stream resolved team (#489) for team_feed/
-                        # not_team_feed ordering rules. Feed resolution first;
-                        # for TEAM_ONLY streams fall back to the matched side's
+                        # Per-stream resolved team (#489/#527) for team_feed/
+                        # not_team_feed ordering rules. Reads stream_feed_team —
+                        # populated even when feed separation is off; for
+                        # TEAM_ONLY streams fall back to the matched side's
                         # team. Distinct from feed_team_id above: this is only
                         # persisted on the stream row and never creates
                         # feed-separated channels.
-                        stream_feed_team_id = feed_team_id
+                        stream_feed_team = matched.get("stream_feed_team")
+                        stream_feed_team_id = (
+                            stream_feed_team.id if stream_feed_team else None
+                        )
                         if stream_feed_team_id is None:
                             side = matched.get("matched_side")
                             if side == "home" and event.home_team:

--- a/tests/test_feed_separation.py
+++ b/tests/test_feed_separation.py
@@ -934,13 +934,20 @@ class TestResolveFeedTeamsIdentifiers:
             broadcast_markets={"Brewers.TV": "away", "Marquee Sports Network": "home"},
         )
 
-    def _resolve(self, stream: dict, event, detect_team_names: bool = True):
+    def _resolve(
+        self,
+        stream: dict,
+        event,
+        detect_team_names: bool = True,
+        separation_enabled: bool = True,
+    ):
         from teamarr.consumers.event_group_processor.matching import StreamMatching
 
         entry = {"stream": stream, "event": event, "feed_hint": None}
         StreamMatching._resolve_feed_teams(
-            StreamMatching(), [entry], detect_team_names
+            StreamMatching(), [entry], detect_team_names, separation_enabled
         )
+        self._last_entry = entry
         return entry["feed_team"]
 
     def test_tvg_id_matches_broadcast_market(self, event):
@@ -974,3 +981,27 @@ class TestResolveFeedTeamsIdentifiers:
     def test_detect_team_names_off_still_uses_broadcast_markets(self, event):
         stream = {"name": "MIL @ CHC", "tvg_id": "Brewers.TV", "tvg_name": None}
         assert self._resolve(stream, event, detect_team_names=False) is event.away_team
+
+    # --- Identification decoupled from separation (#527) ---
+
+    def test_separation_off_still_identifies_stream_feed_team(self, event):
+        # The prioritization lever: with feed separation OFF, resolution still
+        # runs and lands in stream_feed_team (→ persisted feed_team_id →
+        # team_feed ordering rules), while the channel-splitting feed_team
+        # key stays None so no feed-separated channels appear.
+        stream = {"name": "MIL @ CHC", "tvg_id": "Brewers.TV", "tvg_name": None}
+        assert self._resolve(stream, event, separation_enabled=False) is None
+        assert self._last_entry["stream_feed_team"] is event.away_team
+
+    def test_separation_on_populates_both_keys(self, event):
+        stream = {"name": "MIL @ CHC", "tvg_id": "Brewers.TV", "tvg_name": None}
+        assert self._resolve(stream, event, separation_enabled=True) is event.away_team
+        assert self._last_entry["stream_feed_team"] is event.away_team
+
+    def test_separation_off_team_branded_name_identifies(self, event):
+        # FractalBoy's exact case (#527): 'Brewers.TV'-branded stream name,
+        # no broadcast-market data, feed separation off.
+        event.broadcast_markets = {}
+        stream = {"name": "Brewers.TV", "tvg_id": None, "tvg_name": None}
+        assert self._resolve(stream, event, separation_enabled=False) is None
+        assert self._last_entry["stream_feed_team"] is event.away_team


### PR DESCRIPTION
Closes #527 (follow-up to #489, reported by @FractalBoy).

**Problem:** `Brewers.TV`-style event streams (name or tvg-id) were invisible to `team_feed`/`not_team_feed` prioritization rules unless the feed-**separation** master toggle (default off) was on — the entire identification path (`_resolve_feed_teams` + HOME/AWAY term detection in the matcher) ran behind `feed_settings.enabled`. Team streams worked because their `matched_side` fallback isn't gated; exactly the reported split.

**Fix — identify always, decide later:**
- HOME/AWAY terms always reach the matcher; `_resolve_feed_teams` always runs.
- The resolved team always lands in a new `stream_feed_team` entry key → persisted per-stream `feed_team_id` → ordering rules work as a prioritization lever regardless of the toggle.
- The channel-level `feed_team` key (channel splitting, per-feed tvg_ids, naming) is populated **only when separation is enabled** — separation-off users get no new split channels.
- Existing attached streams backfill via the established `update_stream_feed_team` path on the next generation run.

**Tests:** 3 new (separation-off identification, both-keys-on, FractalBoy's literal `Brewers.TV` case); suite 2,116 green. Docs: corrected the two pages that claimed detection requires the toggle.