### PR TITLE
feat(media-servers): persist refresh outcomes, surface consecutive failures (#649)

### DIFF
--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -20,6 +20,7 @@ A read-only strip across the top shows system health at a glance:
 | **Last generated** | When the last run finished (relative time) and its duration, color-coded by staleness: green under a day, amber 1–3 days, red over 3 days or failed. Shows *Generating…* with a spinner during an active run, and a muted "Never generated" before the first run |
 | **Managed channels** | Active Teamarr channel count recorded by the last generation run |
 | **Matched** | Overall stream match rate, color-coded (only shown when match data exists) |
+| **Media servers** | Appears only when a configured Emby, Jellyfin, or Channels DVR server has failed its post-generation refresh on three or more consecutive runs. Hover for the server, failure count, and last error. A single miss stays quiet — this catches a server that has quietly stopped refreshing (a moved host, an expired key) |
 | **EPG URL** | The XMLTV URL with a one-click **Copy** button — this is where you grab the URL for Dispatcharr |
 
 {: .note }

--- a/docs/guide/settings/media-servers.md
+++ b/docs/guide/settings/media-servers.md
@@ -23,6 +23,8 @@ The refresh triggers the server's own **Refresh Guide** scheduled task and waits
 
 Saved secrets display as `********` — leave them as-is to keep the stored value, or type over them to replace.
 
+A failed refresh never fails the generation — but it is recorded. Each run stores every server's outcome (success, duration, error) with its run stats, and once a server has failed three consecutive runs the Dashboard status strip shows a **Media servers … not refreshing** warning (hover for the error) and the support bundle raises a `media_server_refresh_failing` signal. If you see it, check the URL first: a server that moved hosts fails instantly on every run and is otherwise invisible.
+
 ## Channels DVR
 
 Channels DVR splits channel-list and guide data into two providers, so Teamarr refreshes both — sequenced, each step confirmed against the server's log before the next:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -132,5 +132,7 @@ docker exec teamarr cat data/logs/teamarr.log | tail -100  # Log file
 
 Use **Support bundle** in the footer to download a redacted diagnostic ZIP. Attach the ZIP to a support request instead of a database backup. It includes configuration, source and subscription diagnostics, the matching library (aliases, detection and exception keywords, condition presets, persistent corrections, and source-template mappings), recent run and match details, managed-channel ordering evidence, and bounded log excerpts. Stream URLs, M3U account names, passwords, API keys, tokens, template bodies, XMLTV, and provider caches are excluded.
 
+The report opens with automatic **signals** — things worth checking before reading further: Dispatcharr disabled, no enabled sources, active teams without a template, the latest generation not completing, a media server whose refresh has failed on consecutive runs (`media_server_refresh_failing`, with the server and last error as evidence), and no managed channels stored.
+
 - **GitHub Issues**: [github.com/Pharaoh-Labs/teamarr/issues](https://github.com/Pharaoh-Labs/teamarr/issues)
 - **Discord**: Join the Dispatcharr Discord server — there's a Teamarr channel

--- a/frontend/src/api/epg.ts
+++ b/frontend/src/api/epg.ts
@@ -35,6 +35,17 @@ export interface StatsResponse {
   by_type: Record<string, number>
   avg_duration_ms: number
   last_run: string | null
+  media_server_health?: MediaServerHealth[]
+}
+
+/** Per-server refresh health over recent runs (#649). */
+export interface MediaServerHealth {
+  kind: string
+  server: string
+  consecutive_failures: number
+  last_error: string | null
+  last_success_at: string | null
+  failing: boolean
 }
 
 export interface ProcessingRun {

--- a/frontend/src/components/StatusStrip.tsx
+++ b/frontend/src/components/StatusStrip.tsx
@@ -6,7 +6,7 @@ import { useMatchRate, matchRateColor } from "@/hooks/useMatchRate"
 import { useDateFormat } from "@/hooks/useDateFormat"
 import { useGenerationProgress } from "@/hooks/useGenerationProgress"
 import { getTeamXmltvUrl } from "@/api/epg"
-import type { ProcessingRun } from "@/api/epg"
+import type { MediaServerHealth, ProcessingRun } from "@/api/epg"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -30,7 +30,13 @@ function formatDuration(ms: number | null | undefined): string | null {
  * a copy button for the XMLTV URL. No chip navigation — the lone control is the
  * URL copy.
  */
-export function StatusStrip({ lastRun }: { lastRun?: ProcessingRun }) {
+export function StatusStrip({
+  lastRun,
+  mediaServers,
+}: {
+  lastRun?: ProcessingRun
+  mediaServers?: MediaServerHealth[]
+}) {
   const dispatcharr = useDispatcharrStatus()
   const matchRate = useMatchRate()
   const { formatRelativeTime } = useDateFormat()
@@ -111,6 +117,13 @@ export function StatusStrip({ lastRun }: { lastRun?: ProcessingRun }) {
     GenIcon = CircleCheckBig
   }
 
+  // --- Media servers chip (#649): only when a server has failed on
+  // consecutive runs — a single miss is noise, three hours of misses is not.
+  const failingServers = (mediaServers ?? []).filter((s) => s.failing)
+  const mediaTitle = failingServers
+    .map((s) => `${s.server} (${s.kind}): ${s.consecutive_failures} failed runs${s.last_error ? ` — ${s.last_error}` : ""}`)
+    .join("\n")
+
   const genWhen = finishedAt ? formatRelativeTime(finishedAt) : "Never generated"
   const genDuration = formatDuration(lastRun?.duration_ms)
   const liveChannels = lastRun?.channels?.active
@@ -166,6 +179,19 @@ export function StatusStrip({ lastRun }: { lastRun?: ProcessingRun }) {
               <span className={`font-medium ${matchRateColor(matchRate.rate)}`}>{matchRate.rate}%</span>
             )}
             <span className="text-muted-foreground">matched</span>
+          </div>
+        </>
+      )}
+
+      {failingServers.length > 0 && (
+        <>
+          <span className="hidden h-4 w-px bg-border sm:inline-block" />
+          <div className="flex items-center gap-2" title={mediaTitle}>
+            <TriangleAlert className="h-4 w-4 text-red-500" />
+            <span className="text-muted-foreground">Media servers</span>
+            <span className="font-medium text-red-500">
+              {failingServers.length} not refreshing
+            </span>
           </div>
         </>
       )}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -54,7 +54,7 @@ export function Dashboard() {
       </div>
 
       {/* Status strip — at-a-glance system health */}
-      <StatusStrip lastRun={runs[0]} />
+      <StatusStrip lastRun={runs[0]} mediaServers={stats?.media_server_health} />
 
       {/* Generation History — full pipeline runs (matching, channels, EPG) */}
       {runs.length > 0 && (

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -74,6 +74,9 @@ class GenerationResult:
     jellyfin_refresh: dict = field(default_factory=dict)
     channelsdvr_refresh: dict = field(default_factory=dict)
     channelsdvr_epg_refresh: dict = field(default_factory=dict)
+    # One entry per media server refreshed this run (#649): persisted on the
+    # run row so a server that fails every run is visible after the fact.
+    media_server_outcomes: list[dict] = field(default_factory=list)
 
     # For stats run tracking
     run_id: int | None = None
@@ -489,6 +492,9 @@ def run_full_generation(
                 outcomes = _run_media_server_refreshes(
                     jobs, update_progress, is_cancellation_requested
                 )
+                result.media_server_outcomes = [
+                    _media_server_outcome(kind, label, o) for kind, label, o in outcomes
+                ]
 
                 emby_results = [
                     {"server": label, **o["guide"]}
@@ -671,6 +677,11 @@ def _dry_run_media_refresh(result: Any, jobs: list[tuple[str, Any]]) -> bool:
     for kind, urls in by_kind.items():
         logger.info("[DRY_RUN] Suppressed %s guide refresh for %s", kind, ", ".join(urls))
         payload = {"success": True, "dry_run": True, "servers": urls}
+        result.media_server_outcomes += [
+            {"kind": kind, "server": u, "success": True, "duration": 0.0, "error": None,
+             "dry_run": True}
+            for u in urls
+        ]
         if kind == "emby":
             result.emby_refresh = payload
         elif kind == "jellyfin":
@@ -724,6 +735,23 @@ def _run_media_server_refreshes(
                     (kind, label, {"guide": {"success": False, "error": str(e)}})
                 )
     return results
+
+
+def _media_server_outcome(kind: str, label: str, outcome: dict) -> dict:
+    """Flatten one server's refresh result for the run row (#649).
+
+    Channels DVR has two steps (m3u + epg); it counts as a success only when
+    both did, and reports the first error.
+    """
+    parts = [v for v in (outcome.get("guide"), outcome.get("m3u"), outcome.get("epg")) if v]
+    errors = [p.get("error") or p.get("message") for p in parts if not p.get("success")]
+    return {
+        "kind": kind,
+        "server": label,
+        "success": bool(parts) and all(p.get("success") for p in parts),
+        "duration": round(sum(float(p.get("duration") or 0) for p in parts), 2),
+        "error": errors[0] if errors else None,
+    }
 
 
 def _refresh_one_media_server(
@@ -1390,6 +1418,11 @@ def _finalize_stats_run(
 
     stats_run.extra_metrics["provider_calls"] = call_metrics.snapshot()
     stats_run.extra_metrics["provider_calls_total"] = call_metrics.total()
+
+    # Media-server refresh outcomes (#649): non-blocking failures otherwise
+    # leave no trace beyond a phase timing collapsing to ~0.
+    if result.media_server_outcomes:
+        stats_run.extra_metrics["media_servers"] = list(result.media_server_outcomes)
 
     # Per-phase wall time so run-to-run comparisons (and perf regressions)
     # are visible in the run summary instead of requiring log archaeology.

--- a/teamarr/database/stats.py
+++ b/teamarr/database/stats.py
@@ -476,7 +476,63 @@ def get_current_stats(conn: Connection) -> dict:
         # Average over the retention window only (folded runs keep no durations)
         "avg_duration_ms": int(overall["avg_duration"] or 0),
         "last_run": last_run,
+        "media_server_health": get_media_server_health(conn),
     }
+
+
+# Consecutive failed refreshes before a media server is reported as failing.
+# Hourly runs -> three hours of failures; one transient miss stays quiet.
+MEDIA_SERVER_FAILING_THRESHOLD = 3
+MEDIA_SERVER_HEALTH_LOOKBACK = 10
+
+
+def media_server_health(
+    runs: list[dict], threshold: int = MEDIA_SERVER_FAILING_THRESHOLD
+) -> list[dict]:
+    """Per-server refresh health from run dicts, newest first (#649).
+
+    Each run's ``extra_metrics.media_servers`` holds one outcome per server
+    (see generation._media_server_outcome). A server is ``failing`` once it
+    has failed ``threshold`` consecutive runs counted from the newest run it
+    appears in. Servers absent from the newest run (disabled/removed) are
+    not reported.
+    """
+    latest_seen: dict[tuple[str, str], dict] = {}
+    for run in runs:
+        for o in (run.get("extra_metrics") or {}).get("media_servers") or []:
+            key = (o.get("kind") or "", o.get("server") or "")
+            state = latest_seen.get(key)
+            if state is None:
+                state = latest_seen[key] = {
+                    "kind": key[0],
+                    "server": key[1],
+                    "consecutive_failures": 0,
+                    "last_error": None,
+                    "last_success_at": None,
+                    "_streak_open": True,
+                }
+            if o.get("success"):
+                state["_streak_open"] = False
+                if state["last_success_at"] is None:
+                    state["last_success_at"] = run.get("completed_at") or run.get("started_at")
+            elif state["_streak_open"]:
+                state["consecutive_failures"] += 1
+                if state["last_error"] is None:
+                    state["last_error"] = o.get("error")
+    result = []
+    for state in latest_seen.values():
+        state.pop("_streak_open")
+        state["failing"] = state["consecutive_failures"] >= threshold
+        result.append(state)
+    return result
+
+
+def get_media_server_health(
+    conn: Connection, lookback: int = MEDIA_SERVER_HEALTH_LOOKBACK
+) -> list[dict]:
+    """``media_server_health`` over the latest full_epg runs."""
+    runs = get_recent_runs(conn, limit=lookback, run_type="full_epg")
+    return media_server_health([r.to_dict() for r in runs])
 
 
 def _fold_runs_into_lifetime(conn: Connection, where: str = "", params: tuple = ()) -> None:

--- a/teamarr/services/support_bundle.py
+++ b/teamarr/services/support_bundle.py
@@ -15,7 +15,12 @@ from typing import Any
 from teamarr.config import BASE_VERSION
 from teamarr.database.channels.types import ManagedChannelStream
 from teamarr.database.connection import get_connection
-from teamarr.database.stats import get_failed_matches, get_matched_streams, get_recent_runs
+from teamarr.database.stats import (
+    get_failed_matches,
+    get_matched_streams,
+    get_recent_runs,
+    media_server_health,
+)
 from teamarr.services.stream_ordering import get_stream_ordering_service
 from teamarr.utilities.logging import _get_log_dir
 
@@ -342,6 +347,26 @@ class SupportBundleService:
                     "severity": "warning",
                     "message": "The latest generation did not complete.",
                     "evidence": {"run_id": runs[0].get("id"), "status": runs[0].get("status")},
+                }
+            )
+        failing = [s for s in media_server_health(runs) if s["failing"]]
+        if failing:
+            signals.append(
+                {
+                    "code": "media_server_refresh_failing",
+                    "severity": "warning",
+                    "message": "A media server's guide refresh has failed on consecutive runs.",
+                    "evidence": {
+                        "servers": [
+                            {
+                                "kind": s["kind"],
+                                "server": s["server"],
+                                "consecutive_failures": s["consecutive_failures"],
+                                "last_error": s["last_error"],
+                            }
+                            for s in failing
+                        ]
+                    },
                 }
             )
         if not channels.get("total"):

--- a/tests/test_media_server_health.py
+++ b/tests/test_media_server_health.py
@@ -1,0 +1,105 @@
+"""Media-server refresh outcomes are persisted and repeated failures surfaced (#649).
+
+A down/moved media server never fails a generation (by design), which is why
+prod's Emby + Channels DVR pointed at a decommissioned host for three weeks
+unnoticed. Outcomes now live on the run row; the health helper turns them
+into a per-server "failing" flag after consecutive misses.
+"""
+
+from teamarr.consumers.generation import _media_server_outcome
+from teamarr.database.stats import (
+    create_run,
+    get_current_stats,
+    get_media_server_health,
+    media_server_health,
+    save_run,
+)
+
+
+def _run(*outcomes, completed="2026-08-29T13:00:00+00:00"):
+    return {"completed_at": completed, "extra_metrics": {"media_servers": list(outcomes)}}
+
+
+def _o(server, ok, kind="emby", error=None):
+    return {"kind": kind, "server": server, "success": ok, "duration": 0.0, "error": error}
+
+
+# ---------------------------------------------------------------------------
+# _media_server_outcome — flattening one server's refresh result
+# ---------------------------------------------------------------------------
+
+
+def test_emby_outcome_flattens_guide_result():
+    o = _media_server_outcome("emby", "Emby", {"guide": {"success": False, "error": "refused"}})
+    assert o == {
+        "kind": "emby", "server": "Emby", "success": False, "duration": 0.0, "error": "refused",
+    }
+
+
+def test_channelsdvr_outcome_needs_both_steps():
+    ok = {"m3u": {"success": True, "duration": 1.5}, "epg": {"success": True, "duration": 2.0}}
+    assert _media_server_outcome("channelsdvr", "C", ok)["success"] is True
+    assert _media_server_outcome("channelsdvr", "C", ok)["duration"] == 3.5
+    half = {"m3u": {"success": True}, "epg": {"success": False, "message": "timed out"}}
+    o = _media_server_outcome("channelsdvr", "C", half)
+    assert o["success"] is False and o["error"] == "timed out"
+
+
+# ---------------------------------------------------------------------------
+# media_server_health — consecutive failures from newest run backwards
+# ---------------------------------------------------------------------------
+
+
+def test_consecutive_failures_counted_from_newest():
+    runs = [  # newest first
+        _run(_o("Emby", False, error="refused"), completed="t3"),
+        _run(_o("Emby", False, error="refused"), completed="t2"),
+        _run(_o("Emby", False, error="refused"), completed="t1"),
+        _run(_o("Emby", True), completed="t0"),
+    ]
+    [h] = media_server_health(runs)
+    assert h["consecutive_failures"] == 3
+    assert h["failing"] is True
+    assert h["last_error"] == "refused"
+    assert h["last_success_at"] == "t0"
+
+
+def test_a_success_breaks_the_streak():
+    runs = [_run(_o("Emby", False)), _run(_o("Emby", True)), _run(_o("Emby", False))]
+    [h] = media_server_health(runs)
+    assert h["consecutive_failures"] == 1
+    assert h["failing"] is False
+
+
+def test_threshold_and_per_server_independence():
+    runs = [_run(_o("A", False), _o("B", True, kind="channelsdvr"))] * 3
+    by = {h["server"]: h for h in media_server_health(runs)}
+    assert by["A"]["failing"] is True and by["B"]["failing"] is False
+    assert media_server_health(runs, threshold=4)[0]["failing"] is False
+
+
+def test_runs_without_outcomes_are_ignored():
+    assert media_server_health([{"extra_metrics": {}}, {}]) == []
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip through processing_runs
+# ---------------------------------------------------------------------------
+
+
+def test_health_reads_persisted_run_rows(db_conn):
+    for hour in range(3):
+        run = create_run(db_conn, run_type="full_epg")
+        run.extra_metrics["media_servers"] = [_o("Emby", False, error="connection refused")]
+        save_run(db_conn, run)
+        # get_recent_runs collapses full runs that started in the same minute
+        # (parallel-process guard); real runs are an hour apart.
+        db_conn.execute(
+            "UPDATE processing_runs SET started_at = ? WHERE id = ?",
+            (f"2026-08-29 {10 + hour:02d}:00:00", run.id),
+        )
+    db_conn.commit()
+
+    [h] = get_media_server_health(db_conn)
+    assert h["failing"] is True and h["last_error"] == "connection refused"
+    assert get_current_stats(db_conn)["media_server_health"][0]["server"] == "Emby"

--- a/tests/test_runtime_flags.py
+++ b/tests/test_runtime_flags.py
@@ -124,7 +124,8 @@ def test_dry_run_media_refresh_records_and_skips(monkeypatch):
 
     monkeypatch.setenv("DRY_RUN", "true")
     result = SimpleNamespace(
-        emby_refresh={}, jellyfin_refresh={}, channelsdvr_refresh={}, channelsdvr_epg_refresh={}
+        emby_refresh={}, jellyfin_refresh={}, channelsdvr_refresh={}, channelsdvr_epg_refresh={},
+        media_server_outcomes=[],
     )
     jobs = [
         ("emby", SimpleNamespace(url="http://emby:8096")),
@@ -134,6 +135,11 @@ def test_dry_run_media_refresh_records_and_skips(monkeypatch):
     assert result.emby_refresh == {
         "success": True, "dry_run": True, "servers": ["http://emby:8096"],
     }
+    # Suppressed refreshes are still recorded as (dry-run) successes (#649),
+    # so a dev instance never trips the consecutive-failure signal.
+    assert [(o["kind"], o["success"], o["dry_run"]) for o in result.media_server_outcomes] == [
+        ("emby", True, True), ("channelsdvr", True, True),
+    ]
     assert result.channelsdvr_refresh["dry_run"] is True
     assert result.channelsdvr_epg_refresh["dry_run"] is True
     assert result.jellyfin_refresh == {}

--- a/tests/test_support_bundle.py
+++ b/tests/test_support_bundle.py
@@ -54,3 +54,29 @@ def test_bundle_contains_contract_and_redacts_source_data(db_path, tmp_path):
     assert "https://stream.example/live" not in contents
     assert "sb_publishable_abcdef" not in contents
     assert "secret@example.test" not in contents
+
+
+def test_bundle_signals_media_server_failing(db_path, tmp_path):
+    from teamarr.database.stats import create_run, save_run
+
+    with get_connection(db_path) as conn:
+        for _ in range(3):
+            run = create_run(conn, run_type="full_epg")
+            run.extra_metrics["media_servers"] = [
+                {"kind": "emby", "server": "Emby", "success": False, "duration": 0.02,
+                 "error": "connection refused"}
+            ]
+            run.complete()
+            save_run(conn, run)
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    bundle = SupportBundleService(db_path, logs).create()
+    with zipfile.ZipFile(BytesIO(bundle)) as archive:
+        report = json.loads(archive.read("support-report.json"))
+        guide = archive.read("AGENTS.md").decode()
+
+    [signal] = [s for s in report["signals"] if s["code"] == "media_server_refresh_failing"]
+    assert signal["severity"] == "warning"
+    assert signal["evidence"]["servers"][0]["consecutive_failures"] == 3
+    assert "media_server_refresh_failing" in guide


### PR DESCRIPTION
A failed media-server refresh is non-blocking by design (right call — a down Emby must not fail a generation), but nothing persisted or surfaced it. Prod's Emby and Channels DVR targets pointed at a decommissioned host for ~3 weeks; the only symptom was `media_server_refresh` dropping from 30s to 0.02s.

- Every run stores each server's outcome (`kind`, `server`, `success`, `duration`, `error`) in `extra_metrics.media_servers`. Dry-run records suppressed refreshes as successes so dev never trips the signal.
- `stats.media_server_health()` marks a server `failing` after 3 consecutive failed runs (newest-first streak); exposed on `GET /stats` as `media_server_health`, computed from the last 10 full runs — no new state or endpoint.
- Dashboard status strip: a red **Media servers: N not refreshing** chip appears only while a server is failing; hover shows server, streak, last error.
- Support bundle: new `media_server_refresh_failing` warning signal with evidence (guide lists it automatically).
- Docs: dashboard strip row, media-servers page, troubleshooting signals list.

Closes #649 at release.