### PR TITLE
fix: detect bracketed league tags so (MLB)/[NBA] streams stay in their league (#580)

### DIFF
--- a/docs/reference/architecture/detection-keywords.md
+++ b/docs/reference/architecture/detection-keywords.md
@@ -120,6 +120,18 @@ League hints can map to multiple leagues for umbrella brands:
 
 When a stream matches a multi-league hint, the matcher tries events from all listed leagues.
 
+## Bracketed League Tags
+
+Built-in league hint patterns require a delimiter after the code (`\bmlb[:\s-]`), so a
+bracketed tag — `US (MLB) Seattle Mariners`, `[NBA] Lakers vs Celtics` — would otherwise
+go undetected. When detection on the raw stream name finds nothing, it is retried once on
+a de-bracketed copy (`(`, `)`, `[`, `]`, `{`, `}` → space).
+
+The raw name is always tried first, so a user-defined hint written with literal brackets
+still takes priority. A stream with no league hint is scored against **every** league its
+group subscribes to, which is how cross-league false positives arise — detecting the
+bracketed tag scopes the stream to its own league instead.
+
 ## Usage Examples
 
 ```python

--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -1111,14 +1111,25 @@ def _clean_team_name(name: str) -> str:
 # =============================================================================
 
 
+# Bracket characters that wrap a league tag ("US (MLB) Mariners", "[NBA] Lakers").
+# The built-in hint patterns end in [:\s-], so a bracketed code never matched (#580).
+_BRACKETS_RE = re.compile(r"[()\[\]{}]")
+
+
 def detect_league_hint(text: str) -> str | list[str] | None:
-    """Detect league from stream name patterns.
+    r"""Detect league from stream name patterns.
 
     Examples:
         "NHL: Bruins vs Rangers" → "nhl"
         "EPL - Arsenal vs Chelsea" → "eng.1"
         "UFC 315: Main Card" → "ufc"
         "EFL: Portsmouth vs Southampton" → ["eng.2", "eng.3", "eng.4"]
+        "US (MLB) Seattle Mariners (S)" → "mlb"
+
+    Providers commonly bracket the league tag, which the built-in patterns miss
+    because they require a ``[:\s-]`` delimiter after the code. Detection is
+    retried once on a de-bracketed copy — raw text first, so user-defined hint
+    patterns that contain literal brackets keep winning (#580).
 
     Args:
         text: Stream name (should be normalized)
@@ -1129,7 +1140,15 @@ def detect_league_hint(text: str) -> str | list[str] | None:
     if not text:
         return None
 
-    return DetectionKeywordService.detect_league(text)
+    hint = DetectionKeywordService.detect_league(text)
+    if hint is not None:
+        return hint
+
+    debracketed = _BRACKETS_RE.sub(" ", text)
+    if debracketed == text:
+        return None
+
+    return DetectionKeywordService.detect_league(debracketed)
 
 
 # Gender keywords that indicate women's leagues. English (W)/Women plus

--- a/tests/matching/test_bracketed_league_hint.py
+++ b/tests/matching/test_bracketed_league_hint.py
@@ -1,0 +1,74 @@
+"""League hints wrapped in brackets (#580).
+
+The built-in hint patterns end in ``[:\\s-]``, so a bracketed league tag —
+the shape most providers ship ("US (MLB) Seattle Mariners (S)") — produced no
+hint at all. Without a hint the stream is scored against every league the
+group subscribes to, which is how cross-league false positives get their
+chance in the first place (the #569 report's streams were all bracketed).
+
+Detection now retries once on a de-bracketed copy. Raw text goes first so
+user-defined hint patterns containing literal brackets keep winning.
+"""
+
+import pytest
+
+from teamarr.consumers.matching.classifier import classify_stream, detect_league_hint
+from teamarr.services.detection_keywords import DetectionKeywordService
+
+
+def setup_function():
+    """Clear compiled pattern cache before each test."""
+    DetectionKeywordService.invalidate_cache()
+
+
+@pytest.mark.parametrize(
+    "stream,expected",
+    [
+        # The reported shapes (#580) — an MLB/NFL stream must never be free to
+        # roam an MLS group's events.
+        ("US (MLB) Seattle Mariners (S)", "mlb"),
+        ("(NFL) Seattle Seahawks (P)", "nfl"),
+        ("[NBA] Lakers vs Celtics", "nba"),
+        ("(Apple) (MLS) 026 | Seattle vs. Austin", "usa.1"),
+        ("{NHL} Bruins vs Rangers", "nhl"),
+        # Unbracketed forms are unchanged
+        ("NHL: Bruins vs Rangers", "nhl"),
+        ("MLB: Brewers vs Dodgers", "mlb"),
+    ],
+)
+def test_bracketed_league_tag_detects(stream, expected):
+    assert detect_league_hint(stream) == expected
+
+
+@pytest.mark.parametrize(
+    "stream",
+    [
+        # Quality/feed markers must not be mistaken for league codes
+        "US (HD) Seattle Mariners",
+        "US (4K) | Team A vs Team B",
+        "(SD) Some Channel",
+        "US Seattle Mariners (A)",
+    ],
+)
+def test_non_league_brackets_stay_unhinted(stream):
+    assert detect_league_hint(stream) is None
+
+
+def test_bracketed_umbrella_hint_still_narrows_by_gender():
+    # The de-bracketed retry feeds the normal umbrella path, and (W) narrowing
+    # reads the original stream name — so the marker survives its own bracket.
+    result = classify_stream("(NCAAB) (W): Duke vs UNC")
+    assert result.league_hint == "womens-college-basketball"
+
+
+def test_raw_text_wins_over_the_debracketed_retry():
+    # A user pattern written with literal brackets must still take priority.
+    DetectionKeywordService.invalidate_cache()
+    hints = DetectionKeywordService.get_league_hints()
+    import re
+
+    hints.insert(0, (re.compile(r"\(MLB\)", re.IGNORECASE), "llb"))
+    try:
+        assert detect_league_hint("US (MLB) Little League Classic") == "llb"
+    finally:
+        DetectionKeywordService.invalidate_cache()

--- a/tests/matching/test_shared_nickname_crosstalk.py
+++ b/tests/matching/test_shared_nickname_crosstalk.py
@@ -38,6 +38,13 @@ COL = _team("Colorado Rockies", "COL", "Rockies", "mlb", "baseball")
 DBACKS = _team("Arizona Diamondbacks", "ARI", "Diamondbacks", "mlb", "baseball")
 ITALY_U17 = _team("Italy U17", "ITA", "Italy", "fifa.world.u17", "soccer")
 
+# Same city, different sports. ESPN's MLS short_name is the bare city
+# "Seattle", which is the same subset trap one league over (#580 report).
+SOUNDERS = _team("Seattle Sounders FC", "SEA", "Seattle", "usa.1", "soccer")
+ATX = _team("Austin FC", "ATX", "Austin", "usa.1", "soccer")
+MARINERS = _team("Seattle Mariners", "SEA", "Mariners", "mlb", "baseball")
+SEAHAWKS = _team("Seattle Seahawks", "SEA", "Seahawks", "nfl", "football")
+
 
 def _event(home, away, eid, league, sport):
     start = datetime.combine(TODAY, datetime.min.time(), tzinfo=UTC).replace(hour=19)
@@ -128,3 +135,41 @@ class TestTeamVsTeamScoring:
         )
         assert result is not None
         assert result[1] >= 85
+
+
+class TestSharedCityCrosstalk:
+    """Same-city teams in different leagues (#580 report).
+
+    ESPN hands MLS teams a bare-city short_name ("Seattle" for the Sounders),
+    so every Seattle-branded stream scored 100 against an MLS Sounders event
+    and MLB/NFL streams were attached to the soccer channel. The discriminator
+    here is the nickname rather than the location, but the gate is the same.
+    """
+
+    def test_mariners_stream_does_not_match_the_sounders(self):
+        assert _best_name_score("us seattle mariners a", SOUNDERS) < 85
+
+    def test_seahawks_stream_does_not_match_the_sounders(self):
+        assert _best_name_score("nfl seattle seahawks p", SOUNDERS) < 85
+
+    def test_seattle_streams_still_match_their_own_teams(self):
+        assert _best_name_score("us seattle mariners a", MARINERS) == 100
+        assert _best_name_score("nfl seattle seahawks p", SEAHAWKS) == 100
+
+    def test_sounders_stream_still_matches_its_own_event(self):
+        matcher = make_team_matcher()
+        mls = _event(SOUNDERS, ATX, "mls-1", "usa.1", "soccer")
+        score, side = matcher._score_single_team_against_event(
+            "us seattle sounders a", mls
+        )
+        assert score is not None
+        assert side == "home"
+
+    def test_mariners_stream_skips_the_mls_event(self):
+        matcher = make_team_matcher()
+        mls = _event(SOUNDERS, ATX, "mls-1", "usa.1", "soccer")
+        score, side = matcher._score_single_team_against_event(
+            "us seattle mariners a", mls
+        )
+        assert score is None
+        assert side is None


### PR DESCRIPTION
Follow-up to the Seattle crosstalk report (Mariners/Seahawks streams landing on an MLS Sounders channel). The scoring half of that is already fixed on dev by #569/#570 — this closes the other half.

## Problem

`LEAGUE_HINT_PATTERNS` require a `[:\s-]` delimiter after the code, so a bracketed league tag is invisible:

```
"US (MLB) Seattle Mariners (S)"           -> hint=None   (now: mlb)
"(NFL) Seattle Seahawks (P)"              -> hint=None   (now: nfl)
"[NBA] Lakers vs Celtics"                 -> hint=None   (now: nba)
"(Apple) (MLS) 026 | Seattle vs. Austin"  -> hint=None   (now: usa.1)
```

A stream with no hint is scored against **every** league its group subscribes to — that is the opening cross-league false positives need. An `(MLB)`-tagged stream should never reach an MLS event in the first place.

## Fix

`detect_league_hint()` retries once on a de-bracketed copy when raw-text detection finds nothing. Raw text goes first, so user-defined hint patterns containing literal brackets keep priority (covered by a test).

Swept over the test-corpus stream names plus SD/HD/4K/(P)/(A)/(S) quality tags: only the intended detections change, no new false positives. Gender narrowing still works through brackets (`(NCAAB) (W)` -> womens-college-basketball) since `_narrow_by_gender` reads the original name.

## Tests

- `tests/matching/test_bracketed_league_hint.py` (new, 13 cases): bracketed detection, quality-tag non-detection, umbrella + gender narrowing, raw-text priority.
- `tests/matching/test_shared_nickname_crosstalk.py`: adds the reported Seattle case — ESPN gives MLS teams a bare-city `short_name` ("Seattle" for the Sounders), so MLB/NFL Seattle streams scored 100 against the Sounders. Locks in that the #569 gate covers same-city crosstalk, not just same-nickname.

Full suite: 2243 passed. ruff clean.

Issue: #580