### PR TITLE
feat: add Little League Baseball (LLB) as a supported league (#556)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 
 ## Features
 
-- **171 pre-configured leagues across 15 sports**, plus ~228 more soccer leagues discovered live from ESPN — football, basketball, hockey, baseball, soccer, cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar, IMSA, WEC), and tennis (ATP, WTA)
+- **172 pre-configured leagues across 15 sports**, plus ~228 more soccer leagues discovered live from ESPN — football, basketball, hockey, baseball, soccer, cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar, IMSA, WEC), and tennis (ATP, WTA)
 - **Custom leagues** — add any competition from TheSportsDB (premium key required)
 - **252 template variables + chainable filters** — customize channel names and EPG with records, scores, venues, broadcasts, standings, playoff status, motorsports sessions, tennis context, and more
 - **Flexible matching** — stream-name matching, team streams, and EPG program matching per source; aliases, fuzzy matching, and custom regex extractors for inconsistent IPTV naming

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,7 +12,7 @@ Developer documentation covering Teamarr's architecture, data providers, databas
 
 | Section | Contents |
 |---------|----------|
-| [Supported Leagues](supported-leagues) | All 171 pre-configured leagues and the discovered soccer leagues, organized by sport |
+| [Supported Leagues](supported-leagues) | All 172 pre-configured leagues and the discovered soccer leagues, organized by sport |
 | [Providers](providers/) | Data provider system — ESPN, Squiggle, NASCAR, MLB Stats, HockeyTech, Supabase, TheSportsDB — priority chain, API details, rate limiting |
 | [Architecture](architecture/) | API layer, consumer layer, Dispatcharr integration, detection keywords, database, template engine, migrations |
 | [Deployment](deployment/) | Environment variables, Docker configuration, logging |

--- a/docs/reference/providers/espn.md
+++ b/docs/reference/providers/espn.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # ESPN Provider
 
-ESPN is the primary data provider (priority 0), serving 98 pre-configured leagues (97 enabled — MotoGP ships disabled) plus ~228 dynamically discovered soccer leagues. The API is free, public, and requires no authentication.
+ESPN is the primary data provider (priority 0), serving 99 pre-configured leagues (98 enabled — MotoGP ships disabled) plus ~228 dynamically discovered soccer leagues. The API is free, public, and requires no authentication.
 
 ## API Details
 
@@ -59,7 +59,7 @@ baseball/mlb
 | Football | NFL, NCAAF, UFL | |
 | Basketball | NBA, WNBA, G League, NCAAM, NCAAW, NBL (Australia) | FIBA World Cup (M/W) is TSDB — ESPN only tracks the final, not qualifiers |
 | Hockey | NHL, NCAA M/W, Olympics M/W | |
-| Baseball | MLB, NCAA Baseball, World Baseball Classic | MiLB handled by MLB Stats provider |
+| Baseball | MLB, NCAA Baseball, World Baseball Classic, Little League Baseball | MiLB handled by MLB Stats provider; LLB is the August World Series only |
 | Soccer | 48 pre-configured, ~228 discovered | Dot notation: `eng.1`, `ger.2` |
 | Rugby | 20 leagues (Six Nations, Rugby World Cup, Super Rugby, URC, Premiership, Top 14, MLR, NRL, Olympic 7s, …) | Second-largest ESPN sport by league count; NRL and Super Rugby Pacific migrated here from TSDB |
 | Combat Sports | UFC | Event Card matching |

--- a/docs/reference/supported-leagues.md
+++ b/docs/reference/supported-leagues.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 # Supported Sports & Leagues
 
-Teamarr supports **171 pre-configured leagues** across 15 sports, plus **~228 dynamically discovered soccer leagues** from ESPN. Most pre-configured leagues have full support (team import + event matching) — see the Support Levels table below for the event-only exceptions. Discovered leagues support event matching only.
+Teamarr supports **172 pre-configured leagues** across 15 sports, plus **~228 dynamically discovered soccer leagues** from ESPN. Most pre-configured leagues have full support (team import + event matching) — see the Support Levels table below for the event-only exceptions. Discovered leagues support event matching only.
 
 ## Support Levels
 
