### PR TITLE
perf(channel-source): fetch curated channels' streams by id, not the whole catalog (#647)

### DIFF
--- a/teamarr/consumers/event_group_processor/stream_fetcher.py
+++ b/teamarr/consumers/event_group_processor/stream_fetcher.py
@@ -156,9 +156,7 @@ class StreamFetcher:
         streams: list = []
         seen_ids: set[int] = set()
         for g in matched:
-            for s in m3u_manager.list_streams(
-                group_name=g.name, account_id=group.m3u_account_id
-            ):
+            for s in m3u_manager.list_streams(group_name=g.name, account_id=group.m3u_account_id):
                 if s.id not in seen_ids:
                     seen_ids.add(s.id)
                     streams.append(s)
@@ -222,13 +220,6 @@ class StreamFetcher:
         except Exception as e:
             logger.warning("[CHANNEL_SOURCE] Failed to load group ids: %s", e)
 
-        # Stream detail (name, account) keyed by id — listed once.
-        try:
-            detail_by_id = {s.id: s for s in client.m3u.list_streams()}
-        except Exception as e:
-            logger.warning("[CHANNEL_SOURCE] Failed to list streams: %s", e)
-            detail_by_id = {}
-
         # DP channel group id -> name (#379). The channels API returns only
         # channel_group_id; the name (which dispatcharr_group ordering rules
         # match on, and which the rule-builder dropdown shows) lives in the
@@ -239,10 +230,11 @@ class StreamFetcher:
             logger.warning("[CHANNEL_SOURCE] Failed to list channel groups: %s", e)
             dp_group_names = {}
 
-        candidates: list[dict] = []
-        seen: set[int] = set()
+        # Pass 1: cheap eligibility from the channel map alone, so the stream
+        # detail lookup below covers only the streams that can become
+        # candidates — never the whole catalog (#647).
+        eligible: list[tuple[int, dict, dict, int | None]] = []
         skipped_teamarr = 0
-        skipped_overlap = 0
         skipped_group = 0
         for stream_id, ch in stream_channel_map.items():
             if ch.get("id") in managed_ids:
@@ -260,6 +252,22 @@ class StreamFetcher:
                 continue
             if active_source_ids is not None and ed.get("epg_source") not in active_source_ids:
                 continue
+            eligible.append((stream_id, ch, ed, dp_group_id))
+
+        # Stream detail (name, M3U group, account, staleness) for just those ids.
+        detail_by_id: dict[int, Any] = {}
+        if eligible:
+            try:
+                detail_by_id = {
+                    s.id: s for s in client.m3u.get_streams_by_ids(sid for sid, *_ in eligible)
+                }
+            except Exception as e:
+                logger.warning("[CHANNEL_SOURCE] Failed to fetch stream details: %s", e)
+
+        candidates: list[dict] = []
+        seen: set[int] = set()
+        skipped_overlap = 0
+        for stream_id, ch, ed, dp_group_id in eligible:
             if stream_id in seen:
                 continue
             detail = detail_by_id.get(stream_id)

--- a/teamarr/dispatcharr/managers/m3u.py
+++ b/teamarr/dispatcharr/managers/m3u.py
@@ -6,6 +6,7 @@ Handles M3U account listing, stream discovery, and refresh operations.
 import logging
 import time
 import urllib.parse
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from teamarr.dispatcharr.client import DispatcharrClient
@@ -24,6 +25,8 @@ logger = logging.getLogger(__name__)
 # purpose: Dispatcharr is a single Django app, frequently on the same host, so
 # the goal is to remove the serial round-trip cost, not to saturate it.
 _MAX_PAGE_WORKERS = 8
+# ids per ``?ids=`` request — ~8 chars each keeps the URL well under 2 KB.
+_IDS_CHUNK_SIZE = 200
 
 
 def _fix_double_encoded_utf8(text: str) -> str:
@@ -311,11 +314,7 @@ class M3UManager:
         else:
             raw_streams.extend(first.get("results", []))
             total = first.get("count")
-            pages = (
-                -(-total // page_size)
-                if isinstance(total, int) and page_size > 0
-                else None
-            )
+            pages = -(-total // page_size) if isinstance(total, int) and page_size > 0 else None
 
             if limit is not None or pages is None:
                 # A caller with a limit wants to stop early, and a response with
@@ -334,10 +333,7 @@ class M3UManager:
                 with ThreadPoolExecutor(
                     max_workers=workers, thread_name_prefix="m3u-page"
                 ) as executor:
-                    futures = {
-                        executor.submit(fetch, page_url(n)): n
-                        for n in range(2, pages + 1)
-                    }
+                    futures = {executor.submit(fetch, page_url(n)): n for n in range(2, pages + 1)}
                     for future in as_completed(futures):
                         page = futures[future]
                         try:
@@ -358,9 +354,7 @@ class M3UManager:
                             )
                             executor.shutdown(wait=False, cancel_futures=True)
                             return []
-                        by_page[page] = (
-                            data.get("results", []) if isinstance(data, dict) else data
-                        )
+                        by_page[page] = data.get("results", []) if isinstance(data, dict) else data
                         if isinstance(data, dict) and page == pages:
                             last = data
 
@@ -399,6 +393,44 @@ class M3UManager:
                 len(streams),
             )
 
