### PR TITLE
fix(matching): persist the near-miss diagnosis on failed matches (#661)

### DIFF
--- a/teamarr/consumers/event_group_processor/persistence.py
+++ b/teamarr/consumers/event_group_processor/persistence.py
@@ -161,6 +161,16 @@ class MatchPersistence:
                         stream_id=stream_id,
                         stream_name=result.stream_name,
                         reason=failed_reason,
+                        # The evidence behind the reason (#661), and the
+                        # inclusion verdict beside it (#662's unmatched rows).
+                        # MatchOutcome has carried a detail since it was
+                        # introduced and both columns have always existed, but
+                        # this constructor passed neither, so every one of
+                        # 11,279 failures in a real bundle shipped with detail
+                        # NULL and triage had to re-derive causes from the
+                        # parsed_team strings.
+                        detail=result.detail,
+                        exclusion_reason=result.exclusion_reason,
                         parsed_team1=parsed_team1,
                         parsed_team2=parsed_team2,
                         detected_league=detected_league,

--- a/teamarr/consumers/matching/constants.py
+++ b/teamarr/consumers/matching/constants.py
@@ -9,6 +9,12 @@ For pattern/alias data, see teamarr/utilities/constants.py
 # The lifecycle layer filters out past events after matching.
 MATCH_WINDOW_DAYS = 30
 
+# Longest near-miss explanation persisted on a failed match (#661). It rides in
+# every support bundle at up to 500 failure rows per run, so it is capped to
+# keep the archive bounded; the informative half (best candidate + both scores)
+# comes first, so a truncation loses only the alias/date tail.
+NEAR_MISS_DETAIL_MAX = 400
+
 # =============================================================================
 # CONFIDENCE THRESHOLDS
 # Fuzzy match score thresholds that control when matches are accepted.

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -25,6 +25,7 @@ from teamarr.consumers.matching.constants import (
     ALTERNATE_TEAM_CODES,
     BOTH_TEAMS_THRESHOLD,
     HIGH_CONFIDENCE_THRESHOLD,
+    NEAR_MISS_DETAIL_MAX,
     SHORT_CODE_MAX_LEN,
 )
 from teamarr.consumers.matching.country_resolver import (
@@ -1393,39 +1394,50 @@ class TeamMatcher:
             ctx.team1,
             ctx.team2,
         )
-        self._log_near_miss(
+        near_miss = self._near_miss_summary(
             ctx,
             [e for _, e in events],
             team1_normalized,
             team2_normalized,
             date_rejected,
         )
+        logger.debug("[NEAR_MISS] stream_id=%d %s", ctx.stream_id, near_miss)
         return MatchOutcome.failed(
             reason,
             stream_name=ctx.stream_name,
             stream_id=ctx.stream_id,
+            detail=near_miss,
             parsed_team1=ctx.team1,
             parsed_team2=ctx.team2,
         )
 
-    def _log_near_miss(
+    def _near_miss_summary(
         self,
         ctx: MatchContext,
         candidates: list[Event],
         team1_norm: str | None,
         team2_norm: str | None,
         date_rejected: int,
-    ) -> None:
-        """DEBUG-only near-miss report for match failures (#480).
+    ) -> str:
+        """Why the closest candidate lost, as one line (#480, persisted by #661).
 
         A bare "reason=no_event_found" hides everything a bug report needs:
         which candidate came closest, the per-side scores vs the threshold,
-        and whether aliases resolved. This prints the single best-scoring
-        candidate so a log line is enough to diagnose misses like
-        'D-backs' scoring 50 against the Diamondbacks.
+        and whether aliases resolved. This reports the single best-scoring
+        candidate, enough to diagnose misses like 'D-backs' scoring 50 against
+        the Diamondbacks.
+
+        Returned rather than logged (#661). It used to go only to a DEBUG log,
+        where two things destroyed it: installs that raise LOG_LEVEL never
+        computed it at all, and the support bundle caps log tails at 256KB, so
+        78 of 11,279 failures kept their line. Meanwhile the structured record
+        the bundle ships complete had an empty `detail` column. The caller now
+        puts this on the MatchOutcome, so the evidence travels with the failure.
+
+        Cost: bounded at 300 candidates, and only ever runs on the failure
+        path. The per-side scores come from the same memoized kernel the match
+        loop just used, so the pairs are overwhelmingly cache hits.
         """
-        if not logger.isEnabledFor(logging.DEBUG):
-            return
 
         def side(stream_norm: str | None, team) -> float:
             if not stream_norm:
@@ -1446,12 +1458,7 @@ class TeamMatcher:
                 best = (pair[0], pair[1], pair[2], event)
 
         if best is None:
-            logger.debug(
-                "[NEAR_MISS] stream_id=%d no candidates in window; date_gated=%d",
-                ctx.stream_id,
-                date_rejected,
-            )
-            return
+            return f"no candidates in window; date_gated={date_rejected}"
 
         _, s1, s2, event = best
         # Resolve against the candidate's league — user aliases are
@@ -1459,23 +1466,15 @@ class TeamMatcher:
         # alias that WOULD fire in the real path).
         alias1 = self._resolve_alias(team1_norm, event.league) if team1_norm else None
         alias2 = self._resolve_alias(team2_norm, event.league) if team2_norm else None
-        logger.debug(
-            "[NEAR_MISS] stream_id=%d best='%s vs %s' (%s %s) scores %s=%.0f / %s=%.0f "
-            "(need %.0f) alias1=%s alias2=%s date_gated=%d",
-            ctx.stream_id,
-            event.home_team.name,
-            event.away_team.name,
-            event.league,
-            event.start_time.date(),
-            ctx.team1,
-            s1,
-            ctx.team2,
-            s2,
-            BOTH_TEAMS_THRESHOLD,
-            alias1 or "none",
-            alias2 or "none",
-            date_rejected,
+        summary = (
+            f"best='{event.home_team.name} vs {event.away_team.name}' "
+            f"({event.league} {event.start_time.date()}) "
+            f"scores {ctx.team1}={s1:.0f} / {ctx.team2}={s2:.0f} "
+            f"(need {BOTH_TEAMS_THRESHOLD:.0f}) "
+            f"alias1={alias1 or 'none'} alias2={alias2 or 'none'} "
+            f"date_gated={date_rejected}"
         )
+        return summary[:NEAR_MISS_DETAIL_MAX]
 
     def _check_abbreviation_match(
         self,

--- a/tests/matching/test_failure_detail.py
+++ b/tests/matching/test_failure_detail.py
@@ -1,0 +1,219 @@
+"""A failed match explains itself (#661).
+
+Diagnosing four matching bugs on 2026-08-29 meant reading 1026 JSON records
+and re-deriving causes from parsed_team1/parsed_team2 string shapes, because
+every failure record shipped with detail NULL. The explanation already existed
+— _near_miss_summary computed it — but it went only to a DEBUG log, which the
+support bundle truncates to a 256KB tail (78 lines survived out of 11,279).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.constants import (
+    BOTH_TEAMS_THRESHOLD,
+    NEAR_MISS_DETAIL_MAX,
+)
+from teamarr.core.types import Event, EventStatus, Team
+from tests.fakes import make_team_matcher
+
+TZ = ZoneInfo("UTC")
+
+
+def _team(team_id: str, name: str) -> Team:
+    return Team(
+        id=team_id,
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation="",
+        league="college-football",
+        sport="football",
+    )
+
+
+def _event(away: str, home: str) -> Event:
+    start = datetime.now(UTC) + timedelta(hours=3)
+    return Event(
+        id="1",
+        provider="espn",
+        name=f"{away} at {home}",
+        short_name=f"{away} at {home}",
+        league="college-football",
+        sport="football",
+        start_time=start,
+        home_team=_team("h", home),
+        away_team=_team("a", away),
+        status=EventStatus(state="scheduled"),
+    )
+
+
+def _matcher(events):
+    service = MagicMock()
+    service.get_provider_name.return_value = "espn"
+    service.get_events.side_effect = lambda league, day, cache_only=False: (
+        events if day == datetime.now(UTC).date() else []
+    )
+    matcher = make_team_matcher(service=service, cache=MagicMock())
+    matcher._check_cache = lambda ctx: None
+    matcher._cache_result = lambda ctx, result: None
+    return matcher
+
+
+def _fail(stream: str, events):
+    matcher = _matcher(events)
+    return matcher.match_single_league(
+        classify_stream(stream),
+        "college-football",
+        datetime.now(UTC).date(),
+        1,
+        1,
+        1,
+        TZ,
+    )
+
+
+class TestFailedMatchesCarryTheirDiagnosis:
+    def test_detail_is_populated(self):
+        outcome = _fail(
+            "NCAAF 01: Nowhere State at Elsewhere Tech",
+            [_event("Robert Morris Colonials", "Wagner Seahawks")],
+        )
+        assert not outcome.is_matched
+        assert outcome.detail
+
+    def test_detail_names_the_closest_candidate_and_both_scores(self):
+        outcome = _fail(
+            "NCAAF 01: Nowhere State at Elsewhere Tech",
+            [_event("Robert Morris Colonials", "Wagner Seahawks")],
+        )
+        assert "Wagner Seahawks" in outcome.detail
+        assert f"need {BOTH_TEAMS_THRESHOLD:.0f}" in outcome.detail
+        assert "Nowhere State=" in outcome.detail
+        assert "Elsewhere Tech=" in outcome.detail
+
+    def test_empty_window_also_explains_itself(self):
+        """This path always set a detail; only persistence dropped it."""
+        outcome = _fail("NCAAF 01: Nowhere State at Elsewhere Tech", [])
+        assert "No events in college-football" in (outcome.detail or "")
+
+    def test_detail_is_length_capped(self):
+        """It ships in every bundle at up to 500 rows per run."""
+        from teamarr.consumers.matching.team_matcher import MatchContext
+
+        long_name = "Extremely Long University Of Somewhere " * 6
+        event = _event(long_name, long_name)
+        matcher = _matcher([event])
+        ctx = MatchContext(
+            stream_name="s",
+            stream_id=1,
+            group_id=1,
+            target_date=datetime.now(UTC).date(),
+            generation=1,
+            user_tz=TZ,
+            stream_tz=None,
+            classified=classify_stream("NCAAF 01: A at B"),
+            team1=long_name,
+            team2=long_name,
+            sport_durations={},
+        )
+        summary = matcher._near_miss_summary(ctx, [event], long_name, long_name, 0)
+        assert len(summary) <= NEAR_MISS_DETAIL_MAX
+
+    def test_summary_does_not_depend_on_debug_logging(self, monkeypatch):
+        """It used to early-return unless DEBUG was enabled, so installs that
+        raised LOG_LEVEL produced no diagnosis at all."""
+        import logging
+
+        from teamarr.consumers.matching import team_matcher
+
+        monkeypatch.setattr(
+            team_matcher.logger, "isEnabledFor", lambda level: level >= logging.CRITICAL
+        )
+        outcome = _fail(
+            "NCAAF 01: Nowhere State at Elsewhere Tech",
+            [_event("Robert Morris Colonials", "Wagner Seahawks")],
+        )
+        assert outcome.detail
+
+
+class TestPersistenceKeepsTheDetail:
+    """The column, the dataclass field and the INSERT all existed; the
+    FailedMatch(...) construction simply never passed it."""
+
+    def test_detail_reaches_the_failed_match_row(self, db_conn):
+        from teamarr.database.stats import (
+            FailedMatch,
+            create_run,
+            get_failed_matches,
+            save_failed_matches,
+            save_run,
+        )
+
+        run = create_run(db_conn, run_type="full_epg")
+        run.complete()
+        save_run(db_conn, run)
+        db_conn.execute(
+            "INSERT INTO event_epg_groups (id, name, leagues) VALUES (1, 'NCAAF', '[]')"
+        )
+
+        save_failed_matches(
+            db_conn,
+            [
+                FailedMatch(
+                    run_id=run.id,
+                    group_id=1,
+                    group_name="NCAAF",
+                    stream_id=1,
+                    stream_name="NCAAF 01: A at B",
+                    reason="no_event_found",
+                    detail="best='X vs Y' scores A=41 / B=41 (need 60)",
+                )
+            ],
+        )
+        [row] = get_failed_matches(db_conn, run.id)
+        assert row["detail"] == "best='X vs Y' scores A=41 / B=41 (need 60)"
+
+    def test_processor_persists_detail_and_exclusion_reason(self, db_conn):
+        """Guards the exact line that was missing: the constructor call.
+
+        `exclusion_reason` was dropped the same way; #662's unmatched rows
+        read it to say WHY a stream was left out.
+        """
+        from teamarr.consumers.event_group_processor.persistence import MatchPersistence
+        from teamarr.consumers.matching import BatchMatchResult
+        from teamarr.consumers.matching.matcher import MatchedStreamResult
+        from teamarr.consumers.matching.result import FailedReason
+        from teamarr.database.stats import create_run, get_failed_matches, save_run
+
+        run = create_run(db_conn, run_type="full_epg")
+        run.complete()
+        save_run(db_conn, run)
+        db_conn.execute(
+            "INSERT INTO event_epg_groups (id, name, leagues) VALUES (1, 'NCAAF', '[]')"
+        )
+
+        result = MatchedStreamResult(
+            stream_name="NCAAF 01: A at B",
+            stream_id=7,
+            matched=False,
+            failed_reason=FailedReason.NO_EVENT_FOUND,
+            detail="best='X vs Y' scores A=41 / B=41 (need 60)",
+            exclusion_reason="no_event_found",
+        )
+        MatchPersistence()._save_match_details(
+            db_conn,
+            run_id=run.id,
+            group_id=1,
+            group_name="NCAAF",
+            streams=[{"id": 7, "name": "NCAAF 01: A at B"}],
+            match_result=BatchMatchResult(results=[result]),
+        )
+
+        [row] = get_failed_matches(db_conn, run.id)
+        assert row["detail"] == "best='X vs Y' scores A=41 / B=41 (need 60)"
+        assert row["exclusion_reason"] == "no_event_found"


### PR DESCRIPTION
Closes #661. First of the three structural findings from the 2026-08-29 matching audit (#660, #661, #662).

## Problem

Every failure record shipped with `detail` NULL — **11,279 of 11,279** in a real support bundle. Diagnosing four matching bugs that day meant reading 1026 JSON records and re-deriving causes from `parsed_team1`/`parsed_team2` string shapes.

The explanation already existed. `_log_near_miss` computed the closest candidate, both per-side scores against the threshold, alias resolution and date gating — then wrote it to a DEBUG log, where two things destroyed it:

1. It early-returned unless DEBUG was enabled, so installs that raise `LOG_LEVEL` never computed it at all.
2. The bundle caps log tails at `LOG_BYTES = 256 KB`, so **78** near-miss lines survived out of 11,279 failures — 0.7%.

Meanwhile the structured table the bundle ships *complete* (500 rows per run) had the empty column.

The surviving lines show what was being thrown away:

```
[NEAR_MISS] stream_id=280906 best='South Dakota Coyotes vs Central Connecticut Blue Devils'
  scores Central Connecticut=100 / South Dakota=100 (need 60) alias1=none alias2=none date_gated=0
```

Both sides scored 100 against a threshold of 60 and it still failed — an unmissable signature of a non-scoring rejection (the fixture gate, #650). The structured record said `no_event_found`, no detail.

## Change

- `_log_near_miss` becomes `_near_miss_summary`, **returning** the line instead of logging it, and no longer gated on DEBUG. The caller still logs it, and now also hangs it on the `MatchOutcome`.
- `persistence.py` passes the `detail` it had always been dropping. `MatchOutcome.failed()`, the `FailedMatch` dataclass, the schema column and the INSERT **all already supported it** — only the constructor call omitted it. So this also recovers details other paths were already setting, e.g. `"No events in college-football for 2026-08-29"`.
- Capped at `NEAR_MISS_DETAIL_MAX = 400`, informative half first, since it rides in every bundle at up to 500 rows per run.

Wired at both failure sites — the single-league and multi-league loops, which are 91% duplicated (#660).

## Result

The NCAAF failure that took an afternoon to diagnose now reads:

```
best='TCU Horned Frogs vs North Carolina Tar Heels' (college-football 2026-08-29)
scores ROBERT MORRIS=41 / WAGNER | 8.29  | NEC FRONT ROW=41 (need 60)
alias1=none alias2=none date_gated=0
```

That names the #652 pipe bug on sight — the polluted team string is right there with its score.

## Cost

Bounded at 300 candidates and only on the failure path; the per-side scores come from the same memoized kernel the match loop just used, so they are overwhelmingly cache hits. In practice this is not new work on most installs: file logging already defaults to DEBUG, so the computation was already running — it just had nowhere durable to go.

## Redaction

No change needed, and no new exposure. The bundle's `_sanitize` recurses into run details and strips URLs, tokens and M3U account names from every string, so `detail` is covered exactly as `stream_name` and `parsed_team1/2` already are — and its content is drawn from those same fields.

## Tests

`tests/matching/test_failure_detail.py`, 7 cases: detail populated on failure, names the closest candidate and both scores against the threshold, the empty-window path explains itself, the length cap holds, the summary no longer depends on DEBUG being enabled, and the value survives a round trip through `save_failed_matches`. One test asserts the exact `persistence.py` constructor line, since a silently-omitted kwarg is what caused this.

Gates: `2575 passed`, `ruff` clean, frontend builds.

Note: `tests/test_cache_eviction.py::test_insert_into_a_roomy_cache_does_not_scan` failed once during this work and passes in isolation and on 3/3 subsequent full runs. It is a wall-clock timing assertion by design ("Timed rather than mocked because the defect was purely asymptotic"), so it is load-sensitive — unrelated to this change, but worth knowing it can flake in CI.
