### PR TITLE
refactor: decide event date membership once, at the service seam

### DIFF
--- a/docs/reference/architecture/consumer-layer.md
+++ b/docs/reference/architecture/consumer-layer.md
@@ -191,6 +191,7 @@ For EPG-matched linear streams, membership in a channel is **time-windowed** so 
 - `PersistentTTLCache` — in-memory during generation (fast), background flush to SQLite every 2 minutes
 - Provider selection by priority (ESPN → MLB Stats → HockeyTech → TSDB)
 - TTLs: 30 days for final events, 8h for schedules, 30m for live events, 24h for team info
+- **Date membership is decided at this seam** (#590): a requested date is the *user-local* day, converted once to a UTC window (`utilities/event_dates.py`) and applied to everything providers return. Providers only prefilter to a ±1-day raw superset — they never compare calendars themselves, so provider/UTC/venue date mismatches (UFC cards and race weekends spanning midnight, AFL's UTC+10 schedule, TSDB's UTC event dates) can't drop events. Event caches are keyed per user timezone (`events_v2:<league>:<date>:<tz>`).
 
 | Method | TTL | Description |
 |--------|-----|-------------|

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1460,7 +1460,7 @@ INSERT OR IGNORE INTO cache_meta (id) VALUES (1);
 -- =============================================================================
 
 CREATE TABLE IF NOT EXISTS service_cache (
-    -- Cache key (e.g., "events:nfl:2026-01-06")
+    -- Cache key (e.g., "events_v2:nfl:2026-01-06:America/Detroit")
     cache_key TEXT PRIMARY KEY,
 
     -- Cached data (JSON serialized)

--- a/teamarr/providers/bellmedia/provider.py
+++ b/teamarr/providers/bellmedia/provider.py
@@ -42,10 +42,13 @@ class BellMediaProvider(SportsProvider):
         if not self.supports_league(league):
             return []
         teams = self._teams_by_id(league)
+        # ±1-day superset — the API's `date` field is its own calendar, not
+        # the user's; exact membership is the service seam's job (#590).
         return [
             event
-            for row in self._client.get_events_between(league, target_date, target_date)
-            if row.get("date") == target_date.isoformat()
+            for row in self._client.get_events_between(
+                league, target_date - timedelta(days=1), target_date + timedelta(days=1)
+            )
             if (event := self._parse_event(row, league, teams)) is not None
         ]
 

--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -30,7 +30,6 @@ from teamarr.providers.espn.tennis import TennisParserMixin
 from teamarr.providers.espn.tournament import TournamentParserMixin
 from teamarr.providers.espn.ufc import UFCParserMixin
 from teamarr.utilities.event_status import is_event_final
-from teamarr.utilities.tz import to_user_tz
 
 logger = logging.getLogger(__name__)
 
@@ -195,11 +194,11 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
             data = self._client.get_ufc_scoreboard(window)
             if not data:
                 return []
-            # Mixin handles: pure parsing only
-            events = self._parse_ufc_events(data)
-            # Provider handles: date filtering — keep cards with ANY segment
-            # touching target_date, not just those starting on it.
-            return [e for e in events if self._ufc_card_covers_date(e, target_date)]
+            # Mixin handles: pure parsing only. The ±1-day fetch window IS the
+            # superset; segment-aware date membership (a card touching two
+            # days belongs to both, #345) is decided by the user-day window
+            # at the service seam (#590).
+            return self._parse_ufc_events(data)
 
         # Get sport/league from database config
         sport_league = self._get_sport_league_from_db(league)
@@ -210,23 +209,6 @@ class ESPNProvider(UFCParserMixin, TennisParserMixin, TournamentParserMixin, Spo
             return self._get_tournament_events(league, target_date, sport, sport_league)
 
         return self._get_scoreboard_events(league, target_date, sport_league)
-
-    @staticmethod
-    def _ufc_card_covers_date(event: Event, target_date: date) -> bool:
-        """True when any part of the card falls on target_date in user tz.
-
-        A PPV rolls past midnight: early prelims Saturday, main card early
-        Sunday (user tz). Filtering on start_time alone drops the card for
-        one of the days its segments span (#345).
-        """
-        times = list(event.segment_times.values())
-        if not times and event.start_time:
-            times = [event.start_time]
-        if not times:
-            return False
-        first = min(times)
-        last = max(times) + timedelta(hours=3)  # last segment runs ~3h
-        return to_user_tz(first).date() <= target_date <= to_user_tz(last).date()
 
     def _get_scoreboard_events(
         self,

--- a/teamarr/providers/hockeytech/client.py
+++ b/teamarr/providers/hockeytech/client.py
@@ -11,7 +11,7 @@ API keys are constants since they're public keys from official league websites.
 """
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 
 from teamarr.core.interfaces import LeagueMappingSource
 from teamarr.providers.base_client import BaseHTTPClient
@@ -221,9 +221,13 @@ class HockeyTechClient(BaseHTTPClient):
             List of game dicts for that date
         """
         schedule = self.get_schedule(league)
-        date_str = target_date.strftime("%Y-%m-%d")
-
-        return [game for game in schedule if game.get("date_played") == date_str]
+        # ±1-day superset — `date_played` is the venue's calendar, not the
+        # user's; exact membership is the service seam's job (#590).
+        near = {
+            (target_date + timedelta(days=offset)).strftime("%Y-%m-%d")
+            for offset in (-1, 0, 1)
+        }
+        return [game for game in schedule if game.get("date_played") in near]
 
     def get_seasons_info(self, league: str) -> dict[str, dict]:
         """Get season metadata keyed by season_id.

--- a/teamarr/providers/nascar/provider.py
+++ b/teamarr/providers/nascar/provider.py
@@ -116,9 +116,11 @@ class NASCARProvider(SportsProvider):
         if not self.supports_league(league):
             return []
         self._ensure_loaded()
+        # ±1-day superset by UTC session date; exact membership is decided by
+        # the user-day window at the service seam (#590).
         return [
             e for e in self._events_by_league.get(league, [])
-            if any(s.start_time.date() == target_date for s in e.sessions)
+            if any(abs((s.start_time.date() - target_date).days) <= 1 for s in e.sessions)
         ]
 
     def get_team_schedule(self, team_id: str, league: str, days_ahead: int = 14) -> list[Event]:

--- a/teamarr/providers/squiggle/provider.py
+++ b/teamarr/providers/squiggle/provider.py
@@ -63,7 +63,7 @@ class SquiggleProvider(SportsProvider):
 
         events: list[Event] = []
         for game in games:
-            if not self._game_on_date(game, target_date):
+            if not self._game_near_date(game, target_date):
                 continue
             event = self._parse_game(game, league, teams_by_id)
             if event:
@@ -187,12 +187,17 @@ class SquiggleProvider(SportsProvider):
         except Exception:
             return None
 
-    def _game_on_date(self, game: dict, target_date: date) -> bool:
-        """Check whether a game falls on target_date (in UTC)."""
+    def _game_near_date(self, game: dict, target_date: date) -> bool:
+        """±1-day superset gate, compared in UTC (#590).
+
+        AFL runs at UTC+8..+11, so a game's UTC date routinely differs from
+        the date the user sees. Exact membership is decided by the user-day
+        window at the service seam; this only bounds how much gets parsed.
+        """
         dt = self._game_date(game)
         if dt is None:
             return False
-        return dt.date() == target_date
+        return abs((dt.date() - target_date).days) <= 1
 
     @staticmethod
     def _parse_status(game: dict) -> EventStatus:

--- a/teamarr/providers/supabase/client.py
+++ b/teamarr/providers/supabase/client.py
@@ -486,10 +486,15 @@ class SupabaseLeagueClient(BaseHTTPClient):
     def get_events_by_date(self, league: str, target_date: date) -> list[dict]:
         """Get schedule entries for a specific date, merged with scores."""
         schedule = self.get_schedule(league)
-        date_str = target_date.strftime("%Y-%m-%d")
+        # ±1-day superset — `game_date_override` is the league's calendar,
+        # not the user's; exact membership is the service seam's job (#590).
+        near = {
+            (target_date + timedelta(days=offset)).strftime("%Y-%m-%d")
+            for offset in (-1, 0, 1)
+        }
         day_entries = [
             g for g in schedule
-            if g.get("game_date_override") == date_str
+            if g.get("game_date_override") in near
             and g.get("status") != "postponed"
         ]
         if not day_entries:

--- a/teamarr/providers/tsdb/provider.py
+++ b/teamarr/providers/tsdb/provider.py
@@ -32,6 +32,30 @@ _VS_SEPARATORS = (" vs. ", " vs ", " v ")
 TeamNameResolver = Callable[[str, str], str | None]
 
 
+def _nearby_dates(target_date: date) -> set[date]:
+    """target_date ±1 day — the raw-prefilter superset window (#590)."""
+    return {target_date + timedelta(days=offset) for offset in (-1, 0, 1)}
+
+
+def _nearby_date_strs(target_date: date) -> set[str]:
+    """ISO strings of :func:`_nearby_dates`, for raw-field comparison."""
+    return {d.isoformat() for d in _nearby_dates(target_date)}
+
+
+def _event_near_date(event_data: dict, near_strs: set[str]) -> bool:
+    """Whether a raw TSDB row is plausibly on the target day (#588/#590).
+
+    ``dateEvent`` is the UTC calendar date; ``dateEventLocal``, when present,
+    is the venue-local one — they differ across UTC midnight. This is only a
+    cheap SUPERSET gate (so full-season lists aren't parsed wholesale); exact
+    membership is decided by the user-day window at the service seam.
+    """
+    return (
+        event_data.get("dateEvent") in near_strs
+        or event_data.get("dateEventLocal") in near_strs
+    )
+
+
 class TSDBProvider(SportsProvider):
     """TheSportsDB implementation of SportsProvider.
 
@@ -111,10 +135,11 @@ class TSDBProvider(SportsProvider):
            SEASON_FALLBACK_LEAGUES (sparse leagues like Unrivaled)
         """
         if self._client.get_sport(league) == "racing":
+            near = _nearby_dates(target_date)
             return [
                 event
                 for event in self._get_racing_events(league)
-                if any(s.start_time.date() == target_date for s in event.sessions)
+                if any(s.start_time.date() in near for s in event.sessions)
             ]
 
         date_str = target_date.strftime("%Y-%m-%d")
@@ -129,14 +154,13 @@ class TSDBProvider(SportsProvider):
                     events.append(event)
             return events
 
-        # Fall back to next league events, filter by date
+        # Fall back to next league events, prefiltered to a ±1-day superset
+        near_strs = _nearby_date_strs(target_date)
         data = self._client.get_league_next_events(league)
         if data and data.get("events"):
             events = []
             for event_data in data["events"]:
-                # Filter to target date
-                event_date = event_data.get("dateEvent")
-                if event_date != date_str:
+                if not _event_near_date(event_data, near_strs):
                     continue
                 event = self._parse_event(event_data, league)
                 if event:
@@ -144,7 +168,7 @@ class TSDBProvider(SportsProvider):
             if events:
                 return events
 
-        # Final fallback: full-season fetch, filtered by date. Gated to sparse
+        # Final fallback: full-season fetch, prefiltered by date. Gated to sparse
         # leagues (Unrivaled) so ordinary leagues with empty dates don't fire a
         # per-date fetch (GH #217).
         if league not in self.SEASON_FALLBACK_LEAGUES:
@@ -153,9 +177,7 @@ class TSDBProvider(SportsProvider):
         if data and data.get("events"):
             events = []
             for event_data in data["events"]:
-                # Filter to target date
-                event_date = event_data.get("dateEvent")
-                if event_date != date_str:
+                if not _event_near_date(event_data, near_strs):
                     continue
                 event = self._parse_event(event_data, league)
                 if event:
@@ -301,10 +323,11 @@ class TSDBProvider(SportsProvider):
             return []
         data = self._client.get_events_by_season(league)
         if data and data.get("events"):
+            near_strs = _nearby_date_strs(target_date)
             team_events = []
             for event_data in data["events"]:
-                # Filter by date and team
-                if event_data.get("dateEvent") != date_str:
+                # ±1-day superset by date, exact by team
+                if not _event_near_date(event_data, near_strs):
                     continue
                 event = self._parse_event(event_data, league)
                 if event and self._team_in_event(team_name, event):

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -39,7 +39,9 @@ from teamarr.utilities.cache import (
     get_events_cache_ttl,
     make_cache_key,
 )
+from teamarr.utilities.event_dates import event_intersects, user_day_window
 from teamarr.utilities.event_status import is_event_final
+from teamarr.utilities.tz import get_user_timezone
 
 logger = logging.getLogger(__name__)
 
@@ -274,7 +276,13 @@ class SportsDataService:
         Returns:
             List of events (may be empty if cache_only and not cached)
         """
-        cache_key = make_cache_key("events", league, target_date.isoformat())
+        # v2 (#590): results are filtered to the user-local day window below,
+        # so the cache entry's meaning depends on the user's timezone — key it
+        # by tz and version the namespace so pre-#590 entries (filtered by
+        # provider calendars) can't mask newly discoverable events.
+        cache_key = make_cache_key(
+            "events_v2", league, target_date.isoformat(), str(get_user_timezone())
+        )
 
         def load_from_cache() -> list[Event] | _CacheMiss:
             """Return cached events, or _CACHE_MISS if absent/stale/corrupt."""
@@ -317,7 +325,16 @@ class SportsDataService:
             # Iterate through providers
             for provider in self._providers:
                 if provider.supports_league(league):
-                    events = provider.get_events(league, target_date)
+                    # THE date-membership seam (#590): providers return a
+                    # superset (their raw prefilters are ±1 day wide); the
+                    # user-local day window decides what "on target_date"
+                    # means, exactly once, for every provider.
+                    window = user_day_window(target_date)
+                    events = [
+                        e
+                        for e in provider.get_events(league, target_date)
+                        if event_intersects(e, window)
+                    ]
                     # Check if all events are final (for past dates, enables 30-day
                     # cache). Empty list counts as "all final" (nothing to update).
                     all_final = len(events) == 0 or all(is_event_final(e) for e in events)

--- a/teamarr/utilities/event_dates.py
+++ b/teamarr/utilities/event_dates.py
@@ -1,0 +1,76 @@
+"""User-day windows and event/window intersection (#590).
+
+Calendar dates must not cross the provider boundary. A requested
+``target_date`` is a **user-local** calendar day; providers, however, receive
+dates from APIs bucketed by *someone else's* calendar (UTC, the venue, the
+API's home region). Comparing those calendars directly is the bug class
+behind #345 and #588.
+
+The structure that ends it:
+
+- :func:`user_day_window` converts the user-local day to a UTC interval —
+  the ONLY place the user's timezone is consulted for date membership.
+- :func:`event_intersects` decides membership with pure instant arithmetic —
+  no timezone code at all.
+- The service layer (``sports_data.get_events``) applies the filter to
+  everything providers return, so providers only need to OVER-return
+  (±1-day raw supersets); they never decide date membership themselves.
+"""
+
+from datetime import UTC, date, datetime, time, timedelta
+
+from teamarr.core import Event
+from teamarr.utilities.tz import get_user_timezone
+
+# How long an event plausibly runs past its last known start time, so a
+# late start spills into the day it crosses into (a 23:00 game belongs to
+# both days). Matches the tail previously hardcoded in ESPN's UFC coverage
+# filter (#345), which this module supersedes.
+EVENT_TAIL_HOURS = 3.0
+
+
+def user_day_window(target_date: date) -> tuple[datetime, datetime]:
+    """The UTC half-open interval [start, end) of ``target_date`` in user tz.
+
+    DST-safe: a 23- or 25-hour local day yields exactly that window.
+    """
+    tz = get_user_timezone()
+    start = datetime.combine(target_date, time.min, tzinfo=tz)
+    end = datetime.combine(target_date + timedelta(days=1), time.min, tzinfo=tz)
+    return start.astimezone(UTC), end.astimezone(UTC)
+
+
+def event_times(event: Event) -> list[datetime]:
+    """Every known instant of an event: segment starts, session starts, start.
+
+    Naive datetimes are treated as UTC (providers hand us aware UTC; naive
+    only appears in legacy paths and tests).
+    """
+    times: list[datetime] = []
+    for t in (getattr(event, "segment_times", None) or {}).values():
+        if t is not None:
+            times.append(t)
+    for session in getattr(event, "sessions", None) or []:
+        if session.start_time is not None:
+            times.append(session.start_time)
+    if event.start_time is not None:
+        times.append(event.start_time)
+    return [t if t.tzinfo is not None else t.replace(tzinfo=UTC) for t in times]
+
+
+def event_intersects(event: Event, window: tuple[datetime, datetime]) -> bool:
+    """Whether the event's plausible broadcast span touches ``window``.
+
+    The span runs from the earliest known instant to the latest known
+    instant plus :data:`EVENT_TAIL_HOURS`. Events with no known times can't
+    be placed on any day and are excluded.
+    """
+    times = event_times(event)
+    if not times:
+        return False
+    first = min(times)
+    last = max(times) + timedelta(hours=EVENT_TAIL_HOURS)
+    start, end = window
+    # Strict on both edges: a span that only touches a boundary instant
+    # (e.g. a tail ending exactly at midnight) has zero overlap with the day.
+    return first < end and last > start

--- a/tests/providers/test_bellmedia.py
+++ b/tests/providers/test_bellmedia.py
@@ -123,11 +123,16 @@ def test_scheduled_event_hides_scores():
     assert event.away_score is None
 
 
-def test_get_events_filters_to_requested_date():
-    rows = [_event(event_date="2026-08-13"), _event(event_id=2, event_date="2026-08-14")]
+def test_get_events_returns_superset_window():
+    """±1-day superset (#590): exact membership is the service seam's job."""
+    rows = [
+        _event(event_date="2026-08-13"),
+        _event(event_id=2, event_date="2026-08-14"),
+        _event(event_id=3, event_date="2026-08-16"),
+    ]
     events = _provider(rows).get_events("cfl", date(2026, 8, 13))
 
-    assert [event.id for event in events] == ["13419712"]
+    assert [event.id for event in events] == ["13419712", "2"]
 
 
 def test_team_schedule_filters_and_sorts(monkeypatch):

--- a/tests/providers/test_nascar_provider.py
+++ b/tests/providers/test_nascar_provider.py
@@ -251,9 +251,16 @@ def test_get_events_race_day():
     assert events[0].name == "DAYTONA 500"
 
 
+def test_get_events_adjacent_day_in_superset():
+    """±1-day superset (#590): the seam decides exact membership."""
+    p = _provider_with_data(cup=_CUP_RESPONSE)
+    events = p.get_events("nascar-cup", date(2026, 2, 10))  # day before practice
+    assert len(events) == 1
+
+
 def test_get_events_off_day_returns_empty():
     p = _provider_with_data(cup=_CUP_RESPONSE)
-    events = p.get_events("nascar-cup", date(2026, 2, 10))  # day before any session
+    events = p.get_events("nascar-cup", date(2026, 2, 9))  # ≥2 days before any session
     assert events == []
 
 

--- a/tests/providers/test_squiggle.py
+++ b/tests/providers/test_squiggle.py
@@ -183,12 +183,14 @@ def test_parse_game_without_unixtime_returns_none():
 # ---------------------------------------------------------------------------
 
 
-def test_get_events_filters_by_utc_date():
+def test_get_events_prefilters_to_superset_window():
+    """±1-day superset by UTC date (#590); the seam decides exact membership."""
     target = date(2026, 7, 10)
     on_date = _game(gid=1, when=datetime(2026, 7, 10, 23, 0, tzinfo=UTC))
-    off_date = _game(gid=2, when=datetime(2026, 7, 11, 1, 0, tzinfo=UTC))
-    events = _provider(games=[on_date, off_date]).get_events("afl", target)
-    assert [e.id for e in events] == ["1"]
+    next_day = _game(gid=2, when=datetime(2026, 7, 11, 1, 0, tzinfo=UTC))
+    far_off = _game(gid=3, when=datetime(2026, 7, 13, 1, 0, tzinfo=UTC))
+    events = _provider(games=[on_date, next_day, far_off]).get_events("afl", target)
+    assert [e.id for e in events] == ["1", "2"]
 
 
 def test_get_events_unsupported_league_returns_empty():

--- a/tests/providers/test_ufc_date_fetch.py
+++ b/tests/providers/test_ufc_date_fetch.py
@@ -1,15 +1,15 @@
-"""UFC event fetch must be date-aware (#345).
+"""UFC event fetch must be date-aware (#345, #590).
 
 ESPN's default MMA scoreboard returns ONLY the current featured card, so
 get_events("ufc", <any other card's date>) came back empty and those streams
-failed with no_event_card_match. The fix passes a ±1-day dates= window and
-filters by card coverage (any segment touching target_date), which also
-handles PPVs rolling past midnight.
+failed with no_event_card_match. The fix passes a ±1-day dates= window.
+
+Since #590 the provider returns everything in that window as a SUPERSET —
+segment-aware day membership (a PPV rolling past midnight belongs to both
+days) is decided by the user-day window at the service seam, not here.
 """
 
 from datetime import date
-
-import pytest
 
 from teamarr.providers.espn.provider import ESPNProvider
 
@@ -45,14 +45,6 @@ class CapturingClient:
         return self.payload
 
 
-@pytest.fixture(autouse=True)
-def _utc_user_tz(monkeypatch):
-    """Pin to_user_tz to identity so assertions are TZ-independent."""
-    monkeypatch.setattr(
-        "teamarr.providers.espn.provider.to_user_tz", lambda dt: dt
-    )
-
-
 def test_ufc_fetch_passes_date_window():
     client = CapturingClient({"events": []})
     provider = ESPNProvider(client=client)
@@ -80,35 +72,25 @@ def test_future_card_visible_on_its_date():
     assert [e.id for e in events] == ["401"]
 
 
-def test_midnight_spanning_ppv_covers_both_days():
-    # PPV: early prelims 23:00 Aug 8, prelims 00:30 Aug 9, main card 02:00 Aug 9
+def test_windowed_cards_pass_through_as_superset():
+    """Everything ESPN returns for the ±1-day window comes back (#590).
+
+    The neighbouring card is no longer dropped here — exact day membership
+    (including midnight-spanning PPV coverage) is the service seam's job,
+    pinned in tests/services/test_event_date_seam.py.
+    """
     payload = {
         "events": [
+            _card("403", "UFC on ABC", ["2026-08-07T18:00Z"]),
             _card(
                 "402",
                 "UFC 330: Someone vs Someone Else",
                 ["2026-08-08T23:00Z", "2026-08-09T00:30Z", "2026-08-09T02:00Z"],
-            )
-        ]
-    }
-    provider = ESPNProvider(client=CapturingClient(payload))
-
-    assert [e.id for e in provider.get_events("ufc", date(2026, 8, 8))] == ["402"]
-    assert [e.id for e in provider.get_events("ufc", date(2026, 8, 9))] == ["402"]
-    # But not for an unrelated day
-    assert provider.get_events("ufc", date(2026, 8, 11)) == []
-
-
-def test_unrelated_card_filtered_out():
-    # ESPN may return neighbours inside the window — only covering cards pass.
-    payload = {
-        "events": [
-            _card("403", "UFC on ABC", ["2026-08-07T18:00Z"]),
-            _card("404", "UFC Fight Night", ["2026-08-08T18:00Z"]),
+            ),
         ]
     }
     provider = ESPNProvider(client=CapturingClient(payload))
 
     events = provider.get_events("ufc", date(2026, 8, 8))
 
-    assert [e.id for e in events] == ["404"]
+    assert [e.id for e in events] == ["403", "402"]

--- a/tests/services/test_event_date_seam.py
+++ b/tests/services/test_event_date_seam.py
@@ -1,0 +1,201 @@
+"""Date membership is decided ONCE, at the service seam (#590).
+
+Providers return ±1-day supersets; `sports_data.get_events` filters them
+through the user-local day window. These tests pin:
+
+- `user_day_window`: user-tz day → UTC interval, DST-safe
+- `event_intersects`: pure instant math over sessions/segments/start + tail
+- the seam itself: superset in, exact user-day slate out, filtered result
+  cached (the #588 boxing case end-to-end)
+"""
+
+import contextlib
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from teamarr.core import Event, EventStatus, RacingSession, Team
+from teamarr.services.sports_data import SportsDataService
+from teamarr.utilities.event_dates import event_intersects, user_day_window
+
+NY = ZoneInfo("America/New_York")
+
+
+@pytest.fixture(autouse=True)
+def _ny_user(monkeypatch):
+    monkeypatch.setattr("teamarr.utilities.tz.get_user_timezone", lambda: NY)
+
+
+def _team(name: str) -> Team:
+    return Team(
+        id=name.lower(),
+        provider="tsdb",
+        name=name,
+        short_name=name,
+        abbreviation=name[:3].upper(),
+        league="boxing",
+        sport="boxing",
+    )
+
+
+def _event(event_id: str, start: datetime, **kwargs) -> Event:
+    return Event(
+        id=event_id,
+        provider="tsdb",
+        name=f"Event {event_id}",
+        short_name=f"E{event_id}",
+        start_time=start,
+        home_team=_team("Romero"),
+        away_team=_team("Lopez"),
+        status=EventStatus(state="scheduled"),
+        league="boxing",
+        sport="boxing",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# user_day_window
+# ---------------------------------------------------------------------------
+
+
+def test_day_window_is_user_local():
+    start, end = user_day_window(date(2026, 8, 22))
+    assert start == datetime(2026, 8, 22, 4, 0, tzinfo=UTC)  # EDT = UTC-4
+    assert end == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)
+
+
+def test_day_window_handles_dst():
+    # US spring-forward 2026-03-08: a 23-hour day
+    start, end = user_day_window(date(2026, 3, 8))
+    assert end - start == timedelta(hours=23)
+    # US fall-back 2026-11-01: a 25-hour day
+    start, end = user_day_window(date(2026, 11, 1))
+    assert end - start == timedelta(hours=25)
+
+
+# ---------------------------------------------------------------------------
+# event_intersects
+# ---------------------------------------------------------------------------
+
+
+def test_utc_boundary_event_belongs_to_user_day():
+    """The #588 case: Sat 9pm ET fight is Sunday in UTC — it's Saturday."""
+    fight = _event("2528767", datetime(2026, 8, 23, 1, 0, tzinfo=UTC))
+    assert event_intersects(fight, user_day_window(date(2026, 8, 22)))
+    assert not event_intersects(fight, user_day_window(date(2026, 8, 24)))
+
+
+def test_far_utc_event_is_not_on_user_day():
+    """Neither raw calendar matches the user's: Tokyo Sat morning card.
+
+    Sat 10:00 JST = Fri 01:00Z = THU 9pm ET — dateEvent (Fri) and
+    dateEventLocal (Sat) both miss the New York user's Thursday.
+    """
+    tokyo_card = _event("t1", datetime(2026, 8, 21, 1, 0, tzinfo=UTC))
+    assert event_intersects(tokyo_card, user_day_window(date(2026, 8, 20)))
+    assert not event_intersects(tokyo_card, user_day_window(date(2026, 8, 22)))
+
+
+def test_sessions_span_all_their_days():
+    """Race weekend: practice Friday, race Sunday — belongs to Fri, Sat, Sun."""
+    weekend = _event(
+        "5620",
+        datetime(2026, 8, 21, 22, 0, tzinfo=UTC),
+        sessions=[
+            RacingSession(
+                code="practice",
+                name="Practice",
+                start_time=datetime(2026, 8, 21, 22, 0, tzinfo=UTC),
+            ),
+            RacingSession(
+                code="race", name="Race", start_time=datetime(2026, 8, 23, 18, 30, tzinfo=UTC)
+            ),
+        ],
+    )
+    for day in (date(2026, 8, 21), date(2026, 8, 22), date(2026, 8, 23)):
+        assert event_intersects(weekend, user_day_window(day)), day
+    assert not event_intersects(weekend, user_day_window(date(2026, 8, 20)))
+
+
+def test_late_start_spills_into_next_day_via_tail():
+    """A 23:30 ET start still counts as (late) viewing on the next day."""
+    late_game = _event("lg", datetime(2026, 8, 23, 3, 30, tzinfo=UTC))  # 23:30 EDT Aug 22
+    assert event_intersects(late_game, user_day_window(date(2026, 8, 22)))
+    assert event_intersects(late_game, user_day_window(date(2026, 8, 23)))
+
+
+# ---------------------------------------------------------------------------
+# The seam in SportsDataService.get_events
+# ---------------------------------------------------------------------------
+
+
+class _FakeCache:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ttl=None):
+        self.store[key] = value
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+    @contextlib.contextmanager
+    def lock_key(self, key):
+        yield
+
+
+class _SupersetProvider:
+    """Provider honouring the #590 contract: over-returns, never filters."""
+
+    def __init__(self, events):
+        self.events = events
+
+    @property
+    def name(self):
+        return "fake"
+
+    def supports_league(self, league):
+        return True
+
+    def get_events(self, league, target_date):
+        return list(self.events)
+
+
+def _service(events) -> SportsDataService:
+    service = SportsDataService(providers=[])
+    service._cache = _FakeCache()
+    service.add_provider(_SupersetProvider(events))
+    return service
+
+
+def test_seam_filters_provider_superset_to_user_day():
+    saturday_fight = _event("sat", datetime(2026, 8, 23, 1, 0, tzinfo=UTC))  # Sat 9pm ET
+    sunday_fight = _event("sun", datetime(2026, 8, 23, 23, 0, tzinfo=UTC))  # Sun 7pm ET
+    service = _service([saturday_fight, sunday_fight])
+
+    assert [e.id for e in service.get_events("boxing", date(2026, 8, 22))] == ["sat"]
+    assert [e.id for e in service.get_events("boxing", date(2026, 8, 23))] == ["sun"]
+
+
+def test_seam_caches_the_filtered_slate():
+    saturday_fight = _event("sat", datetime(2026, 8, 23, 1, 0, tzinfo=UTC))
+    off_day = _event("off", datetime(2026, 8, 26, 1, 0, tzinfo=UTC))
+    service = _service([saturday_fight, off_day])
+
+    service.get_events("boxing", date(2026, 8, 22))
+
+    (cached,) = service._cache.store.values()
+    assert [e["id"] for e in cached] == ["sat"]
+
+
+def test_cache_key_carries_tz_and_namespace_version():
+    service = _service([])
+    service.get_events("boxing", date(2026, 8, 22))
+
+    (key,) = service._cache.store.keys()
+    assert key == "events_v2:boxing:2026-08-22:America/New_York"


### PR DESCRIPTION
## Summary

Fixes #590, fixes #588. Supersedes PR #589.

A requested `target_date` is the **user-local** calendar day, but every provider answered "is this event on that date?" against someone else's calendar — raw provider date strings or UTC `.date()`. That's the bug class behind #345 and #588, and an audit found it latent in six more sites (Squiggle/AFL, NASCAR + TSDB racing sessions, Bell Media, HockeyTech, Supabase).

Structure that ends it:

- **`utilities/event_dates.py`** — `user_day_window` converts the user day to a UTC interval (the *only* place user tz is consulted, DST-safe); `event_intersects` decides membership with pure instant math over sessions/segments/start + a 3h tail.
- **`sports_data.get_events` is the single enforcement point**: everything providers return is filtered through the window. Cache namespace bumps to `events_v2` and keys carry the user tz, so a timezone change can no longer poison per-date entries.
- **Provider contract weakens to "return a ±1-day raw superset"** — all nine client-side filter sites widened; ESPN's UFC coverage filter (#345) is subsumed by the seam. New providers are correct by construction.

Thanks @ncsufan8628 for the #588 report — the boxing boundary scenario is pinned as a regression test in `tests/services/test_event_date_seam.py`.

**Known open edge (documented in #590):** server-side day-bucketed fetches (ESPN scoreboard `?dates=`, MLB Stats) can under-return at day edges for users far from the API's home calendar; verified ESPN buckets by US-local date so US users are unaffected.

## Testing

- `pytest tests/` — 2,255 passed (new: seam suite incl. DST windows, Tokyo-card case neither raw date catches, race-weekend spans; provider tests updated to the superset contract)
- `ruff check` clean · frontend build green
