### PR TITLE
feat: add WPBL via TSDB league 5929 (#284)

### DIFF
--- a/data/tsdb_seed.json
+++ b/data/tsdb_seed.json
@@ -1,245 +1,284 @@
 {
-  "generated_at": "2026-01-21T12:00:00.000000Z",
-  "generated_with": "premium_key",
-  "note": "Rugby (NRL, Super Rugby), Cricket (IPL, BBL, SA20), Norwegian Hockey, AFL, and CFL.",
-  "leagues": [
-    {
-      "code": "norwegian-hockey",
-      "provider_league_id": "4926",
-      "provider_league_name": "Norwegian Fjordkraft-ligaen",
-      "sport": "Ice Hockey",
-      "team_count": 10
-    },
-    {
-      "code": "cfl",
-      "provider_league_id": "4405",
-      "provider_league_name": "CFL",
-      "sport": "American Football",
-      "team_count": 9
-    },
-    {
-      "code": "unrivaled",
-      "provider_league_name": "Unrivaled",
-      "sport": "basketball",
-      "team_count": 8
-    }
-  ],
-  "teams": [
-    {
-      "provider_team_id": "140834",
-      "team_name": "Frisk Asker",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/a9jrw21697194347.png"
-    },
-    {
-      "provider_team_id": "140836",
-      "team_name": "Lillehammer",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/uledlc1622506179.png"
-    },
-    {
-      "provider_team_id": "147801",
-      "team_name": "L\u00f8renskog",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/igoa9c1697194356.png"
-    },
-    {
-      "provider_team_id": "140838",
-      "team_name": "Narvik",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/wm8d4l1711447795.png"
-    },
-    {
-      "provider_team_id": "153141",
-      "team_name": "Nidaros",
-      "team_abbrev": "NID",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/p1yjtt1757569516.png"
-    },
-    {
-      "provider_team_id": "140839",
-      "team_name": "Sparta Warriors",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/4ls3bz1697194374.png"
-    },
-    {
-      "provider_team_id": "140840",
-      "team_name": "Stavanger Oilers",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/e26kq11622516396.png"
-    },
-    {
-      "provider_team_id": "140841",
-      "team_name": "Stjernen",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/tdkfjd1697194381.png"
-    },
-    {
-      "provider_team_id": "140842",
-      "team_name": "Storhamar",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/mwtp8b1697194388.png"
-    },
-    {
-      "provider_team_id": "140843",
-      "team_name": "V\u00e5lerenga",
-      "team_abbrev": "",
-      "league": "norwegian-hockey",
-      "sport": "Ice Hockey",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/tf4ziz1697194396.png"
-    },
-    {
-      "provider_team_id": "135006",
-      "team_name": "BC Lions",
-      "team_abbrev": "BCL",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/ysxssy1424732039.png"
-    },
-    {
-      "provider_team_id": "135007",
-      "team_name": "Calgary Stampeders",
-      "team_abbrev": "CGY",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/lksemj1565196917.png"
-    },
-    {
-      "provider_team_id": "135008",
-      "team_name": "Edmonton Elks",
-      "team_abbrev": "EDM",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/5icq721630952022.png"
-    },
-    {
-      "provider_team_id": "135002",
-      "team_name": "Hamilton Tiger-Cats",
-      "team_abbrev": "HAM",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/qtwsuq1424727420.png"
-    },
-    {
-      "provider_team_id": "135003",
-      "team_name": "Montreal Alouettes",
-      "team_abbrev": "MTL",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/a6pbbp1628555426.png"
-    },
-    {
-      "provider_team_id": "135004",
-      "team_name": "Ottawa Redblacks",
-      "team_abbrev": "OTT",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/k8wjz71546002654.png"
-    },
-    {
-      "provider_team_id": "135009",
-      "team_name": "Saskatchewan Roughriders",
-      "team_abbrev": "SSK",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/xrdull1630952245.png"
-    },
-    {
-      "provider_team_id": "135005",
-      "team_name": "Toronto Argonauts",
-      "team_abbrev": "TOR",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/5a57ou1628555372.png"
-    },
-    {
-      "provider_team_id": "135010",
-      "team_name": "Winnipeg Blue Bombers",
-      "team_abbrev": "WPG",
-      "league": "cfl",
-      "sport": "American Football",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/4bo4wj1561667273.png"
-    },
-    {
-      "team_name": "Breeze BC",
-      "team_abbrev": null,
-      "provider_team_id": "154048",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/29avf41767618632.png"
-    },
-    {
-      "team_name": "Hive BC",
-      "team_abbrev": null,
-      "provider_team_id": "154049",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/439qxv1764968526.png"
-    },
-    {
-      "team_name": "Laces BC",
-      "team_abbrev": null,
-      "provider_team_id": "151477",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/c3n4jd1740948685.png"
-    },
-    {
-      "team_name": "Lunar Owls BC",
-      "team_abbrev": null,
-      "provider_team_id": "150651",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/j6aj3o1737743072.png"
-    },
-    {
-      "team_name": "Mist BC",
-      "team_abbrev": null,
-      "provider_team_id": "151962",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/sj9q1h1746291813.png"
-    },
-    {
-      "team_name": "Phantom BC",
-      "team_abbrev": null,
-      "provider_team_id": "151478",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/7hrbzm1740953624.png"
-    },
-    {
-      "team_name": "Rose BC",
-      "team_abbrev": null,
-      "provider_team_id": "151481",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/hroc4a1740956842.png"
-    },
-    {
-      "team_name": "Vinyl BC",
-      "team_abbrev": null,
-      "provider_team_id": "150736",
-      "league": "unrivaled",
-      "sport": "basketball",
-      "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/dkedp31738491548.png"
-    }
-  ]
+ "generated_at": "2026-01-21T12:00:00.000000Z",
+ "generated_with": "premium_key",
+ "note": "Rugby (NRL, Super Rugby), Cricket (IPL, BBL, SA20), Norwegian Hockey, AFL, and CFL, and WPBL.",
+ "leagues": [
+  {
+   "code": "norwegian-hockey",
+   "provider_league_id": "4926",
+   "provider_league_name": "Norwegian Fjordkraft-ligaen",
+   "sport": "Ice Hockey",
+   "team_count": 10
+  },
+  {
+   "code": "cfl",
+   "provider_league_id": "4405",
+   "provider_league_name": "CFL",
+   "sport": "American Football",
+   "team_count": 9
+  },
+  {
+   "code": "unrivaled",
+   "provider_league_name": "Unrivaled",
+   "sport": "basketball",
+   "team_count": 8
+  },
+  {
+   "code": "wpbl",
+   "provider_league_id": "5929",
+   "provider_league_name": "WPBL",
+   "sport": "Baseball",
+   "team_count": 4
+  }
+ ],
+ "teams": [
+  {
+   "provider_team_id": "140834",
+   "team_name": "Frisk Asker",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/a9jrw21697194347.png"
+  },
+  {
+   "provider_team_id": "140836",
+   "team_name": "Lillehammer",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/uledlc1622506179.png"
+  },
+  {
+   "provider_team_id": "147801",
+   "team_name": "L\u00f8renskog",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/igoa9c1697194356.png"
+  },
+  {
+   "provider_team_id": "140838",
+   "team_name": "Narvik",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/wm8d4l1711447795.png"
+  },
+  {
+   "provider_team_id": "153141",
+   "team_name": "Nidaros",
+   "team_abbrev": "NID",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/p1yjtt1757569516.png"
+  },
+  {
+   "provider_team_id": "140839",
+   "team_name": "Sparta Warriors",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/4ls3bz1697194374.png"
+  },
+  {
+   "provider_team_id": "140840",
+   "team_name": "Stavanger Oilers",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/e26kq11622516396.png"
+  },
+  {
+   "provider_team_id": "140841",
+   "team_name": "Stjernen",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/tdkfjd1697194381.png"
+  },
+  {
+   "provider_team_id": "140842",
+   "team_name": "Storhamar",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/mwtp8b1697194388.png"
+  },
+  {
+   "provider_team_id": "140843",
+   "team_name": "V\u00e5lerenga",
+   "team_abbrev": "",
+   "league": "norwegian-hockey",
+   "sport": "Ice Hockey",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/tf4ziz1697194396.png"
+  },
+  {
+   "provider_team_id": "135006",
+   "team_name": "BC Lions",
+   "team_abbrev": "BCL",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/ysxssy1424732039.png"
+  },
+  {
+   "provider_team_id": "135007",
+   "team_name": "Calgary Stampeders",
+   "team_abbrev": "CGY",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/lksemj1565196917.png"
+  },
+  {
+   "provider_team_id": "135008",
+   "team_name": "Edmonton Elks",
+   "team_abbrev": "EDM",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/5icq721630952022.png"
+  },
+  {
+   "provider_team_id": "135002",
+   "team_name": "Hamilton Tiger-Cats",
+   "team_abbrev": "HAM",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/qtwsuq1424727420.png"
+  },
+  {
+   "provider_team_id": "135003",
+   "team_name": "Montreal Alouettes",
+   "team_abbrev": "MTL",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/a6pbbp1628555426.png"
+  },
+  {
+   "provider_team_id": "135004",
+   "team_name": "Ottawa Redblacks",
+   "team_abbrev": "OTT",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/k8wjz71546002654.png"
+  },
+  {
+   "provider_team_id": "135009",
+   "team_name": "Saskatchewan Roughriders",
+   "team_abbrev": "SSK",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/xrdull1630952245.png"
+  },
+  {
+   "provider_team_id": "135005",
+   "team_name": "Toronto Argonauts",
+   "team_abbrev": "TOR",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/5a57ou1628555372.png"
+  },
+  {
+   "provider_team_id": "135010",
+   "team_name": "Winnipeg Blue Bombers",
+   "team_abbrev": "WPG",
+   "league": "cfl",
+   "sport": "American Football",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/4bo4wj1561667273.png"
+  },
+  {
+   "team_name": "Breeze BC",
+   "team_abbrev": null,
+   "provider_team_id": "154048",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/29avf41767618632.png"
+  },
+  {
+   "team_name": "Hive BC",
+   "team_abbrev": null,
+   "provider_team_id": "154049",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/439qxv1764968526.png"
+  },
+  {
+   "team_name": "Laces BC",
+   "team_abbrev": null,
+   "provider_team_id": "151477",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/c3n4jd1740948685.png"
+  },
+  {
+   "team_name": "Lunar Owls BC",
+   "team_abbrev": null,
+   "provider_team_id": "150651",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/j6aj3o1737743072.png"
+  },
+  {
+   "team_name": "Mist BC",
+   "team_abbrev": null,
+   "provider_team_id": "151962",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/sj9q1h1746291813.png"
+  },
+  {
+   "team_name": "Phantom BC",
+   "team_abbrev": null,
+   "provider_team_id": "151478",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/7hrbzm1740953624.png"
+  },
+  {
+   "team_name": "Rose BC",
+   "team_abbrev": null,
+   "provider_team_id": "151481",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/hroc4a1740956842.png"
+  },
+  {
+   "team_name": "Vinyl BC",
+   "team_abbrev": null,
+   "provider_team_id": "150736",
+   "league": "unrivaled",
+   "sport": "basketball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/dkedp31738491548.png"
+  },
+  {
+   "provider_team_id": "156334",
+   "team_name": "Boston Hunters",
+   "team_abbrev": "BH",
+   "league": "wpbl",
+   "sport": "Baseball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/545fnu1785231065.png"
+  },
+  {
+   "provider_team_id": "156335",
+   "team_name": "Los Angeles Queens",
+   "team_abbrev": "LAQ",
+   "league": "wpbl",
+   "sport": "Baseball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/g2zygc1785231083.png"
+  },
+  {
+   "provider_team_id": "156336",
+   "team_name": "New York Heights",
+   "team_abbrev": "NYH",
+   "league": "wpbl",
+   "sport": "Baseball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/sngy6d1785231101.png"
+  },
+  {
+   "provider_team_id": "156337",
+   "team_name": "San Francisco Firebells",
+   "team_abbrev": "SFB",
+   "league": "wpbl",
+   "sport": "Baseball",
+   "logo_url": "https://r2.thesportsdb.com/images/media/team/badge/j1qkqs1785231118.png"
+  }
+ ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 
 ## Features
 
-- **170 pre-configured leagues across 15 sports**, plus ~228 more soccer leagues discovered live from ESPN — football, basketball, hockey, baseball, soccer, cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar, IMSA, WEC), and tennis (ATP, WTA)
+- **171 pre-configured leagues across 15 sports**, plus ~228 more soccer leagues discovered live from ESPN — football, basketball, hockey, baseball, soccer, cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar, IMSA, WEC), and tennis (ATP, WTA)
 - **Custom leagues** — add any competition from TheSportsDB (premium key required)
 - **252 template variables + chainable filters** — customize channel names and EPG with records, scores, venues, broadcasts, standings, playoff status, motorsports sessions, tennis context, and more
 - **Flexible matching** — stream-name matching, team streams, and EPG program matching per source; aliases, fuzzy matching, and custom regex extractors for inconsistent IPTV naming

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,7 +12,7 @@ Developer documentation covering Teamarr's architecture, data providers, databas
 
 | Section | Contents |
 |---------|----------|
-| [Supported Leagues](supported-leagues) | All 170 pre-configured leagues and the discovered soccer leagues, organized by sport |
+| [Supported Leagues](supported-leagues) | All 171 pre-configured leagues and the discovered soccer leagues, organized by sport |
 | [Providers](providers/) | Data provider system — ESPN, Squiggle, NASCAR, MLB Stats, HockeyTech, Supabase, TheSportsDB — priority chain, API details, rate limiting |
 | [Architecture](architecture/) | API layer, consumer layer, Dispatcharr integration, detection keywords, database, template engine, migrations |
 | [Deployment](deployment/) | Environment variables, Docker configuration, logging |

--- a/docs/reference/providers/tsdb.md
+++ b/docs/reference/providers/tsdb.md
@@ -7,7 +7,7 @@ nav_order: 7
 
 # TheSportsDB Provider
 
-TheSportsDB (TSDB) is a community-driven sports data API. Teamarr uses it as a fallback provider (priority 100) for leagues not covered by ESPN, including cricket, boxing, CFL, Scandinavian leagues, Brazilian state championships, and motorsports (IMSA, WEC). It serves 48 leagues in total (5 free-tier, 43 premium).
+TheSportsDB (TSDB) is a community-driven sports data API. Teamarr uses it as a fallback provider (priority 100) for leagues not covered by ESPN, including cricket, boxing, CFL, Scandinavian leagues, Brazilian state championships, and motorsports (IMSA, WEC). It serves 49 leagues in total (6 free-tier, 43 premium).
 
 ## API Details
 
@@ -34,6 +34,7 @@ These leagues have low enough event volume to work within free tier limits:
 
 - CFL, Unrivaled, Norwegian Hockey, Boxing
 - Major League Cricket (MLC) — its short US T20 season fits within the free rolling next-events window
+- WPBL (Women's Pro Baseball League) — 4 teams, ~30-game season, roughly one game per day
 
 ### Premium Tier Leagues
 
@@ -59,7 +60,7 @@ Get a key at [thesportsdb.com/pricing](https://www.thesportsdb.com/pricing).
 
 ## Supported Leagues
 
-TSDB serves **48 leagues** in total. The table below is representative, not exhaustive — it omits the 23 Brazilian state championships, `fiba`/`fibaw` (FIBA Basketball World Cup M/W), and `uru.2` (Uruguayan Segunda División), among others. See [Supported Leagues](../supported-leagues) for the full list.
+TSDB serves **49 leagues** in total. The table below is representative, not exhaustive — it omits the 23 Brazilian state championships, `fiba`/`fibaw` (FIBA Basketball World Cup M/W), and `uru.2` (Uruguayan Segunda División), among others. See [Supported Leagues](../supported-leagues) for the full list.
 
 | League | Code | TSDB ID | Sport | Tier |
 |--------|------|---------|-------|------|
@@ -68,6 +69,7 @@ TSDB serves **48 leagues** in total. The table below is representative, not exha
 | Norwegian Fjordkraft-ligaen | `norwegian-hockey` | 4926 | Hockey | Free |
 | Boxing | `boxing` | 4445 | Boxing | Free |
 | Major League Cricket | `mlc` | 5401 | Cricket | Free |
+| WPBL | `wpbl` | 5929 | Baseball | Free |
 | Swedish Hockey League | `shl` | 4419 | Hockey | Premium |
 | Indian Premier League | `ipl` | 4460 | Cricket | Premium |
 | Big Bash League | `bbl` | 4461 | Cricket | Premium |

--- a/docs/reference/supported-leagues.md
+++ b/docs/reference/supported-leagues.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # Supported Sports & Leagues
 
-Teamarr supports **170 pre-configured leagues** across 15 sports, plus **~228 dynamically discovered soccer leagues** from ESPN. Most pre-configured leagues have full support (team import + event matching) — see the Support Levels table below for the event-only exceptions. Discovered leagues support event matching only.
+Teamarr supports **171 pre-configured leagues** across 15 sports, plus **~228 dynamically discovered soccer leagues** from ESPN. Most pre-configured leagues have full support (team import + event matching) — see the Support Levels table below for the event-only exceptions. Discovered leagues support event matching only.
 
 ## Support Levels
 
@@ -137,6 +137,7 @@ TSDB leagues are classified by tier. Most work on the free tier. Leagues marked 
 | Single-A (MiLB) | `milb-a` | MLB Stats |
 | Rookie (MiLB) | `rookie` | MLB Stats |
 | Canadian Baseball League | `cbl` | Supabase |
+| WPBL (Women's Pro Baseball) | `wpbl` | TSDB |
 | World Baseball Classic | `wbc` | ESPN |
 | NCAA Baseball | `ncaabb` | ESPN |
 | NCAA Softball | `ncaasbw` | ESPN |

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1059,6 +1059,8 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     -- ESPN serves no dedicated WBC league logo (only a generic baseball icon), so hardcode the Wikimedia Commons mark.
     ('world-baseball-classic', 'espn', 'baseball/world-baseball-classic', NULL, 'World Baseball Classic', 'baseball', 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/World_Baseball_Classic_logo.svg/500px-World_Baseball_Classic_logo.svg.png', NULL, 1, 'WBC', 'wbc', 'team_vs_team', 'World Baseball Classic', NULL, NULL, NULL, 1),
     ('cbl', 'supabase', 'https://cbl.ca', NULL, 'Canadian Baseball League', 'baseball', 'https://upload.wikimedia.org/wikipedia/en/thumb/1/1e/Canadian_Baseball_League.svg/1280px-Canadian_Baseball_League.svg.png', NULL, 1, 'CBL', 'cbl', 'team_vs_team', NULL, NULL, NULL, NULL, 1),
+    -- WPBL (Women's Pro Baseball League, #284): TSDB-only — ESPN airs games but exposes no API data. 4 teams, ~30-game season.
+    ('wpbl', 'tsdb', '5929', 'WPBL', 'WPBL', 'baseball', 'https://r2.thesportsdb.com/images/media/league/badge/rkx1371785226521.png', NULL, 1, 'WPBL', 'wpbl', 'team_vs_team', NULL, NULL, NULL, 'free', 1),
 
     -- Soccer (ESPN)
     ('usa.1', 'espn', 'soccer/usa.1', NULL, 'Major League Soccer', 'soccer', 'https://a.espncdn.com/i/leaguelogos/soccer/500/19.png', NULL, 1, 'MLS', 'mls', 'team_vs_team', 'MLS Soccer', NULL, NULL, NULL, 1),


### PR DESCRIPTION
Adds the Women's Pro Baseball League (#284), unblocked Aug 4 when TheSportsDB picked the league up (id 5929) — ESPN airs the games but still exposes no API data.

## Changes
- `schema.sql`: `wpbl` leagues row — TSDB 5929, baseball, `team_vs_team`, `tsdb_tier='free'` (4 teams, ~30-game season, ~1 game/day — same free-tier fit as CFL under current tier semantics; #545 tier rework is parked separately)
- `data/tsdb_seed.json`: WPBL league + 4 teams (Boston Hunters, Los Angeles Queens, New York Heights, San Francisco Firebells) with badges and short codes
- Docs: baseball section + TSDB tables get WPBL rows; league counts 170→171 (`docs/index.md`, `docs/reference/index.md`, `docs/reference/supported-leagues.md`); TSDB counts 48→49 (`docs/reference/providers/tsdb.md`)

## Verification
- Fresh schema load: 171 leagues total, 49 TSDB, `wpbl` row correct; seed loads all 4 WPBL teams
- Live TSDB probe: 20 upcoming events, 2 finals with scores, all teams with badges
- Gates: ruff clean · 2,176 tests pass · frontend builds

Closes nothing yet — #284 gets `status: on-dev` at merge and closes at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)