### PR TITLE
fix(providers): disable Bullpen after repeated 401s

### DIFF
--- a/docs/reference/providers/bullpen.md
+++ b/docs/reference/providers/bullpen.md
@@ -52,3 +52,5 @@ Enabling bullpen for TheSportsDB is treated as equivalent to holding a [premium 
 ## Failure behavior
 
 There is no fallback to the direct origin if a bullpen request fails (rate limit, upstream error, or bullpen itself unreachable) — the request fails like any other failed provider call, subject to the normal retry/backoff behavior in `teamarr/providers/base_client.py`.
+
+If Bullpen returns `401 Unauthorized` three times for one proxied request, Teamarr disables the global Bullpen switch and records the reason on the `/bullpen` settings page. Correct the proxy authentication configuration, then re-enable Bullpen to clear the alert and resume proxy traffic.

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -292,6 +292,8 @@ export interface BullpenSettings {
   enabled: boolean
   api_key: string | null
   base_url: string
+  disabled_reason: string | null
+  disabled_at: string | null
   espn_enabled: boolean
   bellmedia_enabled: boolean
   squiggle_enabled: boolean

--- a/frontend/src/pages/BullpenSettings.tsx
+++ b/frontend/src/pages/BullpenSettings.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
+import { Alert } from "@/components/ui/alert"
 import { useBullpenSettings, useUpdateBullpenSettings } from "@/hooks/useSettings"
 import type { BullpenSettings as BullpenSettingsType } from "@/api/settings"
 
@@ -98,6 +99,12 @@ export function BullpenSettings() {
           this page has no sidebar entry and is only reachable at this URL.
         </p>
       </div>
+
+      {data.disabled_reason && (
+        <Alert variant="warning" title="Bullpen disabled automatically">
+          {data.disabled_reason} Re-enable the proxy after correcting its authentication settings.
+        </Alert>
+      )}
 
       <Card>
         <CardHeader>

--- a/teamarr/api/routes/settings/bullpen.py
+++ b/teamarr/api/routes/settings/bullpen.py
@@ -34,6 +34,8 @@ def update_bullpen_settings(update: BullpenSettingsUpdate):
     payload = update.model_dump(exclude_unset=True)
     if payload.get("api_key") == MASKED_SECRET:
         payload.pop("api_key")
+    if payload.get("enabled"):
+        payload.update(disabled_reason=None, disabled_at=None)
 
     with get_db() as conn:
         update_bullpen_settings(conn, **payload)

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -662,6 +662,8 @@ class BullpenSettingsModel(BaseModel):
     enabled: bool = False
     api_key: str | None = None
     base_url: str = "https://bullpen.direct"
+    disabled_reason: str | None = None
+    disabled_at: str | None = None
     espn_enabled: bool = False
     bellmedia_enabled: bool = False
     squiggle_enabled: bool = False

--- a/teamarr/database/migrations/versioned.py
+++ b/teamarr/database/migrations/versioned.py
@@ -304,6 +304,10 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         )
         current_version = 88
 
+    if current_version < 89:
+        _advance_version(conn, 89, "reconciliation: Bullpen disable status")
+        current_version = 89
+
 
 # =============================================================================
 # Migration helpers

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -291,6 +291,8 @@ CREATE TABLE IF NOT EXISTS settings (
     bullpen_enabled BOOLEAN DEFAULT 0,
     bullpen_api_key TEXT,
     bullpen_base_url TEXT DEFAULT 'https://bullpen.direct',
+    bullpen_disabled_reason TEXT,
+    bullpen_disabled_at TEXT,
     bullpen_espn_enabled BOOLEAN DEFAULT 0,
     bullpen_bellmedia_enabled BOOLEAN DEFAULT 0,
     bullpen_squiggle_enabled BOOLEAN DEFAULT 0,
@@ -474,7 +476,7 @@ CREATE TABLE IF NOT EXISTS settings (
     channelsdvr_servers JSON,
 
     -- Schema Version
-    schema_version INTEGER DEFAULT 88
+    schema_version INTEGER DEFAULT 89
 );
 
 -- Insert default settings

--- a/teamarr/database/settings/types.py
+++ b/teamarr/database/settings/types.py
@@ -42,6 +42,8 @@ class BullpenSettings:
     enabled: bool = False
     api_key: str | None = None
     base_url: str = "https://bullpen.direct"
+    disabled_reason: str | None = None
+    disabled_at: str | None = None
     espn_enabled: bool = False
     bellmedia_enabled: bool = False
     squiggle_enabled: bool = False

--- a/teamarr/database/settings/update.py
+++ b/teamarr/database/settings/update.py
@@ -555,6 +555,8 @@ def update_bullpen_settings(
     enabled: bool | None = None,
     api_key: str | None | object = _NOT_PROVIDED,
     base_url: str | None = None,
+    disabled_reason: str | None | object = _NOT_PROVIDED,
+    disabled_at: str | None | object = _NOT_PROVIDED,
     espn_enabled: bool | None = None,
     bellmedia_enabled: bool | None = None,
     squiggle_enabled: bool | None = None,
@@ -575,7 +577,13 @@ def update_bullpen_settings(
         hockeytech_enabled=hockeytech_enabled,
         tsdb_enabled=tsdb_enabled,
     )
-    provided.update(_skip_missing(api_key=api_key))
+    provided.update(
+        _skip_missing(
+            api_key=api_key,
+            disabled_reason=disabled_reason,
+            disabled_at=disabled_at,
+        )
+    )
     return _apply(conn, "bullpen", provided)
 
 

--- a/teamarr/providers/__init__.py
+++ b/teamarr/providers/__init__.py
@@ -17,9 +17,10 @@ to inject the LeagueMappingSource into providers.
 
 import sqlite3
 from collections.abc import Callable
+from datetime import UTC, datetime
 
 from teamarr.database import get_db
-from teamarr.database.settings import get_bullpen_settings
+from teamarr.database.settings import get_bullpen_settings, update_bullpen_settings
 from teamarr.database.team_cache import get_team_name_by_id
 from teamarr.providers.base_client import BullpenConfig
 from teamarr.providers.bellmedia import BellMediaClient, BellMediaProvider
@@ -37,6 +38,32 @@ from teamarr.providers.tsdb import RateLimitStats, TSDBClient, TSDBProvider
 # =============================================================================
 # Factories inject dependencies from the registry at instantiation time.
 
+_BULLPEN_PROVIDERS = (
+    "espn",
+    "bellmedia",
+    "squiggle",
+    "nascar",
+    "mlbstats",
+    "hockeytech",
+    "tsdb",
+)
+
+
+def _disable_bullpen_after_unauthorized() -> None:
+    """Disable Bullpen globally after a provider exhausts 401 retries."""
+    with get_db() as conn:
+        if not get_bullpen_settings(conn).enabled:
+            return
+        update_bullpen_settings(
+            conn,
+            enabled=False,
+            disabled_reason="Bullpen returned 401 Unauthorized after three attempts.",
+            disabled_at=datetime.now(UTC).isoformat(),
+        )
+
+    for provider in _BULLPEN_PROVIDERS:
+        ProviderRegistry.reinitialize_provider(provider)
+
 
 def _get_bullpen_config(provider_flag: str) -> BullpenConfig | None:
     """Resolve BullpenConfig for one provider from database settings.
@@ -53,6 +80,7 @@ def _get_bullpen_config(provider_flag: str) -> BullpenConfig | None:
                 return BullpenConfig(
                     api_key=settings.api_key,
                     base_url=settings.base_url or "https://bullpen.direct",
+                    on_unauthorized=_disable_bullpen_after_unauthorized,
                 )
     except sqlite3.Error:
         # Database not available or column doesn't exist yet - expected during startup

--- a/teamarr/providers/base_client.py
+++ b/teamarr/providers/base_client.py
@@ -23,6 +23,7 @@ import logging
 import random
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
@@ -42,6 +43,7 @@ RETRY_JITTER = 0.3  # ±30% randomization to prevent thundering herd
 RATE_LIMIT_BASE_DELAY = 5.0  # Start at 5s for 429s (more serious)
 RATE_LIMIT_MAX_DELAY = 60.0  # Cap at 60s
 RATE_LIMIT_MAX_RETRIES = 3  # Give up after 3 rate-limit retries
+BULLPEN_UNAUTHORIZED_ATTEMPTS = 3
 
 
 @dataclass
@@ -54,6 +56,16 @@ class BullpenConfig:
 
     api_key: str | None = None
     base_url: str = "https://bullpen.direct"
+    on_unauthorized: Callable[[], None] | None = None
+    disabled: bool = False
+
+    def disable(self) -> None:
+        """Stop proxy use by this client and persist the shared shutdown."""
+        if self.disabled:
+            return
+        self.disabled = True
+        if self.on_unauthorized:
+            self.on_unauthorized()
 
 
 def bullpen_rewrite(origin_base: str, target: str, bullpen: BullpenConfig | None) -> str:
@@ -65,7 +77,7 @@ def bullpen_rewrite(origin_base: str, target: str, bullpen: BullpenConfig | None
     once ``base`` itself has been rewritten). Returns ``origin_base``
     unchanged when bullpen isn't configured.
     """
-    if bullpen is None:
+    if bullpen is None or bullpen.disabled:
         return origin_base
     path = urlsplit(origin_base).path.rstrip("/")
     return f"{bullpen.base_url.rstrip('/')}/v1/{target}{path}"
@@ -73,11 +85,20 @@ def bullpen_rewrite(origin_base: str, target: str, bullpen: BullpenConfig | None
 
 def bullpen_headers(url: str, bullpen: BullpenConfig | None) -> dict[str, str] | None:
     """Return Bullpen authentication only for requests to the proxy host."""
-    if bullpen is None or not bullpen.api_key:
+    if bullpen is None or bullpen.disabled or not bullpen.api_key:
         return None
     if urlsplit(url).netloc != urlsplit(bullpen.base_url).netloc:
         return None
     return {"X-Bullpen-Key": bullpen.api_key}
+
+
+def is_bullpen_url(url: str, bullpen: BullpenConfig | None) -> bool:
+    """Return whether a request URL is routed to the configured Bullpen host."""
+    return bool(
+        bullpen
+        and not bullpen.disabled
+        and urlsplit(url).netloc == urlsplit(bullpen.base_url).netloc
+    )
 
 
 class BaseHTTPClient:
@@ -161,6 +182,8 @@ class BaseHTTPClient:
                 call_metrics reduces either form to the last path segment)
         """
         label = label if label is not None else url
+        if self._bullpen and self._bullpen.disabled:
+            return None
         rate_limit_retries = 0
 
         for attempt in range(self._retry_count + RATE_LIMIT_MAX_RETRIES):
@@ -171,6 +194,25 @@ class BaseHTTPClient:
                     response = client.get(url, params=params, headers=headers)
                 else:
                     response = client.get(url, params=params)
+
+                if response.status_code == 401 and is_bullpen_url(url, self._bullpen):
+                    if attempt < BULLPEN_UNAUTHORIZED_ATTEMPTS - 1:
+                        logger.warning(
+                            "[%s] Bullpen unauthorized. Retry %d/%d",
+                            self.LOG_TAG,
+                            attempt + 1,
+                            BULLPEN_UNAUTHORIZED_ATTEMPTS,
+                        )
+                        time.sleep(self._calculate_delay(attempt))
+                        continue
+                    logger.error(
+                        "[%s] Bullpen unauthorized after %d attempts; disabling proxy",
+                        self.LOG_TAG,
+                        BULLPEN_UNAUTHORIZED_ATTEMPTS,
+                    )
+                    if self._bullpen:
+                        self._bullpen.disable()
+                    return None
 
                 # Handle 429 rate limit separately with longer backoff
                 if response.status_code == 429:

--- a/teamarr/providers/nascar/provider.py
+++ b/teamarr/providers/nascar/provider.py
@@ -13,6 +13,7 @@ URL patterns (no auth required):
 """
 
 import logging
+import time
 from datetime import UTC, date, datetime
 
 import httpx
@@ -26,7 +27,13 @@ from teamarr.core import (
     Team,
     Venue,
 )
-from teamarr.providers.base_client import BullpenConfig, bullpen_headers, bullpen_rewrite
+from teamarr.providers.base_client import (
+    BULLPEN_UNAUTHORIZED_ATTEMPTS,
+    BullpenConfig,
+    bullpen_headers,
+    bullpen_rewrite,
+    is_bullpen_url,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -197,16 +204,32 @@ class NASCARProvider(SportsProvider):
         return result
 
     def _fetch(self, url: str) -> list | dict | None:
+        if self._bullpen and self._bullpen.disabled:
+            return None
         headers = bullpen_headers(url, self._bullpen)
-        try:
-            with httpx.Client(timeout=self._timeout, headers=headers) as client:
-                resp = client.get(url)
-                resp.raise_for_status()
-                return resp.json()
-        except httpx.HTTPStatusError as e:
-            logger.warning("[NASCAR] HTTP %d fetching %s", e.response.status_code, url)
-        except Exception as e:
-            logger.warning("[NASCAR] Failed to fetch %s: %s", url, e)
+        for attempt in range(BULLPEN_UNAUTHORIZED_ATTEMPTS):
+            try:
+                with httpx.Client(timeout=self._timeout, headers=headers) as client:
+                    resp = client.get(url)
+                    if resp.status_code == 401 and is_bullpen_url(url, self._bullpen):
+                        if attempt < BULLPEN_UNAUTHORIZED_ATTEMPTS - 1:
+                            time.sleep(0.5 * (attempt + 1))
+                            continue
+                        logger.error(
+                            "[NASCAR] Bullpen unauthorized after %d attempts; disabling proxy",
+                            BULLPEN_UNAUTHORIZED_ATTEMPTS,
+                        )
+                        if self._bullpen:
+                            self._bullpen.disable()
+                        return None
+                    resp.raise_for_status()
+                    return resp.json()
+            except httpx.HTTPStatusError as e:
+                logger.warning("[NASCAR] HTTP %d fetching %s", e.response.status_code, url)
+                return None
+            except Exception as e:
+                logger.warning("[NASCAR] Failed to fetch %s: %s", url, e)
+                return None
         return None
 
     def _parse_race(self, data: dict, league: str) -> Event | None:

--- a/teamarr/providers/tsdb/client.py
+++ b/teamarr/providers/tsdb/client.py
@@ -35,7 +35,14 @@ from datetime import date, datetime
 import httpx
 
 from teamarr.core import LeagueMappingSource
-from teamarr.providers.base_client import BaseHTTPClient, BullpenConfig, bullpen_rewrite
+from teamarr.providers.base_client import (
+    BULLPEN_UNAUTHORIZED_ATTEMPTS,
+    BaseHTTPClient,
+    BullpenConfig,
+    bullpen_headers,
+    bullpen_rewrite,
+    is_bullpen_url,
+)
 from teamarr.utilities import call_metrics
 from teamarr.utilities.cache import TTLCache, make_cache_key
 
@@ -310,6 +317,9 @@ class TSDBClient(BaseHTTPClient):
         Never fails due to rate limits - always waits and continues.
         All waits are tracked in rate_limit_stats() for UI feedback.
         """
+        if self._bullpen and self._bullpen.disabled:
+            return None
+
         # Wait for rate limit slot (preemptive)
         rate_limiter = self._get_rate_limiter()
         rate_limiter.acquire()
@@ -320,7 +330,23 @@ class TSDBClient(BaseHTTPClient):
         for attempt in range(self._retry_count + self.BACKOFF_MAX_RETRIES):
             try:
                 client = self._get_client()
-                response = client.get(url, params=params)
+                headers = bullpen_headers(url, self._bullpen)
+                if headers:
+                    response = client.get(url, params=params, headers=headers)
+                else:
+                    response = client.get(url, params=params)
+
+                if response.status_code == 401 and is_bullpen_url(url, self._bullpen):
+                    if attempt < BULLPEN_UNAUTHORIZED_ATTEMPTS - 1:
+                        time.sleep(self._retry_delay * (attempt + 1))
+                        continue
+                    logger.error(
+                        "[TSDB] Bullpen unauthorized after %d attempts; disabling proxy",
+                        BULLPEN_UNAUTHORIZED_ATTEMPTS,
+                    )
+                    if self._bullpen:
+                        self._bullpen.disable()
+                    return None
 
                 # Handle rate limit response (reactive) with exponential backoff
                 if response.status_code == 429:

--- a/tests/migrations/test_checkpoint_v43.py
+++ b/tests/migrations/test_checkpoint_v43.py
@@ -626,7 +626,7 @@ class TestFullMigrationPath:
 
         # Should now be at latest schema version (v43 checkpoint + v44-v74 migrations)
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
 
 
 if __name__ == "__main__":

--- a/tests/migrations/test_subscription_migration.py
+++ b/tests/migrations/test_subscription_migration.py
@@ -381,4 +381,4 @@ class TestGroupNormalization:
         _run_v58_migration(db)
 
         row = db.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row[0] == 88  # v59-v88 migrations run after v58
+        assert row[0] == 89  # v59-v89 migrations run after v58

--- a/tests/migrations/test_versioned_migrations.py
+++ b/tests/migrations/test_versioned_migrations.py
@@ -218,7 +218,7 @@ class TestV73DeletesDuplicateLeagues:
         _run_migrations(conn)
 
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
 
 
 class TestV73CleansTeamCache:
@@ -412,7 +412,7 @@ class TestV73MissingTablesGraceful:
         _run_migrations(conn)
 
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ class TestFreshInstall:
         conn = sqlite3.connect(str(db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
 
 
 # ===========================================================================
@@ -1222,7 +1222,7 @@ class TestV82ChannelsDVRServersList:
         row = conn.execute(
             "SELECT schema_version, channelsdvr_servers FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
         servers = json.loads(row["channelsdvr_servers"])
         assert servers == [
             {
@@ -1241,7 +1241,7 @@ class TestV82ChannelsDVRServersList:
         row = conn.execute(
             "SELECT schema_version, channelsdvr_servers FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
         assert row["channelsdvr_servers"] is None
 
     def test_settings_roundtrip_servers_list(self, db_conn):

--- a/tests/providers/test_base_http_client.py
+++ b/tests/providers/test_base_http_client.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from teamarr.providers import base_client
-from teamarr.providers.base_client import BaseHTTPClient
+from teamarr.providers.base_client import BaseHTTPClient, BullpenConfig
 
 
 class _StubClient(BaseHTTPClient):
@@ -79,6 +79,38 @@ def test_429_gives_up_after_max_retries(monkeypatch):
     assert client._request_json("https://api.test/x") is None
     # Initial attempt + RATE_LIMIT_MAX_RETRIES retries
     assert len(calls) == base_client.RATE_LIMIT_MAX_RETRIES + 1
+
+
+def test_bullpen_401_retries_then_disables(monkeypatch):
+    monkeypatch.setattr(base_client.time, "sleep", lambda s: None)
+    calls = []
+    disabled = []
+    bullpen = BullpenConfig(
+        api_key="key",
+        base_url="https://proxy.test",
+        on_unauthorized=lambda: disabled.append(True),
+    )
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(401)
+
+    client = _make_client(handler, bullpen=bullpen)
+    assert client._request_json("https://proxy.test/v1/stub/request") is None
+
+    assert len(calls) == base_client.BULLPEN_UNAUTHORIZED_ATTEMPTS
+    assert bullpen.disabled is True
+    assert disabled == [True]
+
+
+def test_direct_401_does_not_disable_bullpen():
+    disabled = []
+    bullpen = BullpenConfig(api_key="key", on_unauthorized=lambda: disabled.append(True))
+    client = _make_client(lambda request: httpx.Response(401), bullpen=bullpen)
+
+    assert client._request_json("https://origin.test/request") is None
+    assert bullpen.disabled is False
+    assert disabled == []
 
 
 @pytest.mark.parametrize("attempt", [0, 1, 2, 5, 10])

--- a/tests/providers/test_bullpen.py
+++ b/tests/providers/test_bullpen.py
@@ -114,3 +114,22 @@ def test_bullpen_api_key_can_be_cleared():
     update_bullpen_settings(conn, api_key=None)
 
     assert get_bullpen_settings(conn).api_key is None
+
+
+def test_bullpen_disable_status_can_be_cleared():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_PATH.read_text())
+
+    update_bullpen_settings(
+        conn,
+        enabled=False,
+        disabled_reason="Bullpen returned 401 Unauthorized after three attempts.",
+        disabled_at="2026-08-28T12:00:00+00:00",
+    )
+    update_bullpen_settings(conn, enabled=True, disabled_reason=None, disabled_at=None)
+
+    settings = get_bullpen_settings(conn)
+    assert settings.enabled is True
+    assert settings.disabled_reason is None
+    assert settings.disabled_at is None

--- a/tests/providers/test_nascar_provider.py
+++ b/tests/providers/test_nascar_provider.py
@@ -13,6 +13,8 @@ from datetime import UTC, date, datetime, timedelta
 
 import pytest
 
+from teamarr.providers.base_client import BullpenConfig
+from teamarr.providers.nascar import provider as nascar_provider
 from teamarr.providers.nascar.provider import NASCARProvider, _session_code_and_name
 
 # ---------------------------------------------------------------------------
@@ -382,6 +384,43 @@ def test_fresh_cache_not_refetched():
     p._fetch = lambda url: calls.append(url)
     p.get_events("nascar-cup", date(2026, 2, 15))
     assert calls == []
+
+
+def test_bullpen_401_retries_then_disables(monkeypatch):
+    calls = []
+    disabled = []
+
+    class _Response:
+        status_code = 401
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, url):
+            calls.append(url)
+            return _Response()
+
+    monkeypatch.setattr(nascar_provider.httpx, "Client", _Client)
+    monkeypatch.setattr(nascar_provider.time, "sleep", lambda s: None)
+    bullpen = BullpenConfig(
+        api_key="key",
+        base_url="https://proxy.test",
+        on_unauthorized=lambda: disabled.append(True),
+    )
+    provider = NASCARProvider(bullpen=bullpen)
+
+    url = "https://proxy.test/v1/nascar/cacher/2026/1/race_list_basic.json"
+    assert provider._fetch(url) is None
+    assert len(calls) == 3
+    assert bullpen.disabled is True
+    assert disabled == [True]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_tsdb.py
+++ b/tests/providers/test_tsdb.py
@@ -14,7 +14,9 @@ from unittest.mock import MagicMock
 import httpx
 
 from teamarr.consumers.cache.refresh import CacheRefresher
+from teamarr.providers.base_client import BullpenConfig
 from teamarr.providers.registry import ProviderConfig, ProviderRegistry
+from teamarr.providers.tsdb import client as tsdb_client
 from teamarr.providers.tsdb.client import TSDBClient
 from teamarr.providers.tsdb.provider import TSDBProvider
 from teamarr.providers.tsdb.racing import parse_racing_events
@@ -566,4 +568,27 @@ def test_transport_error_log_excludes_api_key(caplog):
 
     assert "sensitive-key" not in caplog.text
     assert "endpoint lookupleague.php (ConnectError)" in caplog.text
+    client.close()
+
+
+def test_bullpen_401_retries_then_disables(monkeypatch):
+    monkeypatch.setattr(tsdb_client.time, "sleep", lambda s: None)
+    disabled = []
+    bullpen = BullpenConfig(
+        api_key="key",
+        base_url="https://proxy.test",
+        on_unauthorized=lambda: disabled.append(True),
+    )
+    client = TSDBClient(bullpen=bullpen, retry_count=1)
+    calls = []
+    client._client = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: (calls.append(request), httpx.Response(401))[1]
+        )
+    )
+
+    assert client._request("lookupleague.php") is None
+    assert len(calls) == 3
+    assert bullpen.disabled is True
+    assert disabled == [True]
     client.close()

--- a/tests/test_media_server_settings.py
+++ b/tests/test_media_server_settings.py
@@ -62,7 +62,7 @@ class TestV83MediaServerLists:
             "SELECT schema_version, emby_servers, jellyfin_servers "
             "FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 88
+        assert row["schema_version"] == 89
         emby = json.loads(row["emby_servers"])
         assert emby == [
             {


### PR DESCRIPTION
## Summary

Closes #548 follow-up for Bullpen authentication failures.

- Retry Bullpen `401 Unauthorized` responses three times before disabling the global Bullpen switch.
- Cover shared HTTP clients plus TSDB and NASCAR, which use custom request paths.
- Persist a disable reason and timestamp, reinitialize proxy-backed providers, and show a warning on `/bullpen`.
- Add schema version 89 migration tracking for the persisted disable status.
- Document the automatic shutdown behavior.

## Verification

- `pytest` - 2,488 passed
- `ruff check teamarr tests`
- `npm run build`