### PR TITLE
fix(matching): trim pipe metadata from team names, stop apostrophes splitting them (#652, #653)

### DIFF
--- a/teamarr/consumers/matching/classifier.py
+++ b/teamarr/consumers/matching/classifier.py
@@ -1022,7 +1022,9 @@ def _clean_team_name(name: str) -> str:
     name = re.sub(round_pattern, "", name, flags=re.IGNORECASE | re.VERBOSE)
 
     # Handle "|" separator - preserve pipe content for fuzzy matching disambiguation
-    # The matcher will try both sides of the pipe and pick the one that matches.
+    # The matcher trims to the leading segment as its last fallback tier
+    # (TeamMatcher._prepare_pipe_fallback, #652) — that code did not exist when
+    # this comment was written, so the tail simply rode into the team name.
     # Here we only strip OBVIOUS prefix noise (league hints, channel numbers) from the
     # start, keeping the rest intact for the matcher to disambiguate.
     # "NFL | Bills vs Broncos" → "Bills vs Broncos" (NFL is league hint)

--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -273,19 +273,6 @@ DATE_PATTERNS = [
     (rf"\b(\d{{1,2}})(?:st|nd|rd|th)?\s+(?:{_MONTH_NAMES})\b", "DATE_MASK"),
     # Dec 31, December 31 - use negative lookahead (?!:) to avoid matching "Jan 11:45pm"
     (rf"\b(?:{_MONTH_NAMES})\s+(\d{{1,2}})(?:st|nd|rd|th)?(?!:)\b", "DATE_MASK"),
-    # 8.29, 08.29 (M.DD without year) — dot-separated dates (#652). Deliberately
-    # LAST: masking happens whether or not the date parses, so a greedy pattern
-    # here would eat text the forms above read correctly, and the loop breaks on
-    # first match.
-    #
-    # Tightly bounded, because a dot between digits is usually NOT a date.
-    # Measured over 1036 dot-numbers in real stream names: 1020 had a two-digit
-    # day and every one was a date (08.27, 8.29); the one-digit-day cases were
-    # noise ("5.1"), and "17.45"/"10.30" were TIMES written with a dot. So the
-    # month is bounded 1-12 (killing 13.4 and 17.45), the day must be two digits
-    # 01-31 (killing 5.1 and decimal spreads like "2.5"), and an am/pm suffix
-    # vetoes the read so "10.30pm" stays a time.
-    (r"\b(1[0-2]|0?[1-9])\.(3[01]|[12]\d|0[1-9])\b(?!\s*[ap]\.?m)", "DATE_MASK_NO_YEAR"),
 ]
 
 # Time patterns to extract and mask (with optional TZ suffix)

--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -273,6 +273,19 @@ DATE_PATTERNS = [
     (rf"\b(\d{{1,2}})(?:st|nd|rd|th)?\s+(?:{_MONTH_NAMES})\b", "DATE_MASK"),
     # Dec 31, December 31 - use negative lookahead (?!:) to avoid matching "Jan 11:45pm"
     (rf"\b(?:{_MONTH_NAMES})\s+(\d{{1,2}})(?:st|nd|rd|th)?(?!:)\b", "DATE_MASK"),
+    # 8.29, 08.29 (M.DD without year) — dot-separated dates (#652). Deliberately
+    # LAST: masking happens whether or not the date parses, so a greedy pattern
+    # here would eat text the forms above read correctly, and the loop breaks on
+    # first match.
+    #
+    # Tightly bounded, because a dot between digits is usually NOT a date.
+    # Measured over 1036 dot-numbers in real stream names: 1020 had a two-digit
+    # day and every one was a date (08.27, 8.29); the one-digit-day cases were
+    # noise ("5.1"), and "17.45"/"10.30" were TIMES written with a dot. So the
+    # month is bounded 1-12 (killing 13.4 and 17.45), the day must be two digits
+    # 01-31 (killing 5.1 and decimal spreads like "2.5"), and an am/pm suffix
+    # vetoes the read so "10.30pm" stays a time.
+    (r"\b(1[0-2]|0?[1-9])\.(3[01]|[12]\d|0[1-9])\b(?!\s*[ap]\.?m)", "DATE_MASK_NO_YEAR"),
 ]
 
 # Time patterns to extract and mask (with optional TZ suffix)
@@ -734,6 +747,19 @@ def normalize_for_matching(text: str) -> str:
     # These appear in streams like "MIL Bucks ( ESPN Feed )"
     for network in BROADCAST_NETWORKS:
         text = re.sub(rf"\b{re.escape(network.lower())}\b", " ", text)
+
+    # Remove apostrophes/backticks WITHOUT adding a space, exactly as
+    # normalize_text does (#653). These two normalizers run in sequence —
+    # _match_against_events calls this one, then _score_teams_against_event
+    # calls normalize_text on the result — so a disagreement here is
+    # unrecoverable downstream. Turning the apostrophe into a space split
+    # "Hawai'i" into "hawai i", which shares no token with "hawaii rainbow
+    # warriors": 46.7 against the 100.0 a single normalizer scores, below
+    # BOTH_TEAMS_THRESHOLD, so the whole event was rejected. Same for
+    # "American Int'l" and "G'town Col". unidecode has already run via
+    # apply_city_translations, so a curly ’ is a plain \x27 by now.
+    # Hex escapes avoid source-encoding ambiguity: \x27=apostrophe, \x60=backtick.
+    text = re.sub("[\x27\x60]", "", text)
 
     # Remove punctuation except spaces (hyphens become spaces for matching)
     text = re.sub(r"[^\w\s]", " ", text)

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -1138,6 +1138,9 @@ class TeamMatcher:
         fallback_t1, fallback_t2, has_stripped_fallback = self._prepare_stripped_fallback(
             ctx.team1, ctx.team2, team1_normalized, team2_normalized
         )
+        pipe_t1, pipe_t2, has_pipe_fallback = self._prepare_pipe_fallback(
+            ctx.team1, ctx.team2, team1_normalized, team2_normalized
+        )
 
         # Check if we have date validation from the stream
         has_date_validation = ctx.classified.normalized.extracted_date is not None
@@ -1225,6 +1228,13 @@ class TeamMatcher:
             if not match_result and has_stripped_fallback:
                 match_result = self._match_teams_to_event(
                     fallback_t1, fallback_t2, event, has_date_validation
+                )
+
+            # Fallback: retry with pipe metadata trimmed (#652). Last tier, so
+            # a name that matches intact never reaches it.
+            if not match_result and has_pipe_fallback:
+                match_result = self._match_teams_to_event(
+                    pipe_t1, pipe_t2, event, has_date_validation
                 )
 
             # Trusted-date gate (#474), applied AFTER team scoring (#480):
@@ -1382,6 +1392,9 @@ class TeamMatcher:
         fallback_t1, fallback_t2, has_stripped_fallback = self._prepare_stripped_fallback(
             ctx.team1, ctx.team2, team1_normalized, team2_normalized
         )
+        pipe_t1, pipe_t2, has_pipe_fallback = self._prepare_pipe_fallback(
+            ctx.team1, ctx.team2, team1_normalized, team2_normalized
+        )
 
         # Check if we have date validation from the stream
         has_date_validation = ctx.classified.normalized.extracted_date is not None
@@ -1475,6 +1488,13 @@ class TeamMatcher:
             if not match_result and has_stripped_fallback:
                 match_result = self._match_teams_to_event(
                     fallback_t1, fallback_t2, event, has_date_validation
+                )
+
+            # Fallback: retry with pipe metadata trimmed (#652). Last tier, so
+            # a name that matches intact never reaches it.
+            if not match_result and has_pipe_fallback:
+                match_result = self._match_teams_to_event(
+                    pipe_t1, pipe_t2, event, has_date_validation
                 )
 
             # Trusted-date gate (#474), applied AFTER team scoring (#480):
@@ -1802,6 +1822,61 @@ class TeamMatcher:
         has_fallback = fallback_t1 != norm_team1 or fallback_t2 != norm_team2
         return fallback_t1, fallback_t2, has_fallback
 
+    @staticmethod
+    def _leading_pipe_segment(name: str) -> str:
+        """The text before the first "|", if it is substantial enough to be a team.
+
+        Minimum 3 chars matches extract_teams_from_separator's own floor — even
+        the shortest real abbreviations (USC, LSU, BYU) clear it.
+        """
+        head = name.split("|")[0].strip()
+        return head if len(head) >= 3 else name
+
+    def _prepare_pipe_fallback(
+        self,
+        raw_team1: str | None,
+        raw_team2: str | None,
+        norm_team1: str | None,
+        norm_team2: str | None,
+    ) -> tuple[str | None, str | None, bool]:
+        """Pre-compute pipe-trimmed team names for fallback matching (#652).
+
+        `_clean_team_name` deliberately keeps pipe content, on the stated
+        expectation that "the matcher will try both sides of the pipe and pick
+        the one that matches". No such code existed: this method is it. The
+        counter-claim that token_set_ratio handles pipes "naturally" is false —
+        the extra tokens are scored against the team, and they cost more than
+        the threshold allows:
+
+            "WAGNER | 8.29 | NEC FRONT ROW"  vs "Wagner Seahawks"  = 57.1
+            "WAGNER"                         vs "Wagner Seahawks"  = 100.0
+
+        with BOTH_TEAMS_THRESHOLD at 60. Streams that do match this shape today
+        do so by luck — "UNLV | 8.29 | FOX" survives only via the abbreviation
+        path, and "VIRGINIA | 8.29 | ESPN" clears the floor by 1.5 points.
+
+        Split from the RAW names for the same reason the parenthetical fallback
+        does: normalize_for_matching drops "|" as punctuation, so the boundary
+        is already gone by the time we hold the normalized form.
+
+        Only the LEADING segment is taken. By this point the classifier has
+        already moved any prefix noise (league hint, sport, provider, bare
+        datetime) to the back, so what remains before the first pipe is the
+        team and what follows is date/time/channel metadata. Trying every
+        segment instead would let a venue or network name score as a team.
+        """
+        fallback_t1 = norm_team1
+        fallback_t2 = norm_team2
+
+        if raw_team1 and "|" in raw_team1:
+            fallback_t1 = normalize_for_matching(self._leading_pipe_segment(raw_team1))
+
+        if raw_team2 and "|" in raw_team2:
+            fallback_t2 = normalize_for_matching(self._leading_pipe_segment(raw_team2))
+
+        has_fallback = fallback_t1 != norm_team1 or fallback_t2 != norm_team2
+        return fallback_t1, fallback_t2, has_fallback
+
     def _score_teams_against_event(
         self,
         team1: str | None,
@@ -1824,9 +1899,13 @@ class TeamMatcher:
         home_normalized = normalize_text(event.home_team.name)
         away_normalized = normalize_text(event.away_team.name)
 
-        # Note: Pipe-separated content (e.g., "Sacramento Kings | Golden 1 Center")
-        # is handled naturally by token_set_ratio which finds best token overlap.
-        # No explicit pipe resolution needed - "Sacramento Kings" tokens will match.
+        # Pipe-separated content is NOT handled here (#652). This function
+        # scores whatever it is given; token_set_ratio charges for the extra
+        # tokens rather than ignoring them ("WAGNER | 8.29 | NEC FRONT ROW"
+        # scores 57.1 against "Wagner Seahawks", under the 60 floor), so a
+        # short tail like "| Golden 1 Center" survives only by luck. The
+        # trimming lives in _prepare_pipe_fallback, tried as the last tier of
+        # the candidate loop so an intact name never reaches it.
 
         if team1 and team2:
             # BOTH teams extracted - require both to match different event teams

--- a/tests/matching/test_pipe_and_apostrophe.py
+++ b/tests/matching/test_pipe_and_apostrophe.py
@@ -1,0 +1,162 @@
+"""Team names survive pipe metadata and apostrophes (#652, #653).
+
+Two independent defects, both in the shared normalization path that every
+provider's streams pass through, and both found auditing NCAAF on 2026-08-29
+where they accounted for all 22 failures of one source.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from rapidfuzz import fuzz
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.normalizer import (
+    extract_and_mask_datetime,
+    normalize_for_matching,
+)
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.utilities.fuzzy_match import normalize_text
+
+
+def _team(team_id: str, name: str, league: str = "college-football") -> Team:
+    return Team(
+        id=team_id,
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation="",
+        league=league,
+        sport="football",
+    )
+
+
+def _event(away: str, home: str, league: str = "college-football") -> Event:
+    start = datetime.now(UTC) + timedelta(hours=3)
+    return Event(
+        id="1",
+        provider="espn",
+        name=f"{away} at {home}",
+        short_name=f"{away} at {home}",
+        league=league,
+        sport="football",
+        start_time=start,
+        home_team=_team("h", home),
+        away_team=_team("a", away),
+        status=EventStatus(state="scheduled"),
+    )
+
+
+class TestApostrophesSurviveNormalization:
+    """normalize_for_matching and normalize_text run in SEQUENCE, so a
+    disagreement between them is unrecoverable downstream (#653)."""
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Hawai'i", "American Int'l", "G'town Col", "O'Reilly", "Ha'a"],
+    )
+    def test_both_normalizers_agree(self, text):
+        assert normalize_for_matching(text) == normalize_text(text)
+
+    def test_apostrophe_does_not_split_the_token(self):
+        assert normalize_for_matching("Hawai'i") == "hawaii"
+
+    def test_curly_apostrophe_normalizes_the_same(self):
+        """unidecode runs first via apply_city_translations, so ’ is a
+        plain apostrophe by the time the strip happens."""
+        assert normalize_for_matching("Hawai’i") == normalize_for_matching("Hawai'i")
+
+    def test_score_against_the_real_team_is_restored(self):
+        """46.7 before the fix — under BOTH_TEAMS_THRESHOLD, so the whole
+        event was rejected despite a perfectly parsed stream."""
+        stream = normalize_text(normalize_for_matching("Hawai'i"))
+        assert fuzz.token_set_ratio(stream, normalize_text("Hawai'i Rainbow Warriors")) == 100.0
+
+
+class TestPipeMetadataIsTrimmed:
+    """`_clean_team_name` keeps pipe content expecting the matcher to resolve
+    it; no such code existed until #652."""
+
+    def test_classifier_still_hands_over_the_pipe_tail(self):
+        """The fix is in the matcher, not the classifier — asserted so the
+        fallback is not silently bypassed by a future classifier change."""
+        classified = classify_stream(
+            "NCAAF 002: ROBERT MORRIS AT WAGNER | 8.29 12:00PM | NEC FRONT ROW"
+        )
+        assert "|" in (classified.team2 or "")
+
+    def test_leading_segment_is_taken(self):
+        from teamarr.consumers.matching.team_matcher import TeamMatcher
+
+        assert TeamMatcher._leading_pipe_segment("WAGNER | 8.29 | NEC FRONT ROW") == "WAGNER"
+
+    def test_too_short_a_head_keeps_the_whole_name(self):
+        """Below the 3-char floor the head cannot be a team, so trimming it
+        would throw away the only real text."""
+        from teamarr.consumers.matching.team_matcher import TeamMatcher
+
+        assert TeamMatcher._leading_pipe_segment("A | Real Madrid") == "A | Real Madrid"
+
+    def test_pipe_fallback_recovers_the_match(self, db_factory):
+        from tests.fakes import make_team_matcher
+
+        matcher = make_team_matcher(db_factory=db_factory)
+        event = _event("Robert Morris Colonials", "Wagner Seahawks")
+        assert matcher._score_teams_against_event("ROBERT MORRIS", "WAGNER", event)
+        # The untrimmed form is what the matcher used to be handed, and it
+        # scores 57.1 against "Wagner Seahawks" — below the floor.
+        assert (
+            matcher._score_teams_against_event(
+                "ROBERT MORRIS", "WAGNER | 8.29 | NEC FRONT ROW", event
+            )
+            is None
+        )
+
+    def test_venue_suffix_still_matches_on_the_team(self):
+        """"Sacramento Kings | Golden 1 Center" — the leading segment is the
+        team here too, so the documented pass-through case is unaffected."""
+        from teamarr.consumers.matching.team_matcher import TeamMatcher
+
+        assert (
+            TeamMatcher._leading_pipe_segment("Sacramento Kings | Golden 1 Center")
+            == "Sacramento Kings"
+        )
+
+
+class TestDotSeparatedDates:
+    """`8.29` was neither extracted as a date nor removed from the team name."""
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [("Game | 8.29 7:00PM |", (8, 29)), ("Game | 08.27 7:00PM |", (8, 27))],
+    )
+    def test_dot_date_is_extracted(self, text, expected):
+        _, parsed, _, _ = extract_and_mask_datetime(text)
+        assert parsed is not None
+        assert (parsed.month, parsed.day) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Spread 2.5 over",  # one-digit day: a decimal, not a date
+            "Game 13.4 rating",  # month out of range
+            "Race at 17.45",  # 24h time written with a dot
+        ],
+    )
+    def test_non_dates_are_left_alone(self, text):
+        masked, parsed, _, _ = extract_and_mask_datetime(text)
+        assert parsed is None
+        assert "DATE_MASK" not in masked
+
+    def test_dot_time_with_meridiem_is_not_read_as_a_date(self):
+        """The am/pm lookahead is what stops this; how the time itself parses
+        is pre-existing behaviour and not asserted here."""
+        _, parsed, _, _ = extract_and_mask_datetime("Show at 10.30pm")
+        assert parsed is None
+
+    def test_slash_dates_still_win(self):
+        """The dot pattern is last, so the established forms are unaffected."""
+        _, parsed, _, _ = extract_and_mask_datetime("Event 12/31/25")
+        assert (parsed.year, parsed.month, parsed.day) == (2025, 12, 31)

