### PR TITLE
fix: gate short_name scoring so shared nicknames stop crossing leagues (#569)

### DIFF
--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -123,18 +123,69 @@ def _abbrev_equals(stream_code: str, event_abbrev: str | None) -> bool:
     return code == normalize_text(event_abbrev)
 
 
+def _initialism(tokens: list[str]) -> str:
+    """First letter of each token, in order ("san francisco" -> "sf")."""
+    return "".join(t[0] for t in tokens if t)
+
+
+def _short_name_leg_is_safe(stream_norm: str, name_norm: str, short_norm: str, abbrev: str) -> bool:
+    """May the short_name score stand in for this stream candidate? (#569)
+
+    token_set_ratio returns 100 whenever the short name is a token subset of
+    the stream — so a bare nickname short_name makes every team sharing that
+    nickname interchangeable. ESPN hands both the NFL and MLB Giants
+    short_name "Giants", so "san francisco giants" scored 100 against the New
+    York Giants (57 on the full name) and SF streams landed on NFL channels.
+
+    The discriminator is whatever the full name carries beyond the nickname
+    ("new york" for NYG). Accept the short_name leg only when the stream's own
+    residual tokens are consistent with that discriminator — its own words,
+    its initialism ("ny"), or the provider abbreviation. This keeps #480's
+    "d backs" working, keeps "SF Giants" on the MLB side, and additionally
+    pins "NY Giants" to the NFL side, which is ambiguous today.
+    """
+    short_tokens = set(short_norm.split())
+    name_tokens = name_norm.split()
+    discriminator = [t for t in name_tokens if t not in short_tokens]
+    stream_residual = [t for t in stream_norm.split() if t not in short_tokens]
+
+    # Bare nickname on either side carries no location to contradict.
+    if not stream_residual or not discriminator:
+        return True
+
+    allowed = set(discriminator)
+    allowed.add(_initialism(discriminator))
+    allowed.add(_initialism(name_tokens))
+    if abbrev:
+        allowed.add(abbrev)
+    return all(token in allowed for token in stream_residual)
+
+
 def _best_name_score(stream_norm: str, event_team) -> float:
     """token_set_ratio against the best of the team's name and short_name.
 
     Official nicknames often share no words with the full name — ESPN's
     short_name for Arizona is literally "D-backs", which scores ~50 against
     "Arizona Diamondbacks" (#480). Streams use whichever form the provider
-    liked, so both are fair game.
+    liked, so both are fair game — but the short_name leg is gated by
+    _short_name_leg_is_safe so a shared nickname can't erase the location
+    that tells two teams apart (#569).
     """
-    score = fuzz.token_set_ratio(stream_norm, normalize_text(event_team.name))
+    name_norm = normalize_text(event_team.name)
+    score = fuzz.token_set_ratio(stream_norm, name_norm)
+
     short = getattr(event_team, "short_name", None)
-    if short and short != event_team.name:
-        score = max(score, fuzz.token_set_ratio(stream_norm, normalize_text(short)))
+    if not short or short == event_team.name:
+        return score
+
+    short_norm = normalize_text(short)
+    short_score = fuzz.token_set_ratio(stream_norm, short_norm)
+    if short_score <= score:
+        return score
+
+    abbrev = normalize_text(getattr(event_team, "abbreviation", "") or "")
+    if _short_name_leg_is_safe(stream_norm, name_norm, short_norm, abbrev):
+        return short_score
     return score
 
 

--- a/tests/matching/test_shared_nickname_crosstalk.py
+++ b/tests/matching/test_shared_nickname_crosstalk.py
@@ -1,0 +1,130 @@
+"""Shared-nickname crosstalk across leagues (#569).
+
+ESPN gives both the NFL and MLB Giants short_name "Giants". Because
+token_set_ratio returns 100 whenever the short name is a token subset of the
+stream, 'US: San Francisco Giants' scored 100 against the New York Giants (57
+on the full name) and SF's team-branded stream was attached to NFL channels.
+
+The short_name leg now only stands in when the stream's residual tokens agree
+with the team's own discriminator — its words, its initialism, or the
+abbreviation — so location survives while #480's 'D-backs' still matches.
+"""
+
+from datetime import UTC, datetime
+
+from teamarr.consumers.matching.team_matcher import _best_name_score
+from teamarr.core.types import Event, EventStatus, Team
+from tests.fakes import make_team_matcher
+
+TODAY = datetime.now(UTC).date()
+
+
+def _team(name, abbr, short_name, league, sport):
+    return Team(
+        id="t-" + abbr.lower(),
+        provider="espn",
+        name=name,
+        short_name=short_name,
+        abbreviation=abbr,
+        league=league,
+        sport=sport,
+    )
+
+
+NYG = _team("New York Giants", "NYG", "Giants", "nfl", "football")
+MIN = _team("Minnesota Vikings", "MIN", "Vikings", "nfl", "football")
+SFG = _team("San Francisco Giants", "SF", "Giants", "mlb", "baseball")
+COL = _team("Colorado Rockies", "COL", "Rockies", "mlb", "baseball")
+DBACKS = _team("Arizona Diamondbacks", "ARI", "Diamondbacks", "mlb", "baseball")
+ITALY_U17 = _team("Italy U17", "ITA", "Italy", "fifa.world.u17", "soccer")
+
+
+def _event(home, away, eid, league, sport):
+    start = datetime.combine(TODAY, datetime.min.time(), tzinfo=UTC).replace(hour=19)
+    return Event(
+        id=eid,
+        provider="espn",
+        name=f"{home.name} vs {away.name}",
+        short_name=f"{home.short_name} vs {away.short_name}",
+        start_time=start,
+        home_team=home,
+        away_team=away,
+        status=EventStatus(state="scheduled"),
+        league=league,
+        sport=sport,
+    )
+
+
+class TestSharedNicknameScoring:
+    def test_sf_giants_does_not_match_ny_giants(self):
+        # The whole bug in one line: 100 before the gate, 57 after.
+        assert _best_name_score("san francisco giants", NYG) < 85
+
+    def test_sf_giants_still_matches_its_own_team(self):
+        assert _best_name_score("san francisco giants", SFG) == 100
+
+    def test_city_initialism_pins_the_right_giants(self):
+        # 'SF Giants' / 'NY Giants' scored 100 against BOTH teams before #569
+        assert _best_name_score("sf giants", SFG) == 100
+        assert _best_name_score("sf giants", NYG) < 85
+        assert _best_name_score("ny giants", NYG) == 100
+        assert _best_name_score("ny giants", SFG) < 85
+
+    def test_bare_nickname_stays_ambiguous(self):
+        # No location to contradict — league/sport hints resolve these, not us
+        assert _best_name_score("giants", NYG) == 100
+        assert _best_name_score("giants", SFG) == 100
+
+    def test_age_group_national_teams_stay_separate(self):
+        # short_name 'Italy' made every Italy age group interchangeable
+        assert _best_name_score("italy u20", ITALY_U17) < 85
+        assert _best_name_score("italy u17", ITALY_U17) == 100
+
+    def test_bare_nickname_still_rides_the_short_name_leg(self):
+        # What the short_name leg is FOR (#480): the full name scores only 67
+        # against its own nickname, so the leg has to carry it.
+        assert _best_name_score("diamondbacks", DBACKS) == 100
+
+    def test_abbreviation_prefixed_nickname_survives(self):
+        # 'MLB 13 | ARI Diamondbacks' — the abbreviation is a valid residual
+        assert _best_name_score("ari diamondbacks", DBACKS) == 100
+
+
+class TestTeamOnlyFanOut:
+    """End-to-end: the branded stream reaches only the baseball event."""
+
+    def _outcomes(self, team_norm, event):
+        matcher = make_team_matcher()
+        return matcher._score_single_team_against_event(team_norm, event)
+
+    def test_sf_giants_stream_skips_the_nfl_event(self):
+        nfl = _event(NYG, MIN, "nfl-1", "nfl", "football")
+        score, side = self._outcomes("san francisco giants", nfl)
+        assert score is None
+        assert side is None
+
+    def test_sf_giants_stream_hits_the_mlb_event(self):
+        mlb = _event(SFG, COL, "mlb-1", "mlb", "baseball")
+        score, side = self._outcomes("san francisco giants", mlb)
+        assert score is not None
+        assert side == "home"
+
+
+class TestTeamVsTeamScoring:
+    """The both-teams path shares _best_name_score, so it is gated too."""
+
+    def test_sf_giants_matchup_does_not_score_an_nfl_event(self):
+        matcher = make_team_matcher()
+        nfl = _event(NYG, MIN, "nfl-1", "nfl", "football")
+        assert matcher._score_teams_against_event(
+            "Colorado Rockies", "San Francisco Giants", nfl
+        ) is None
+
+    def test_sf_giants_matchup_scores_its_own_event(self):
+        matcher = make_team_matcher()
+        mlb = _event(SFG, COL, "mlb-1", "mlb", "baseball")
+        result = matcher._score_teams_against_event(
+            "Colorado Rockies", "San Francisco Giants", mlb
+        )
+        assert result is not None
+        assert result[1] >= 85


### PR DESCRIPTION
ESPN gives both the NFL and MLB Giants short_name 'Giants'. token_set_ratio
returns 100 whenever the short name is a token subset of the stream, so
'US: San Francisco Giants' scored 100 against the New York Giants (57 on the
full name) and the SF team-branded stream was attached to NFL channels.

The short_name leg (#480) now only stands in for the full-name score when the
stream's residual tokens agree with the team's own discriminator — its words,
its initialism, or the provider abbreviation. Bare-nickname streams are
unchanged; 'SF Giants' and 'NY Giants', ambiguous at 100 against both teams
today, now pin to the correct one.

Swept against a 10,320-row team_cache: 2,005 of 2,015 cross-team false
positives eliminated (788 unique name pairs, incl. Racing Santander/Racing
Club and every FIFA age-group pair), 9 regressions in 29,900 self-match
variants — all synthetic multi-token college abbreviations.

---

Bead: `teamarrv2-t7hc` · Issue: #569