+        return streams
+
+    def get_streams_by_ids(
+        self,
+        stream_ids: Iterable[int],
+        chunk_size: int = _IDS_CHUNK_SIZE,
+    ) -> list[DispatcharrStream]:
+        """Fetch specific streams by id via ``/api/channels/streams/?ids=``.
+
+        Dispatcharr answers an ``ids`` filter with an unpaginated list, so a
+        few hundred streams cost a handful of requests instead of a walk over
+        the whole catalog (#647: 119 pages / 118k streams on a real install to
+        look up ~500). Ids are sent in chunks to keep URLs short. A failed
+        chunk is logged and skipped — callers treat a missing detail as "use
+        what the channel already tells us", so partial is strictly better
+        than nothing here.
+        """
+        ids = sorted({int(i) for i in stream_ids})
+        if not ids:
+            return []
+        streams: list[DispatcharrStream] = []
+        for start in range(0, len(ids), chunk_size):
+            chunk = ids[start : start + chunk_size]
+            url = "/api/channels/streams/?ids=" + ",".join(map(str, chunk))
+            response = self._client.get(url)
+            if response is None or response.status_code != 200:
+                logger.warning(
+                    "[M3U] Failed to fetch %d stream(s) by id: %s",
+                    len(chunk),
+                    response.status_code if response else "No response",
+                )
+                continue
+            data = response.json()
+            raw_list = data.get("results", []) if isinstance(data, dict) else data
+            for raw in raw_list:
+                if "name" in raw:
+                    raw["name"] = _fix_double_encoded_utf8(raw["name"])
+                streams.append(DispatcharrStream.from_api(raw))
         return streams
 
     def get_group_with_streams(

--- a/tests/lifecycle/test_channel_source.py
+++ b/tests/lifecycle/test_channel_source.py
@@ -59,7 +59,10 @@ def _make_processor(
             get_epg_data_list=lambda: epg_data_list,
         ),
         m3u=SimpleNamespace(
-            list_streams=lambda: streams,
+            # Detail lookup is by id (#647) — the full catalog is never listed.
+            get_streams_by_ids=lambda ids: [
+                s for s in streams if s.id in {int(i) for i in ids}
+            ],
             # Real channels API has no channel_group_name; names come from here (#379).
             list_groups=lambda: dp_groups or [],
         ),

--- a/tests/test_m3u_streams_by_ids.py
+++ b/tests/test_m3u_streams_by_ids.py
@@ -1,0 +1,47 @@
+"""``M3UManager.get_streams_by_ids`` (#647): chunked ``?ids=`` lookups.
+
+The channel-source builder needs details for a few hundred specific streams;
+walking the whole catalog (119 pages on a real install) for that was the
+single most expensive fetch of a generation.
+"""
+
+from types import SimpleNamespace
+
+from teamarr.dispatcharr.managers.m3u import M3UManager
+
+
+class _Client:
+    def __init__(self, fail_urls=()):
+        self.urls: list[str] = []
+        self.fail_urls = set(fail_urls)
+
+    def get(self, url):
+        self.urls.append(url)
+        if url in self.fail_urls:
+            return SimpleNamespace(status_code=500, json=lambda: None)
+        ids = [int(i) for i in url.split("ids=")[1].split(",")]
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: [{"id": i, "name": f"s{i}", "url": "u", "is_stale": False} for i in ids],
+        )
+
+
+def test_chunks_dedupes_and_parses():
+    client = _Client()
+    streams = M3UManager(client).get_streams_by_ids([5, 3, 3, 1, 4, 2], chunk_size=2)
+    assert [s.id for s in streams] == [1, 2, 3, 4, 5]
+    assert streams[0].name == "s1"
+    assert len(client.urls) == 3
+    assert client.urls[0] == "/api/channels/streams/?ids=1,2"
+
+
+def test_empty_input_makes_no_request():
+    client = _Client()
+    assert M3UManager(client).get_streams_by_ids([]) == []
+    assert client.urls == []
+
+
+def test_failed_chunk_is_skipped_not_fatal():
+    client = _Client(fail_urls={"/api/channels/streams/?ids=1,2"})
+    streams = M3UManager(client).get_streams_by_ids([1, 2, 3], chunk_size=2)
+    assert [s.id for s in streams] == [3]


### PR DESCRIPTION
`_fetch_channel_source_streams` called `m3u.list_streams()` unfiltered — every stream in Dispatcharr (119 pages / 118k streams on prod) — to look up details for the ~500 streams on in-scope curated channels. The user's channel-group scope was applied after that download, so it never reduced it.

Now a two-pass build: cheap eligibility from the channel map first (managed/scope/EPG filters), then `M3UManager.get_streams_by_ids` — chunked `/api/channels/streams/?ids=` lookups, which Dispatcharr answers unpaginated. Missing details keep today's fallback (channel name, no account).

Measured against prod Dispatcharr (reads only): 526 streams in **0.08s** vs **7.6s** in the last real run. No behavior change to candidates.

Closes #647 at release.