### PR TITLE
docs: document measured TSDB free-tier reality (#545)

### DIFF
--- a/docs/guide/settings/general.md
+++ b/docs/guide/settings/general.md
@@ -60,10 +60,10 @@ Optional premium API key for TheSportsDB — used for TSDB league coverage, addi
 
 | Tier | Rate Limit | Coverage |
 |------|------------|----------|
-| **Free** | 30 req/min | Limited — about 5 events/day per league |
-| **Premium** | 100 req/min | Full event coverage |
+| **Free** | 30 req/min | Rolling single next/last game per league; no team schedules |
+| **Premium** | 100 req/min | Full event coverage + team schedules |
 
-A handful of TSDB leagues (CFL, Unrivaled, boxing, Norwegian Fjordkraft-ligaen) work on the free tier, but **most TSDB-sourced leagues are premium-tier** — the crown icon in the league picker is the authoritative marker, and [Supported Leagues](../../reference/supported-leagues) lists tiers per league. Get a key at [thesportsdb.com/pricing](https://www.thesportsdb.com/pricing).
+A handful of TSDB leagues (CFL, Unrivaled, boxing, Norwegian Fjordkraft-ligaen, WPBL) are classified free-tier: without a key their games still appear via event-source channels, but only as each becomes the league's next game (short lead time), and **team channels stay empty without a premium key**. Most TSDB-sourced leagues are premium-tier — the crown icon in the league picker is the authoritative marker, and [Supported Leagues](../../reference/supported-leagues) lists tiers per league. See [TSDB free-tier details](../../reference/providers/tsdb#how-the-free-tier-actually-behaves-in-teamarr). Get a key at [thesportsdb.com/pricing](https://www.thesportsdb.com/pricing).
 
 A saved key displays masked (`********`); type over it to replace it. The **Premium** badge in the card header only means a key is stored — it isn't a validated tier. To actually verify a key, **retype it and click Validate**, which tests it against TSDB live and reports the real tier (clicking Validate on the masked placeholder will report invalid).
 

--- a/docs/reference/providers/tsdb.md
+++ b/docs/reference/providers/tsdb.md
@@ -20,17 +20,24 @@ TheSportsDB (TSDB) is a community-driven sports data API. Teamarr uses it as a f
 
 ## API Tiers
 
-| | Free | Premium |
+Measured 2026-08-04 (two networks, three client types; matches TSDB's published limits — TSDB quietly tightened the free tier sometime in 2026):
+
+| | Free (`123`) | Premium |
 |---|---|---|
-| **API Key** | `123` (default) | Your own key (6+ digits) |
 | **Rate Limit** | 30 req/min | 100 req/min |
-| **Events per Query** | 5 per day per league | Full coverage |
-| **Team Search** | 10 teams | 3,000 teams |
+| **`eventsnextleague` / `eventspastleague`** | **1 event** (rolling next/last) | 20 |
+| **`eventsday` with `l=` league filter** | **always 0 — the filter is premium-gated** (unfiltered returns the global top-3 events/day) | full |
+| **`eventsseason`** | 15-event cap | 3,000 |
+| **`all_leagues`** | sample only | full list |
 | **Cost** | Free | ~$9/month |
+
+### How the free tier actually behaves in Teamarr
+
+Teamarr's event pipeline polls `get_events(league, date)` per date on 30min–8h cache TTLs. Each game enters the guide **the moment it becomes the league's rolling "next" game** — so on the free tier every game does appear, but with short lead time (day-of for stacked schedules), and a second same-day game only appears after the first finishes (replacing it in that date's cache). **Team channels get zero events on the free tier**: `get_team_schedule` iterates only the league-filtered `eventsday` endpoint, which free keys can't use. In short: free = event-source channels with day-of lead; premium = full forward guide + working team channels.
 
 ### Free Tier Leagues
 
-These leagues have low enough event volume to work within free tier limits:
+These leagues remain classified free: their event-source channels work through the rolling-next capture described above (team channels still require a premium key, as on every TSDB league):
 
 - CFL, Unrivaled, Norwegian Hockey, Boxing
 - Major League Cricket (MLC) — its short US T20 season fits within the free rolling next-events window

--- a/teamarr/providers/tsdb/client.py
+++ b/teamarr/providers/tsdb/client.py
@@ -119,9 +119,10 @@ class RateLimiter:
 
     Tracks all wait events for UI feedback. Never fails - always waits and continues.
 
-    Rate limits per TSDB tier:
-    - Free: 30 req/min, 10 teams/search, 5 events/day
-    - Premium: 100 req/min, 3000 teams/search, 3000 events/season
+    Rate limits per TSDB tier (measured 2026-08-04):
+    - Free: 30 req/min; rolling 1-event next/past; league-filtered eventsday
+      returns nothing (filter is premium-gated); 15-event season cap
+    - Premium: 100 req/min, 20-event next/past, 3000 events/season
     """
 
     # Cooldown duration when internal limit is hit (seconds)
@@ -214,10 +215,16 @@ class TSDBClient(BaseHTTPClient):
 
     Configure premium key in Settings UI.
 
-    Free tier limitations:
+    Free tier limitations (measured 2026-08-04 — TSDB tightened these in 2026):
     - 30 requests/minute
-    - Team schedule (eventsnext.php) only shows HOME events
-    - No livescores or highlights
+    - eventsnextleague/eventspastleague: 1 event (rolling window). The
+      pipeline's per-date polling still harvests every game as it becomes
+      the league's next (see provider.get_events), but with short lead time.
+    - eventsday WITH a league filter returns nothing — the l= filter is
+      premium-gated (unfiltered free returns the global top-3 events/day).
+      Our get_events_by_date always filters, so it yields 0 keyless; this
+      is why get_team_schedule (eventsday-only) is empty on free.
+    - eventsseason: 15-event cap; all_leagues: sample only
 
     League mappings provided via LeagueMappingSource (no direct database access).
 
@@ -591,14 +598,14 @@ class TSDBClient(BaseHTTPClient):
     def get_team_next_events(self, team_id: str) -> dict | None:
         """Fetch upcoming events for a team.
 
-        Note: Free tier only returns HOME events.
-
         Args:
             team_id: TSDB team ID
 
         Returns:
             Raw TSDB response or None
         """
+        # TODO: PRUNE? — no in-tree callers (verified Aug 2026), dead along
+        # with get_team_last_events; verify with user
         return self._request("eventsnext.php", {"id": team_id})
 
     def get_team_last_events(self, team_id: str) -> dict | None:

--- a/teamarr/providers/tsdb/provider.py
+++ b/teamarr/providers/tsdb/provider.py
@@ -86,9 +86,10 @@ class TSDBProvider(SportsProvider):
     def is_premium(self) -> bool:
         """Check if TSDB has premium/full API access.
 
-        Premium access has no rate limits on schedule endpoints.
-        Free tier is limited to ~5 events per day via eventsnextleague.
-        Used by ProviderRegistry for fallback resolution.
+        Free tier (measured 2026-08-04) serves only a rolling 1-event
+        next/past window and no league-filtered eventsday — see the
+        TSDBClient docstring. Used by ProviderRegistry for fallback
+        resolution and the cache-prewarm premium gate.
         """
         return self._client.is_premium
 
@@ -224,7 +225,11 @@ class TSDBProvider(SportsProvider):
         """Get schedule for a team including past and future games.
 
         Uses eventsday.php across multiple days to get both HOME and AWAY
-        games (eventsnext.php only returns HOME on free tier).
+        games. FREE-TIER CAVEAT (measured 2026-08-04): league-filtered
+        eventsday returns nothing without a premium key, so this whole
+        method yields [] keyless — team channels require premium. Event
+        channels survive on free via get_events' eventsnextleague fallback
+        (rolling 1-event window harvested by per-date polling).
 
         Scans:
         - Past DAYS_BACK days for .last variable resolution (cached indefinitely)


### PR DESCRIPTION
Decision-neutral documentation of the #545 investigation findings, so the free-tier behavior never has to be rediscovered. No behavior changes — docs and docstrings only.

## What changed
- `docs/reference/providers/tsdb.md`: API Tiers table replaced with measured Aug-2026 limits (rolling 1-event next/past, premium-gated `eventsday` league filter, 15-event season cap) + new section on how Teamarr's per-date polling harvests the rolling window (event channels work day-of on free; team channels require a key)
- `docs/guide/settings/general.md`: tier table + free-league caveat corrected (was "about 5 events/day per league")
- `client.py` / `provider.py` docstrings: stale free-tier claims replaced with measured facts; `get_team_schedule` now warns it yields `[]` keyless; dead per-team `eventsnext.php`/`eventslast.php` methods marked `TODO: PRUNE?` for the Q3 audit

Gates: ruff clean · 2,176 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)