@@ -139,6 +139,7 @@ TSDB leagues are classified by tier. Most work on the free tier. Leagues marked 
 | Canadian Baseball League | `cbl` | Supabase |
 | WPBL (Women's Pro Baseball) | `wpbl` | TSDB |
 | World Baseball Classic | `wbc` | ESPN |
+| Little League Baseball | `llb` | ESPN |
 | NCAA Baseball | `ncaabb` | ESPN |
 | NCAA Softball | `ncaasbw` | ESPN |
 

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1061,6 +1061,10 @@ INSERT OR REPLACE INTO leagues (league_code, provider, provider_league_id, provi
     ('cbl', 'supabase', 'https://cbl.ca', NULL, 'Canadian Baseball League', 'baseball', 'https://upload.wikimedia.org/wikipedia/en/thumb/1/1e/Canadian_Baseball_League.svg/1280px-Canadian_Baseball_League.svg.png', NULL, 1, 'CBL', 'cbl', 'team_vs_team', NULL, NULL, NULL, NULL, 1),
     -- WPBL (Women's Pro Baseball League, #284): TSDB-only — ESPN airs games but exposes no API data. 4 teams, ~30-game season.
     ('wpbl', 'tsdb', '5929', 'WPBL', 'WPBL', 'baseball', 'https://r2.thesportsdb.com/images/media/league/badge/rkx1371785226521.png', NULL, 1, 'WPBL', 'wpbl', 'team_vs_team', NULL, NULL, NULL, 'free', 1),
+    -- LLB (#556): Little League Baseball World Series. As with WBC, ESPN serves only a generic
+    -- baseball icon for this league, so hardcode the Wikimedia mark. Teams are regional all-star
+    -- squads ESPN re-seeds each season, and the calendar is whitelisted to ~3 weeks each August.
+    ('llb', 'espn', 'baseball/llb', NULL, 'Little League Baseball', 'baseball', 'https://upload.wikimedia.org/wikipedia/en/thumb/8/8c/Little_League_logo.svg/500px-Little_League_logo.svg.png', NULL, 1, 'LLB', 'llb', 'team_vs_team', 'Little League Baseball', NULL, NULL, NULL, 1),
 
     -- Soccer (ESPN)
     ('usa.1', 'espn', 'soccer/usa.1', NULL, 'Major League Soccer', 'soccer', 'https://a.espncdn.com/i/leaguelogos/soccer/500/19.png', NULL, 1, 'MLS', 'mls', 'team_vs_team', 'MLS Soccer', NULL, NULL, NULL, 1),


### PR DESCRIPTION
Closes #556.

Adds ESPN's Little League Baseball World Series (`baseball/llb`) as pre-configured league #172.

## Verification

Seeded a scratch DB from `schema.sql` and ran the real provider path (`create_default_service()`):

- **Events** — Aug 10: 1 (final), Aug 13: 2, Aug 23: 4, with correct venues (Lamade Stadium / Volunteer Stadium, Williamsport).
- **Teams** — `get_league_teams('llb')` returns 232 regional squads with country-flag logos, so `import_enabled=1` is correct and LLB rightly stays out of `LEAGUES_WITHOUT_TEAMS`.

Bracket games beyond the current round come back as `TBD @ TBD` until teams advance — inherent to the tournament, not a matching bug.

## Notes

- ESPN serves only a generic baseball icon for this league, so the logo is a hardcoded Wikimedia mark, matching the existing WBC precedent.
- `gracenote_category` is set explicitly (`Little League Baseball`), so the "56 import-enabled fallback leagues" figure in the Gracenote design doc is unaffected.
- Seed-data-only schema change — no `schema_version` bump needed; `INSERT OR REPLACE` applies on restart.

## Docs

- `supported-leagues.md`: LLB row under Baseball & Softball
- `providers/espn.md`: baseball coverage row + ESPN count 98 → 99 (97 → 98 enabled)
- League-count claims 171 → 172 in `docs/index.md`, `docs/reference/index.md`, `supported-leagues.md`

## Gates

`ruff` clean · `pytest` 2179 passed · `npm run build` green