### PR TITLE
fix: exclude tennis leagues from generic team-matching paths (#541)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -739,3 +739,4 @@
 {"id":"int-bc8a00dc561ae14a693e2dcec8869c28","kind":"field_change","created_at":"2026-07-31T14:00:07.48101166Z","actor":"egyptiangio","issue_id":"teamarrv2-sn0d","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-157153f1952b1cc814368f2752b009e9","kind":"field_change","created_at":"2026-07-31T14:14:55.798196557Z","actor":"egyptiangio","issue_id":"teamarrv2-ucvf","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-850c11f4ffe2c1bbb6bda9132a4a39ec","kind":"field_change","created_at":"2026-07-31T15:39:10.280818819Z","actor":"egyptiangio","issue_id":"teamarrv2-ucvf","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-08dde4896f2d8b5969d9ccdfbf8de29a","kind":"field_change","created_at":"2026-08-04T02:55:50.127647454Z","actor":"egyptiangio","issue_id":"teamarrv2-6sjr","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -994,6 +994,18 @@ class StreamMatcher:
             return epg_matched
         return name_results
 
+    def _non_tennis_leagues(self, leagues: list[str]) -> list[str]:
+        """Drop tennis leagues from a generic team-matching candidate pool.
+
+        Tennis events are player-vs-player, so through the TEAM_ONLY /
+        TEAM_VS_TEAM paths arbitrary text sharing a surname can fuzzy-bind to
+        them ("Good Day Chicago" -> "Kayla Day vs Diane Parry", #541) —
+        bypassing both the tennis-EPG skip (mf7.9) and the tennis_majors_only
+        filter, which only the tennis pipeline enforces. Tennis events must
+        stay reachable solely via TENNIS_MATCH -> TennisMatcher.
+        """
+        return [lg for lg in leagues if self._league_sports.get(lg) != "tennis"]
+
     def _match_team_vs_team(
         self,
         classified: ClassifiedStream,
@@ -1011,9 +1023,18 @@ class StreamMatcher:
             except (KeyError, ValueError):
                 pass  # Keep group setting or None
 
+        search_leagues = self._non_tennis_leagues(self._search_leagues)
+        if not search_leagues:
+            return MatchOutcome.filtered(
+                FilteredReason.LEAGUE_NOT_INCLUDED,
+                stream_name=classified.normalized.original,
+                stream_id=stream_id,
+                detail="No non-tennis leagues configured for team matching",
+            )
+
         # Determine if single-league or multi-league matching
-        if len(self._search_leagues) == 1:
-            league = self._search_leagues[0]
+        if len(search_leagues) == 1:
+            league = search_leagues[0]
             return self._team_matcher.match_single_league(
                 classified=classified,
                 league=league,
@@ -1029,7 +1050,7 @@ class StreamMatcher:
         else:
             return self._team_matcher.match_multi_league(
                 classified=classified,
-                enabled_leagues=self._search_leagues,
+                enabled_leagues=search_leagues,
                 target_date=target_date,
                 group_id=self._group_id,
                 stream_id=stream_id,
@@ -1058,7 +1079,7 @@ class StreamMatcher:
 
         return self._team_matcher.match_team_only(
             classified=classified,
-            enabled_leagues=list(self._include_leagues),
+            enabled_leagues=self._non_tennis_leagues(list(self._include_leagues)),
             target_date=target_date,
             group_id=self._group_id,
             stream_id=stream_id,
@@ -1087,7 +1108,7 @@ class StreamMatcher:
 
         return self._team_matcher.match_all_star(
             classified=classified,
-            enabled_leagues=list(self._include_leagues),
+            enabled_leagues=self._non_tennis_leagues(list(self._include_leagues)),
             target_date=target_date,
             group_id=self._group_id,
             stream_id=stream_id,

--- a/teamarr/consumers/matching/tennis_matcher.py
+++ b/teamarr/consumers/matching/tennis_matcher.py
@@ -469,6 +469,13 @@ class TennisMatcher:
         if event.start_time.astimezone(ctx.user_tz).date() != ctx.target_date:
             return None
 
+        # Majors-only gates cache hits too: entries cached before the toggle
+        # was enabled would otherwise keep resurrecting non-major matches
+        # until expiry (#541).
+        if self._majors_only and not event.is_major:
+            self._cache.delete(ctx.group_id, ctx.stream_id, ctx.stream_name)
+            return None
+
         return MatchOutcome.matched(
             MatchMethod.CACHE,
             event,

--- a/tests/test_tennis.py
+++ b/tests/test_tennis.py
@@ -945,3 +945,129 @@ def test_majors_only_filters_player_matching():
         user_tz=tz,
     )
     assert not outcome.is_matched
+
+
+# ---------------------------------------------------------------------------
+# Generic team paths must not reach tennis events (#541)
+# ---------------------------------------------------------------------------
+
+
+def test_generic_team_paths_exclude_tennis_leagues():
+    """#541: an EPG programme like 'Good Day Chicago' classifies TEAM_ONLY and
+    must not fuzzy-bind to 'Kayla Day vs Diane Parry' — tennis leagues are
+    excluded from the generic TEAM_ONLY/TEAM_VS_TEAM/ALL_STAR candidate pools,
+    so tennis events stay reachable only via the tennis pipeline (which
+    enforces tennis_majors_only)."""
+    from tests.fakes import make_stream_matcher
+
+    m = make_stream_matcher(
+        leagues=("wta", "atp", "mlb"),
+        league_event_types={"wta": "event", "atp": "event", "mlb": "team_vs_team"},
+        league_sports={"wta": "tennis", "atp": "tennis", "mlb": "baseball"},
+    )
+
+    seen: dict[str, list[str]] = {}
+
+    def _capture_only(**kwargs):
+        seen["team_only"] = kwargs["enabled_leagues"]
+        return []
+
+    def _capture_all_star(**kwargs):
+        seen["all_star"] = kwargs["enabled_leagues"]
+        return []
+
+    def _capture_single(**kwargs):
+        seen["single"] = [kwargs["league"]]
+        return None
+
+    m._team_matcher.match_team_only = _capture_only
+    m._team_matcher.match_all_star = _capture_all_star
+    m._team_matcher.match_single_league = _capture_single
+
+    c = classify_stream("Good Day Chicago", league_event_type="team_vs_team")
+    m._match_team_only(c, stream_id=1, target_date=date(2026, 8, 3))
+    m._match_all_star(c, stream_id=1, target_date=date(2026, 8, 3))
+    # wta/atp filtered out of the 3 search leagues -> single-league path
+    m._match_team_vs_team(c, stream_id=1, target_date=date(2026, 8, 3))
+
+    assert seen["team_only"] == ["mlb"]
+    assert seen["all_star"] == ["mlb"]
+    assert seen["single"] == ["mlb"]
+
+
+def test_team_vs_team_filtered_when_group_is_tennis_only():
+    """A tennis-only group must yield an explicit FILTERED outcome on the
+    generic team path, never a fuzzy match into player-vs-player events."""
+    from teamarr.consumers.matching.result import FilteredReason
+    from tests.fakes import make_stream_matcher
+
+    m = make_stream_matcher(
+        leagues=("wta",),
+        league_event_types={"wta": "event"},
+        league_sports={"wta": "tennis"},
+    )
+    c = classify_stream("Day vs Parry", league_event_type="team_vs_team")
+    out = m._match_team_vs_team(c, stream_id=1, target_date=date(2026, 8, 3))
+    assert out.is_filtered
+    assert out.filtered_reason == FilteredReason.LEAGUE_NOT_INCLUDED
+
+
+def test_majors_only_gates_cache_hits():
+    """Entries cached before majors-only was enabled must not keep
+    resurrecting non-major matches until expiry (#541)."""
+    from types import SimpleNamespace
+
+    tz = ZoneInfo("America/New_York")
+
+    cached_data = {
+        "id": "wta-toronto-1",
+        "provider": "espn",
+        "name": "Kayla Day vs Diane Parry",
+        "start_time": datetime(2026, 8, 3, 11, 0, tzinfo=tz).isoformat(),
+        "home_team": {"name": "Kayla Day", "short_name": "Day"},
+        "away_team": {"name": "Diane Parry", "short_name": "Parry"},
+        "league": "wta",
+        "sport": "tennis",
+        "is_major": False,
+    }
+
+    class _EntryCache:
+        def __init__(self):
+            self.deleted = []
+
+        def get(self, *a, **k):
+            return SimpleNamespace(
+                cached_data=dict(cached_data),
+                league="wta",
+                match_method="tennis",
+                user_corrected=False,
+            )
+
+        def touch(self, *a, **k):
+            pass
+
+        def delete(self, *a, **k):
+            self.deleted.append(a)
+
+    c = classify_stream(
+        "WTA Toronto: Day vs Parry @ Aug 3 11:00 AM",
+        league_event_type="event",
+        event_league_sport="tennis",
+    )
+
+    def _match(majors_only, cache):
+        tm = TennisMatcher(service=_PoolService([]), cache=cache, majors_only=majors_only)
+        return tm.match(
+            c, "wta", date(2026, 8, 3),
+            group_id=1, stream_id=1, generation=1, user_tz=tz,
+        )
+
+    # majors_only off: the cached non-major match is a valid hit
+    cache_off = _EntryCache()
+    assert _match(False, cache_off).is_matched
+    assert not cache_off.deleted
+
+    # majors_only on: same cache entry is rejected AND evicted
+    cache_on = _EntryCache()
+    assert not _match(True, cache_on).is_matched
+    assert cache_on.deleted


### PR DESCRIPTION
## Problem (#541)

User subscribed to ATP/WTA with **majors only** enabled still got a channel for "Day/Parry" (WTA Toronto 1000), with several FOX locals attached whose guide showed "Good Day <city>" programmes.

Root cause: the majors-only filter lives only in the tennis pipeline (`TennisMatcher`), but tennis leagues were also in the **generic** team-matching candidate pools. Tennis events are player-vs-player, so a TEAM_ONLY-classified programme title sharing a surname ("Good **Day** Chicago") could fuzzy-bind to "Kayla **Day** vs Diane Parry" through the generic path — which applies neither the majors filter nor the tennis-EPG skip (mf7.9). Every FOX affiliate airing "Good Day" then attached to the same event channel.

## Fix

- `matcher.py`: new `_non_tennis_leagues()` helper; TEAM_VS_TEAM / TEAM_ONLY / ALL_STAR paths now exclude tennis-sport leagues (same pattern as the existing racing-league exclusion). A tennis-only pool yields an explicit `FILTERED: LEAGUE_NOT_INCLUDED`.
- `tennis_matcher.py`: majors-only now also gates **cache hits** — entries cached before the toggle was enabled are rejected and evicted instead of resurrecting non-major matches until expiry.

Real tennis streams are unaffected: tennis-hinted/tennis-group streams classify as TENNIS_MATCH and route through the tennis pipeline as before. Per field reports, tennis EPG programmes are tournament-name-only anyway (noted on bead mf7.9 for the eventual tennis-EPG design).

## Tests

3 new tests in `tests/test_tennis.py`: generic paths receive only non-tennis leagues; tennis-only group returns FILTERED; cache hit gated by majors-only (off = hit, on = rejected + evicted).

Gates: ruff clean, 2171 passed, frontend build OK.

Closes #541 at release (bead `teamarrv2-6sjr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)