### PR TITLE
fix: anchor create threshold to session start for segmented channels

### DIFF
--- a/docs/guide/channels/lifecycle.md
+++ b/docs/guide/channels/lifecycle.md
@@ -20,6 +20,8 @@ Controls when event channels are created in and deleted from Dispatcharr.
 
 The **Pre-Event Buffer (hours)** field is greyed out until **Before event + buffer** is selected; it sets how many hours before the event to create the channel (0–336 hours, default 1).
 
+For session-based events (race weekends, UFC card segments), each session's channel is timed against that session's own start — the Sunday race channel appears on race day (or race start minus buffer), not when Friday practice enters the window.
+
 Channels are never created for events that are already over: final events are excluded (an API-only `include_final_events` setting can override this), an event not yet reported final is treated as final two hours after its estimated end, and an event already past its delete threshold is skipped entirely.
 
 ## Delete Timing

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -300,6 +300,7 @@ class ChannelCreator(_LifecycleHost):
                         decision = self._timing_manager.should_create_channel(
                             event,
                             stream_exists=True,
+                            segment_start=segment_start,
                         )
 
                         if not decision.should_act:

--- a/teamarr/consumers/lifecycle/timing.py
+++ b/teamarr/consumers/lifecycle/timing.py
@@ -186,18 +186,23 @@ class ChannelLifecycleManager:
         self,
         event: Event,
         stream_exists: bool = False,
+        segment_start: datetime | None = None,
     ) -> LifecycleDecision:
         """Determine if a channel should be created for this event.
 
         Args:
             event: The event to check
             stream_exists: Whether a matching stream currently exists
+            segment_start: Segment/session-specific start time (racing
+                sessions, UFC card segments). When given, the create
+                threshold anchors to it instead of `event.start_time`,
+                which for racing points at the weekend's FIRST session.
 
         Returns:
             LifecycleDecision with should_act and reason
         """
         # Calculate create threshold
-        create_threshold = self._calculate_create_threshold(event)
+        create_threshold = self._calculate_create_threshold(event, segment_start)
         now = now_user()
 
         # Check if we're past delete threshold (prevents create-then-delete)
@@ -282,13 +287,21 @@ class ChannelLifecycleManager:
             delete_threshold,
         )
 
-    def _calculate_create_threshold(self, event: Event) -> datetime:
+    def _calculate_create_threshold(
+        self, event: Event, segment_start: datetime | None = None
+    ) -> datetime:
         """Calculate when channel should be created.
 
         - same_day: Midnight (00:00) of event day
         - before_event: event_start - pre_buffer_minutes
+
+        Racing anchors `event.start_time` to the weekend's first session, so
+        per-session channels must derive their threshold from their own
+        session start (`segment_start`) or the race-day channel is created as
+        soon as Friday practice enters the window (#550). Mirrors the
+        session-aware delete side (`get_event_end_time`).
         """
-        event_start = to_user_tz(event.start_time)
+        event_start = to_user_tz(segment_start or event.start_time)
 
         if self.create_timing == "before_event":
             return event_start - timedelta(minutes=self.pre_buffer_minutes)

