### PR TITLE
fix(tsdb): handle local dates across UTC boundaries

### DIFF
--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1460,7 +1460,7 @@ INSERT OR IGNORE INTO cache_meta (id) VALUES (1);
 -- =============================================================================
 
 CREATE TABLE IF NOT EXISTS service_cache (
-    -- Cache key (e.g., "events:nfl:2026-01-06")
+    -- Cache key (e.g., "events_v2:nfl:2026-01-06")
     cache_key TEXT PRIMARY KEY,
 
     -- Cached data (JSON serialized)

--- a/teamarr/providers/tsdb/provider.py
+++ b/teamarr/providers/tsdb/provider.py
@@ -134,9 +134,11 @@ class TSDBProvider(SportsProvider):
         if data and data.get("events"):
             events = []
             for event_data in data["events"]:
-                # Filter to target date
-                event_date = event_data.get("dateEvent")
-                if event_date != date_str:
+                # TSDB's canonical date is UTC for some events, while
+                # dateEventLocal is the venue-local calendar date.  Accept
+                # either so events crossing midnight UTC remain discoverable
+                # from the date users see on the schedule.
+                if not self._event_matches_date(event_data, date_str):
                     continue
                 event = self._parse_event(event_data, league)
                 if event:
@@ -153,9 +155,7 @@ class TSDBProvider(SportsProvider):
         if data and data.get("events"):
             events = []
             for event_data in data["events"]:
-                # Filter to target date
-                event_date = event_data.get("dateEvent")
-                if event_date != date_str:
+                if not self._event_matches_date(event_data, date_str):
                     continue
                 event = self._parse_event(event_data, league)
                 if event:
@@ -304,7 +304,7 @@ class TSDBProvider(SportsProvider):
             team_events = []
             for event_data in data["events"]:
                 # Filter by date and team
-                if event_data.get("dateEvent") != date_str:
+                if not self._event_matches_date(event_data, date_str):
                     continue
                 event = self._parse_event(event_data, league)
                 if event and self._team_in_event(team_name, event):
@@ -316,6 +316,20 @@ class TSDBProvider(SportsProvider):
     def _team_in_event(self, team_name: str, event: Event) -> bool:
         """Check if team is playing in this event."""
         return team_name in (event.home_team.name, event.away_team.name)
+
+    @staticmethod
+    def _event_matches_date(event_data: dict, date_str: str) -> bool:
+        """Return whether either TSDB calendar date matches ``date_str``.
+
+        ``dateEvent`` is retained as the primary/legacy field.  Some TSDB
+        records additionally expose ``dateEventLocal`` for the venue-local
+        date, which can differ when an event crosses a UTC date boundary.
+        Missing local dates therefore preserve the previous behavior.
+        """
+        return date_str in (
+            event_data.get("dateEvent"),
+            event_data.get("dateEventLocal"),
+        )
 
     def _get_team_name(self, team_id: str, league: str) -> str | None:
         """Get team name from ID using injected resolver.

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -274,7 +274,10 @@ class SportsDataService:
         Returns:
             List of events (may be empty if cache_only and not cached)
         """
-        cache_key = make_cache_key("events", league, target_date.isoformat())
+        # v2 invalidates persisted empty results produced before TSDB's
+        # dateEventLocal boundary handling. Keep the version at this seam so
+        # stale entries cannot mask newly discoverable events after upgrade.
+        cache_key = make_cache_key("events_v2", league, target_date.isoformat())
 
         def load_from_cache() -> list[Event] | _CacheMiss:
             """Return cached events, or _CACHE_MISS if absent/stale/corrupt."""

--- a/tests/matching/test_event_card_fuzzy_match.py
+++ b/tests/matching/test_event_card_fuzzy_match.py
@@ -7,12 +7,15 @@ strategies 1 (event number) and 2 (fighter names) are skipped and strategy 3 is
 exercised in isolation; it only reads ``event.name``, so stand-in events suffice.
 """
 
-from datetime import date
+from datetime import UTC, date, datetime
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
+from teamarr.consumers.matching.classifier import StreamCategory, classify_stream
 from teamarr.consumers.matching.event_matcher import EventCardMatcher, EventMatchContext
 from teamarr.consumers.matching.result import MatchMethod
+from teamarr.core import Event, EventStatus, Team
 
 
 def _ctx(stream_name: str) -> EventMatchContext:
@@ -47,3 +50,63 @@ def test_generic_stream_does_not_fuzzy_match():
     events = [SimpleNamespace(name="UFC 300: Pereira vs Hill")]
     outcome = matcher._match_to_event_card(ctx, events, "ufc")
     assert not outcome.is_matched
+
+
+def test_boxing_stream_matches_boundary_event_by_fighter_names():
+    """A locally-Aug-22 card fetched from TSDB reaches the real matcher."""
+    fighter1 = Team(
+        id="2528767_1",
+        provider="tsdb",
+        name="Rolando Romero",
+        short_name="R. Romero",
+        abbreviation="ROMERO",
+        league="boxing",
+        sport="boxing",
+    )
+    fighter2 = Team(
+        id="2528767_2",
+        provider="tsdb",
+        name="Teofimo Lopez",
+        short_name="T. Lopez",
+        abbreviation="LOPEZ",
+        league="boxing",
+        sport="boxing",
+    )
+    event = Event(
+        id="2528767",
+        provider="tsdb",
+        name="Rolando Romero vs Teofimo Lopez",
+        short_name="LOPEZ vs ROMERO",
+        start_time=datetime(2026, 8, 23, 1, tzinfo=UTC),
+        home_team=fighter1,
+        away_team=fighter2,
+        status=EventStatus(state="scheduled"),
+        league="boxing",
+        sport="boxing",
+    )
+    service = MagicMock()
+    service.get_provider_name.return_value = "tsdb"
+    service.get_events.return_value = [event]
+    cache = MagicMock()
+    cache.get.return_value = None
+    classified = classify_stream(
+        "LIVE EVENT 02 - 6/8pm Rolly v Teofimo",
+        league_event_type="event_card",
+        event_league_sport="boxing",
+    )
+    assert classified.category is StreamCategory.EVENT_CARD
+
+    outcome = EventCardMatcher(service, cache).match(
+        classified=classified,
+        league="boxing",
+        target_date=date(2026, 8, 22),
+        group_id=1,
+        stream_id=2,
+        generation=1,
+        user_tz=ZoneInfo("America/New_York"),
+    )
+
+    assert outcome.is_matched
+    assert outcome.event is event
+    assert outcome.match_method is MatchMethod.FUZZY
+    service.get_events.assert_called_once_with("boxing", date(2026, 8, 22), cache_only=True)

--- a/tests/providers/test_tsdb.py
+++ b/tests/providers/test_tsdb.py
@@ -10,6 +10,8 @@ import threading
 from datetime import date
 from unittest.mock import MagicMock
 
+import pytest
+
 from teamarr.consumers.cache.refresh import CacheRefresher
 from teamarr.providers.registry import ProviderConfig, ProviderRegistry
 from teamarr.providers.tsdb.provider import TSDBProvider
@@ -203,6 +205,71 @@ def test_fallback_league_uses_season_endpoint():
 def test_unrivaled_is_gated():
     assert "unrivaled" in TSDBProvider.SEASON_FALLBACK_LEAGUES
     assert "cfl" not in TSDBProvider.SEASON_FALLBACK_LEAGUES
+
+
+# ===========================================================================
+# UTC/local date-boundary filtering
+# ===========================================================================
+
+
+def _boxing_event(date_event: str, date_event_local: str | None) -> dict:
+    return {
+        "idEvent": "2528767",
+        "strEvent": "Rolando Romero vs Teofimo Lopez",
+        "dateEvent": date_event,
+        "dateEventLocal": date_event_local,
+        "strTimestamp": "2026-08-23T01:00:00",
+        "strTime": "01:00:00",
+        "strStatus": "Not Started",
+    }
+
+
+@pytest.mark.parametrize(
+    ("date_event", "date_event_local", "included"),
+    [
+        ("2026-08-22", None, True),
+        ("2026-08-23", "2026-08-22", True),
+        ("2026-08-23", "2026-08-23", False),
+    ],
+)
+def test_next_events_accept_utc_or_local_calendar_date(date_event, date_event_local, included):
+    client = MagicMock()
+    client.get_sport.return_value = "boxing"
+    client.get_events_by_date.return_value = {"events": []}
+    client.get_league_next_events.return_value = {
+        "events": [_boxing_event(date_event, date_event_local)]
+    }
+    provider = TSDBProvider(client=client)
+
+    events = provider.get_events("boxing", date(2026, 8, 22))
+
+    assert bool(events) is included
+
+
+def test_season_fallback_accepts_local_calendar_date():
+    provider, client = _provider_with_empty_day_endpoints()
+    client.get_sport.return_value = "basketball"
+    client.get_events_by_season.return_value = {
+        "events": [_boxing_event("2026-08-23", "2026-08-22")]
+    }
+
+    events = provider.get_events("unrivaled", date(2026, 8, 22))
+
+    assert [event.id for event in events] == ["2528767"]
+
+
+def test_boxing_boundary_event_retains_utc_timestamp():
+    client = MagicMock()
+    client.get_sport.return_value = "boxing"
+    client.get_events_by_date.return_value = {"events": []}
+    client.get_league_next_events.return_value = {
+        "events": [_boxing_event("2026-08-23", "2026-08-22")]
+    }
+    provider = TSDBProvider(client=client)
+
+    event = provider.get_events("boxing", date(2026, 8, 22))[0]
+
+    assert event.start_time.isoformat() == "2026-08-23T01:00:00+00:00"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- accept a TSDB event when either `dateEvent` or `dateEventLocal` matches the requested calendar date
- apply the shared date check to next-event, season, and team-schedule fallbacks
- preserve the original TSDB timestamp and existing behavior when `dateEventLocal` is absent
- version the persisted event-cache namespace so pre-fix empty results cannot mask newly discoverable events after upgrade
- cover the UTC/local boundary through the real Boxing event-card classifier and matcher

No fighter-specific keywords or time corrections are introduced.

Fixes #588

## Testing

- `pytest -q` — 2252 passed
- `ruff check teamarr/providers/tsdb/provider.py teamarr/services/sports_data.py tests/providers/test_tsdb.py tests/matching/test_event_card_fuzzy_match.py`