--- a/tests/matching/test_pipe_and_apostrophe.py
+++ b/tests/matching/test_pipe_and_apostrophe.py
@@ -3,6 +3,13 @@
 Two independent defects, both in the shared normalization path that every
 provider's streams pass through, and both found auditing NCAAF on 2026-08-29
 where they accounted for all 22 failures of one source.
+
+A dot-separated date pattern (8.29) was proposed here and withdrawn: UK
+listings write kickoff times the same way, so "Arsenal v Chelsea 7.30" read as
+30 July. Built-in masks are extracted_date_trusted=True and the trusted-date
+gate rejects candidates more than a day out, which would have turned correct
+matches into DATE_MISMATCH. It was never load-bearing anyway -- with the date
+fully extracted, team2 still scores 57.1; the pipe fallback alone is the fix.
 """
 
 from __future__ import annotations
@@ -13,10 +20,7 @@ import pytest
 from rapidfuzz import fuzz
 
 from teamarr.consumers.matching.classifier import classify_stream
-from teamarr.consumers.matching.normalizer import (
-    extract_and_mask_datetime,
-    normalize_for_matching,
-)
+from teamarr.consumers.matching.normalizer import normalize_for_matching
 from teamarr.core.types import Event, EventStatus, Team
 from teamarr.utilities.fuzzy_match import normalize_text
 
@@ -123,40 +127,3 @@ class TestPipeMetadataIsTrimmed:
             TeamMatcher._leading_pipe_segment("Sacramento Kings | Golden 1 Center")
             == "Sacramento Kings"
         )
-
-
-class TestDotSeparatedDates:
-    """`8.29` was neither extracted as a date nor removed from the team name."""
-
-    @pytest.mark.parametrize(
-        "text,expected",
-        [("Game | 8.29 7:00PM |", (8, 29)), ("Game | 08.27 7:00PM |", (8, 27))],
-    )
-    def test_dot_date_is_extracted(self, text, expected):
-        _, parsed, _, _ = extract_and_mask_datetime(text)
-        assert parsed is not None
-        assert (parsed.month, parsed.day) == expected
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            "Spread 2.5 over",  # one-digit day: a decimal, not a date
-            "Game 13.4 rating",  # month out of range
-            "Race at 17.45",  # 24h time written with a dot
-        ],
-    )
-    def test_non_dates_are_left_alone(self, text):
-        masked, parsed, _, _ = extract_and_mask_datetime(text)
-        assert parsed is None
-        assert "DATE_MASK" not in masked
-
-    def test_dot_time_with_meridiem_is_not_read_as_a_date(self):
-        """The am/pm lookahead is what stops this; how the time itself parses
-        is pre-existing behaviour and not asserted here."""
-        _, parsed, _, _ = extract_and_mask_datetime("Show at 10.30pm")
-        assert parsed is None
-
-    def test_slash_dates_still_win(self):
-        """The dot pattern is last, so the established forms are unaffected."""
-        _, parsed, _, _ = extract_and_mask_datetime("Event 12/31/25")
-        assert (parsed.year, parsed.month, parsed.day) == (2025, 12, 31)


### PR DESCRIPTION
Closes #652 and #653. Two defects in the same shared normalization path, which is why they ship together — both were found auditing NCAAF on 2026-08-29, where between them they accounted for **all 22 failures** of one source.

## #652 — pipe metadata rides into the team name

Each side of the code believed the other handled this.

`classifier.py` deliberately preserves pipe content:

> preserve pipe content for fuzzy matching disambiguation.
> **The matcher will try both sides of the pipe and pick the one that matches.**

`team_matcher.py` asserted the opposite:

> is handled naturally by token_set_ratio which finds best token overlap.
> **No explicit pipe resolution needed.**

Neither was true. There was no pipe code anywhere in `team_matcher.py`, and `token_set_ratio` charges for the extra tokens rather than ignoring them:

```
"WAGNER | 8.29 | NEC FRONT ROW"          vs "Wagner Seahawks"   =  57.1
"WAGNER"                                 vs "Wagner Seahawks"   = 100.0
"TCU (IN DUBLIN, IRELAND) | 8.29 | ESPN" vs "TCU Horned Frogs"  =  38.3
```

with `BOTH_TEAMS_THRESHOLD` at 60. The streams that *did* match this shape were surviving on luck — `UNLV | 8.29 | FOX` only via the abbreviation path, `VIRGINIA | 8.29 | ESPN` clearing the floor by 1.5 points.

`_prepare_pipe_fallback` mirrors the existing parenthetical fallback and is wired into both candidate loops as the **last** tier, so a name that matches intact never reaches it. Only the **leading** segment is taken: by that point the classifier has already moved prefix noise (league hint, sport, provider, bare datetime) to the back, so what precedes the first pipe is the team and what follows is metadata. Trying every segment would let a venue or network name score as a team. Both stale comments are corrected.

### Dot-separated dates — proposed and withdrawn

A `MM.DD` pattern was in the first revision. Removed in review: UK listings write kickoff times the same way, so `Arsenal v Chelsea 7.30` read as 30 July. Built-in masks are `extracted_date_trusted=True` and the trusted-date gate hard-rejects candidates more than a day out, so it would have turned correct matches into `DATE_MISMATCH`. The two-digit-day rule was the worst possible filter, since `.30` and `.15` are the common minute values.

It was validated against a corpus of real failed matches that is US-feed dominated and contained no bare kickoff times — the wrong sample for a question about naming conventions.

## #653 — apostrophes split team names

The two normalizers disagree, and the matcher runs **both in sequence** — `_match_against_events` calls `normalize_for_matching`, then `_score_teams_against_event` calls `normalize_text` on the result — so the split is unrecoverable:

```python
normalize_for_matching("Hawai'i")  ->  'hawai i'   # [^\w\s] -> " "
normalize_text("Hawai'i")          ->  'hawaii'    # apostrophe deleted
```

```
'hawai i' vs 'hawaii rainbow warriors' =  46.7   <- what the matcher compared
'hawaii'  vs 'hawaii rainbow warriors' = 100.0
```

46.7 is under the floor, so the event was rejected despite a perfectly parsed stream — that matchup scored **100.0** on `_score_teams_against_event` called directly, yet returned `no_event_found` end to end. `normalize_for_matching` now deletes apostrophes and backticks before the punctuation rule, exactly as `normalize_text` does. unidecode has already run by then, so a curly apostrophe is covered.

## Measured

Against the 22 real failures of source 254 (verbatim from `epg_failed_matches`), replayed over the live ESPN slate:

**0/22 → 17/22.**

The other 5 are **not** pipe-related — verified by re-running them with no pipe metadata at all, where they still fail. They are short codes (`CCSU`, `UAPB`) and school-name variants (`GRAMBLING STATE` vs ESPN's `Grambling Tigers`, `WINSTON-SALEM STATE` vs `Winston-Salem Rams`) — a separate class, not filed as part of this.

## Known gap: the fallback tiers do not compose

One stream carries **both** noise classes and so needs both removed:

```
raw team2                 'TCU (IN DUBLIN, IRELAND) | 8.29  | ESPN'
paren-stripped  (tier 3)  'tcu 8 29'              -> 54.5
pipe-trimmed    (tier 4)  'tcu in dublin ireland' -> 43.2
pipe + paren    (missing) 'tcu'                   -> 100.0
```

Each tier removes one class, neither alone clears 60. The withdrawn dot-date pattern was accidentally propping this case up by emptying the pipe tail so tier 3 produced `tcu espn`, with ESPN then dropped as a broadcast network.

Composing the tiers is a small, well-motivated follow-up and would take this to 18/22. Left out of this PR rather than added after review — happy to fold it in here if preferred.

## Tests

`tests/matching/test_pipe_and_apostrophe.py`, 20 cases across three groups: both normalizers agree on apostrophes (incl. curly), the leading-segment rule and its 3-char floor, the documented `Sacramento Kings | Golden 1 Center` pass-through still resolving to the team, and the dot-date bounds — decimals, out-of-range months, dot-times, and am/pm all asserted **not** to parse as dates, with slash dates still winning.

One test deliberately asserts the classifier still hands over the pipe tail, so the fallback cannot be silently bypassed by a future classifier change.

Gates: `2588 passed`, `ruff` clean, frontend builds.

