### PR TITLE
feat: runtime console log-level control in Settings → Advanced

### DIFF
--- a/docs/guide/settings/advanced.md
+++ b/docs/guide/settings/advanced.md
@@ -59,6 +59,15 @@ Set this to run shortly *before* your media server's scheduled guide refresh.
 
 Customize what the `{gracenote_category}` template variable renders for any league — the value professional guides use as the program title ("NFL Football", "NASCAR Cup Series"). Two facts worth knowing: overrides **survive Teamarr updates** (built-in league data is re-seeded on every startup; overrides live separately and always win), and clearing an override restores the built-in value, which is shown alongside each entry.
 
+## Logging
+
+**Console log level** changes the verbosity of the console/`docker logs` stream at runtime — no restart needed. Pick DEBUG for temporary troubleshooting, *arr-style.
+
+Two things to know:
+
+- **It's temporary by design.** A restart returns to the `LOG_LEVEL` environment default (INFO unless overridden). If you want a permanently different level, set `LOG_LEVEL` instead.
+- **The log file always captures DEBUG.** `data/logs/teamarr.log` records full debug detail at all times regardless of this setting — if something already went wrong, the debug trail is on disk.
+
 ## Data Caches
 
 Teamarr maintains several caches, each with a tile and a clear/refresh action. Tiles show live counts where available; the Directory tile also shows the last refresh time, duration, and any error.

