### PR TITLE
fix: add Little League Baseball league hints — stop LLB→MLB crosstalk (#560)

### DIFF
--- a/teamarr/utilities/constants.py
+++ b/teamarr/utilities/constants.py
@@ -395,6 +395,13 @@ LEAGUE_HINT_PATTERNS: list[tuple[str, str | list[str]]] = [
     (r"\bnba[:\s-]", "nba"),
     (r"\bnhl[:\s-]", "nhl"),
     (r"\bmlb[:\s-]", "mlb"),
+    # LLB after MLB (#560): "MLB: Little League Classic" is an MLB game —
+    # the earlier MLB pattern must win. Bare "Little League" / LLWS streams
+    # would otherwise parse team abbreviations (MIL vs. LAD) straight into
+    # MLB matchups.
+    (r"\blittle league\b", "llb"),
+    (r"\bllws\b", "llb"),
+    (r"\bllb[:\s-]", "llb"),
     (r"\bmls[:\s-]", "usa.1"),
     (r"\bwnba[:\s-]", "wnba"),
     (r"\bnwsl[:\s-]", "usa.nwsl"),

--- a/tests/matching/test_llb_league_hint.py
+++ b/tests/matching/test_llb_league_hint.py
@@ -1,0 +1,44 @@
+"""Tests for the Little League Baseball league hint (#560).
+
+Without an LLB hint, streams like "Little League Baseball: ... MIL vs. LAD"
+carried no league constraint, so the team abbreviations matched the MLB
+Brewers/Dodgers matchup and LLB games landed in MLB channels. The hint
+hard-scopes such streams to llb — matched there when subscribed, filtered
+(never crosstalk) when not.
+
+Ordering matters the other way too: the MLB Little League Classic is an
+MLB game ("MLB: Little League Classic ..."), and the earlier MLB pattern
+must keep winning for it.
+"""
+
+import pytest
+
+from teamarr.consumers.matching.classifier import detect_league_hint
+from teamarr.services.detection_keywords import DetectionKeywordService
+
+
+def setup_function():
+    """Clear compiled pattern cache before each test."""
+    DetectionKeywordService.invalidate_cache()
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        # The reporter's exact stream shape (#560)
+        (
+            "US (ESPN+ 141) | Little League Baseball: "
+            "Little League Baseball Regionals • MIL vs. LAD (2026-08-14 21:00:15)",
+            "llb",
+        ),
+        ("Little League World Series: Japan vs Mexico", "llb"),
+        ("LLWS Semifinal: Texas vs Florida", "llb"),
+        ("LLB: Great Lakes vs Mountain", "llb"),
+        # MLB Little League Classic is an MLB game — MLB pattern wins by order
+        ("MLB: Little League Classic • NYM vs SEA", "mlb"),
+        # Plain MLB streams keep their hint
+        ("MLB: Brewers vs Dodgers", "mlb"),
+    ],
+)
+def test_llb_league_hint(stream, expected):
+    assert detect_league_hint(stream) == expected


### PR DESCRIPTION
Fixes #560's crosstalk: `US (ESPN+ 141) | Little League Baseball: Little League Baseball Regionals • MIL vs. LAD` matched the MLB Brewers–Dodgers game because no league hint existed for Little League — #556 added the league but no detection keywords, so the classifier fell through to bare team-abbreviation matching.

**Change:** three built-in `LEAGUE_HINT_PATTERNS` entries mapping to `llb`: `\blittle league\b`, `\bllws\b`, `\bllb[:\s-]`. League hints hard-scope matching (`team_matcher.py`): subscribed → matches only LLB events; not subscribed → stream filtered `LEAGUE_NOT_INCLUDED` — in neither case can it reach MLB channels. Placed after the `\bmlb[:\s-]` pattern so "MLB: Little League Classic" (an actual MLB game) keeps hinting `mlb` — regression-tested.

Tests: +6 including the reporter's exact stream shape; 2,200 total passing. Bead: teamarrv2-ep6x.