--- a/tests/lifecycle/test_racing_create_threshold.py
+++ b/tests/lifecycle/test_racing_create_threshold.py
@@ -1,0 +1,104 @@
+"""Create threshold must anchor to the session's own start time (#550).
+
+Racing anchors `event.start_time` to the weekend's FIRST broadcastable
+session (e.g. Friday practice), so once practice entered the pre-buffer
+window `should_create_channel` approved every session channel — the race-day
+channel appeared up to ~35h early with a 1440-minute pre-buffer.
+
+The delete side is already session-aware (`get_event_end_time`); these tests
+pin the create side's mirror: each session channel's threshold derives from
+its own `segment_start`, and callers passing no segment keep the old
+event-anchored behavior.
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from teamarr.consumers.lifecycle.timing import ChannelLifecycleManager
+from teamarr.core import Event, EventStatus, RacingSession, Team
+
+# NASCAR-style weekend: practice Friday evening, race Sunday afternoon.
+PRACTICE_START = datetime(2026, 8, 21, 22, 0, tzinfo=UTC)  # Fri
+QUALIFYING_START = datetime(2026, 8, 22, 21, 0, tzinfo=UTC)  # Sat
+RACE_START = datetime(2026, 8, 23, 18, 30, tzinfo=UTC)  # Sun
+
+
+def _race_weekend() -> Event:
+    team = Team(
+        id="5620_1",
+        provider="espn",
+        name="Field",
+        short_name="Field",
+        abbreviation="FLD",
+        league="nascar-cup",
+        sport="racing",
+    )
+    return Event(
+        id="5620",
+        provider="espn",
+        name="Iowa Corn 350",
+        short_name="Iowa Corn 350",
+        start_time=PRACTICE_START,  # provider anchors to first session
+        home_team=team,
+        away_team=team,
+        status=EventStatus(state="scheduled"),
+        league="nascar-cup",
+        sport="racing",
+        sessions=[
+            RacingSession(code="practice", name="Practice", start_time=PRACTICE_START),
+            RacingSession(code="qualifying", name="Qualifying", start_time=QUALIFYING_START),
+            RacingSession(code="race", name="Race", start_time=RACE_START),
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _utc_user(monkeypatch):
+    monkeypatch.setattr("teamarr.utilities.tz.get_user_timezone", lambda: ZoneInfo("UTC"))
+
+
+def _freeze_now(monkeypatch, now: datetime) -> None:
+    monkeypatch.setattr("teamarr.consumers.lifecycle.timing.now_user", lambda: now)
+
+
+def test_race_channel_waits_for_its_own_session_before_event(monkeypatch):
+    """1440-min pre-buffer + Friday practice must not create Sunday's race channel."""
+    manager = ChannelLifecycleManager(create_timing="before_event", pre_buffer_minutes=1440)
+    event = _race_weekend()
+    # Practice is inside its window; the race is still ~44h out.
+    _freeze_now(monkeypatch, datetime(2026, 8, 21, 22, 30, tzinfo=UTC))
+
+    assert manager.should_create_channel(event, segment_start=PRACTICE_START).should_act
+    assert not manager.should_create_channel(event, segment_start=RACE_START).should_act
+
+
+def test_race_channel_created_once_race_enters_window(monkeypatch):
+    manager = ChannelLifecycleManager(create_timing="before_event", pre_buffer_minutes=1440)
+    event = _race_weekend()
+    _freeze_now(monkeypatch, datetime(2026, 8, 22, 19, 0, tzinfo=UTC))  # Sat, <24h to race
+
+    assert manager.should_create_channel(event, segment_start=RACE_START).should_act
+
+
+def test_same_day_anchors_to_session_day(monkeypatch):
+    """same_day mode: race channel appears at midnight of RACE day, not practice day."""
+    manager = ChannelLifecycleManager(create_timing="same_day")
+    event = _race_weekend()
+    _freeze_now(monkeypatch, datetime(2026, 8, 21, 23, 0, tzinfo=UTC))  # Friday
+
+    assert manager.should_create_channel(event, segment_start=PRACTICE_START).should_act
+    assert not manager.should_create_channel(event, segment_start=RACE_START).should_act
+
+    _freeze_now(monkeypatch, datetime(2026, 8, 23, 0, 1, tzinfo=UTC))  # Sunday 00:01
+    assert manager.should_create_channel(event, segment_start=RACE_START).should_act
+
+
+def test_no_segment_keeps_event_anchored_behavior(monkeypatch):
+    """Non-segmented callers are unchanged: threshold from event.start_time."""
+    manager = ChannelLifecycleManager(create_timing="before_event", pre_buffer_minutes=60)
+    event = _race_weekend()
+    _freeze_now(monkeypatch, datetime(2026, 8, 21, 21, 30, tzinfo=UTC))
+
+    assert manager.should_create_channel(event).should_act


### PR DESCRIPTION
## Summary

Fixes the create-side half of #550. Racing anchors `event.start_time` to the weekend's first session, so once Friday practice entered the pre-buffer window, `expand_racing_segments` fan-out channels for every session were approved at once — the race-day channel appeared up to ~35h early with a 1440-minute pre-buffer.

`should_create_channel` now takes the segment/session start (already extracted in `creator.py` for racing sessions and UFC card segments) and derives the create threshold from it, mirroring the session-aware delete side (`get_event_end_time`). Callers passing no segment are unchanged. In `same_day` mode the race channel now appears at midnight of race day; in `before_event` mode at race start minus buffer.

Reported by @ruckusvol with full root-cause analysis (NASCAR Cup Iowa Corn 350).

Deliberately leaves #550's second bug (`{today_tonight}` has no "tomorrow" case, bead `dpn4`) for its own change — it needs a template-compat scope decision first.

## Testing

- `pytest tests/` all green (4 new tests in `tests/lifecycle/test_racing_create_threshold.py`)
- `ruff check` clean · frontend build green
- Docs: `docs/guide/channels/lifecycle.md` updated