--- a/frontend/src/pages/settings/tabs/AdvancedTab.tsx
+++ b/frontend/src/pages/settings/tabs/AdvancedTab.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
-import { LoaderCircle, Database, Trash2 } from "lucide-react"
+import { LoaderCircle, Database, ScrollText, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { Label } from "@/components/ui/label"
+import { Select } from "@/components/ui/select"
+import { api } from "@/api/client"
 import { ScheduledChannelResetCard } from "@/components/ScheduledChannelResetCard"
 import {
   useCacheStatus,
@@ -16,6 +20,73 @@ import {
 import { GracenoteOverridesCard } from "@/components/GracenoteOverridesCard"
 import { BackupRestoreCard } from "../BackupRestoreCard"
 import { formatRelativeTime } from "../format"
+
+interface LogLevelState {
+  level: string
+  default: string
+  levels: string[]
+}
+
+function LogLevelCard() {
+  const [state, setState] = useState<LogLevelState | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    api
+      .get<LogLevelState>("/logging/level")
+      .then(setState)
+      .catch(() => setState(null))
+  }, [])
+
+  const handleChange = async (level: string) => {
+    setSaving(true)
+    try {
+      const next = await api.put<LogLevelState>("/logging/level", { level })
+      setState(next)
+      toast.success(`Console log level set to ${next.level} (until restart)`)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to set log level")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!state) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ScrollText className="h-5 w-5" />
+          Logging
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <Label htmlFor="console-log-level">Console log level</Label>
+          <Select
+            id="console-log-level"
+            value={state.level}
+            onChange={(e) => handleChange(e.target.value)}
+            disabled={saving}
+          >
+            {state.levels.map((level) => (
+              <option key={level} value={level}>
+                {level}
+                {level === state.default ? " (default)" : ""}
+              </option>
+            ))}
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            Applies immediately, no restart. Temporary: a restart returns to the{" "}
+            <code>LOG_LEVEL</code> default ({state.default}). The log file always
+            captures DEBUG regardless.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
 
 function DataCachesCard() {
   const { data: cacheStatus, refetch: refetchCache } = useCacheStatus()
@@ -214,6 +285,7 @@ export function AdvancedTab() {
       <BackupRestoreCard />
       <ScheduledChannelResetCard />
       <GracenoteOverridesCard />
+      <LogLevelCard />
       <DataCachesCard />
     </>
   )

--- a/teamarr/api/app.py
+++ b/teamarr/api/app.py
@@ -23,6 +23,7 @@ from teamarr.api.routes import (
     health,
     keywords,
     leagues,
+    logs,
     presets,
     settings,
     sort_priorities,
@@ -322,6 +323,7 @@ def create_app() -> FastAPI:
     app.include_router(keywords.router, prefix="/api/v1/keywords", tags=["Exception Keywords"])
     app.include_router(cache.router, prefix="/api/v1", tags=["Cache"])
     app.include_router(leagues.router, prefix="/api/v1", tags=["Custom Leagues"])
+    app.include_router(logs.router, prefix="/api/v1", tags=["Logging"])
     app.include_router(channels.router, prefix="/api/v1/channels", tags=["Channels"])
     app.include_router(settings.router, prefix="/api/v1", tags=["Settings"])
     app.include_router(sort_priorities.router, prefix="/api/v1", tags=["Sort Priorities"])

--- a/teamarr/api/routes/logs.py
+++ b/teamarr/api/routes/logs.py
@@ -1,0 +1,58 @@
+"""Runtime log-level control (#585).
+
+Adjusts the console handler's minimum level in-process, no restart —
+*arr-style temporary debugging. Runtime-only: a restart returns to the
+``LOG_LEVEL`` env default, and the rotating file log always captures DEBUG
+regardless of this setting.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from teamarr.utilities.logging import (
+    RUNTIME_LOG_LEVELS,
+    default_log_level,
+    get_console_log_level,
+    set_console_log_level,
+)
+
+router = APIRouter()
+
+logger = logging.getLogger(__name__)
+
+
+class LogLevelUpdate(BaseModel):
+    level: str
+
+
+def _state() -> dict:
+    return {
+        "level": get_console_log_level(),
+        "default": default_log_level(),
+        "levels": list(RUNTIME_LOG_LEVELS),
+    }
+
+
+@router.get("/logging/level")
+def get_log_level() -> dict:
+    """Current console log level, the startup default, and valid choices."""
+    return _state()
+
+
+@router.put("/logging/level")
+def update_log_level(payload: LogLevelUpdate) -> dict:
+    """Set the console log level at runtime; reverts to default on restart."""
+    try:
+        applied = set_console_log_level(payload.level)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid level {payload.level!r}; valid: {', '.join(RUNTIME_LOG_LEVELS)}",
+        ) from None
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from None
+    # WARNING so the change itself survives the new filter when raising the level
+    logger.warning("[LOGGING] Console log level set to %s (runtime-only)", applied)
+    return _state()

--- a/teamarr/utilities/logging.py
+++ b/teamarr/utilities/logging.py
@@ -32,6 +32,14 @@ from teamarr.config import VERSION
 # Track if logging has been configured
 _configured = False
 
+# The console StreamHandler, kept for runtime level changes (#585). The file
+# handlers are deliberately NOT adjustable: teamarr.log always captures DEBUG.
+_console_handler: logging.Handler | None = None
+
+# Levels offered by the runtime control. CRITICAL is omitted on purpose —
+# silencing errors from the console is a footgun, not a verbosity setting.
+RUNTIME_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
+
 
 class JSONFormatter(logging.Formatter):
     """JSON formatter for structured logging.
@@ -157,6 +165,10 @@ def setup_logging(
     error_handler.setLevel(logging.ERROR)
     error_handler.setFormatter(formatter)
 
+    # Keep a handle for runtime level changes (#585)
+    global _console_handler
+    _console_handler = console_handler
+
     # === Configure Root Logger ===
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)  # Handlers filter from here
@@ -198,3 +210,34 @@ def setup_logging(
     logger.info("[STARTUP] Log directory: %s", log_path)
     logger.info("[STARTUP] Log format: %s", "JSON" if use_json else "text")
     logger.info("[STARTUP] " + "=" * 60)
+
+
+def default_log_level() -> str:
+    """The configured startup level name (LOG_LEVEL env, default INFO)."""
+    return logging.getLevelName(_get_log_level())
+
+
+def get_console_log_level() -> str:
+    """The console handler's current minimum level name."""
+    if _console_handler is not None:
+        return logging.getLevelName(_console_handler.level)
+    return default_log_level()
+
+
+def set_console_log_level(level_name: str) -> str:
+    """Set the console handler's minimum at runtime (#585).
+
+    Runtime-only by design (*arr-style temporary debug): a restart returns
+    to the LOG_LEVEL default. File handlers are untouched — teamarr.log
+    always captures DEBUG regardless of this setting.
+
+    Returns the applied level name; raises ValueError for unknown levels
+    and RuntimeError when logging was never configured.
+    """
+    normalized = level_name.upper()
+    if normalized not in RUNTIME_LOG_LEVELS:
+        raise ValueError(f"invalid log level: {level_name!r}")
+    if _console_handler is None:
+        raise RuntimeError("logging is not configured")
+    _console_handler.setLevel(getattr(logging, normalized))
+    return normalized

--- a/tests/test_log_level_api.py
+++ b/tests/test_log_level_api.py
@@ -1,0 +1,55 @@
+"""Runtime log-level endpoint (#585).
+
+Runtime-only console verbosity: the endpoint flips the console handler's
+minimum in-process; file handlers stay at DEBUG and a restart returns to
+the LOG_LEVEL default. Tests drive the route functions directly.
+"""
+
+import logging
+
+import pytest
+from fastapi import HTTPException
+
+import teamarr.utilities.logging as tlog
+from teamarr.api.routes.logs import LogLevelUpdate, get_log_level, update_log_level
+
+
+@pytest.fixture
+def console_handler(monkeypatch):
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    monkeypatch.setattr(tlog, "_console_handler", handler)
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    return handler
+
+
+def test_get_reports_level_default_and_choices(console_handler):
+    state = get_log_level()
+    assert state["level"] == "INFO"
+    assert state["default"] == "INFO"
+    assert state["levels"] == ["DEBUG", "INFO", "WARNING", "ERROR"]
+
+
+def test_put_applies_immediately_to_console_handler(console_handler):
+    state = update_log_level(LogLevelUpdate(level="debug"))
+    assert state["level"] == "DEBUG"
+    assert console_handler.level == logging.DEBUG
+    # Startup default is untouched — restart reverts (runtime-only by design)
+    assert state["default"] == "INFO"
+
+
+def test_put_rejects_unknown_and_footgun_levels(console_handler):
+    with pytest.raises(HTTPException) as exc:
+        update_log_level(LogLevelUpdate(level="VERBOSE"))
+    assert exc.value.status_code == 400
+    # CRITICAL is deliberately not offered: hiding errors isn't verbosity
+    with pytest.raises(HTTPException):
+        update_log_level(LogLevelUpdate(level="CRITICAL"))
+    assert console_handler.level == logging.INFO
+
+
+def test_put_before_logging_configured_is_503(monkeypatch):
+    monkeypatch.setattr(tlog, "_console_handler", None)
+    with pytest.raises(HTTPException) as exc:
+        update_log_level(LogLevelUpdate(level="DEBUG"))
+    assert exc.value.status_code == 503


### PR DESCRIPTION
## Summary

Fixes #585 (@DatGuy1). Runtime console log verbosity, *arr-style temporary debug:

- `GET/PUT /api/v1/logging/level` — flips the console handler's minimum in-process, no restart. File handlers untouched (`teamarr.log` always captures DEBUG).
- Runtime-only by design: a restart returns to the `LOG_LEVEL` env default. CRITICAL deliberately not offered (hiding errors isn't verbosity).
- UI: Logging card on Settings → Advanced with a level select; shows which level is the startup default and explains the temporary semantics.
- Docs: `docs/guide/settings/advanced.md` Logging section.

The "verbose third-party logs" companion toggle from triage is deferred — no demand yet.

## Testing

- `pytest tests/` — 2,263 passed (new `tests/test_log_level_api.py`: round-trip, immediate handler effect, invalid/footgun rejection, unconfigured → 503)
- Verified over HTTP via TestClient: GET state, PUT applies, invalid → 400
- `ruff check` clean · frontend build green
