### PR TITLE
fix(templates): {today_tonight} says tomorrow/weekday for games not today (#550)

### DIFF
--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -181,8 +181,8 @@ Game scheduling information.
 | `{game_day_short}` | Short day of week | base, .next, .last | `Sun` |
 | `{game_time}` | Game time formatted per user settings | base, .next, .last | `1:00 PM EST` |
 | `{days_until}` | Days until game | base, .next, .last | `0` |
-| `{today_tonight}` | 'today' or 'tonight' based on 5pm cutoff | base, .next, .last | `today` |
-| `{today_tonight_title}` | 'Today' or 'Tonight' (title case) | base, .next, .last | `Today` |
+| `{today_tonight}` | 'today' or 'tonight' (5pm cutoff) when the game is today; 'tomorrow', the weekday, or the date when it is further out | base, .next, .last | `today` |
+| `{today_tonight_title}` | Title-case form of `{today_tonight}` | base, .next, .last | `Today` |
 | `{relative_day}` | Relative day: 'today', 'tonight', 'tomorrow', day of week, or date | base, .next | `tomorrow` |
 | `{relative_day_title}` | Relative day (title case) | base, .next | `Tomorrow` |
 | `{day}` | Game day of month, no leading zero | base, .next, .last | `22` |

--- a/teamarr/templates/variables/datetime.py
+++ b/teamarr/templates/variables/datetime.py
@@ -138,26 +138,30 @@ def extract_game_time(ctx: TemplateContext, game_ctx: GameContext | None) -> str
     name="today_tonight",
     category=Category.DATETIME,
     suffix_rules=SuffixRules.ALL,
-    description="'today' or 'tonight' based on 5pm cutoff",
+    description="'today'/'tonight' for a same-day game; 'tomorrow', weekday, or date otherwise",
 )
 def extract_today_tonight(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    dt = _get_local_time(game_ctx)
-    if not dt:
-        return ""
-    return "tonight" if dt.hour >= 17 else "today"
+    """'today'/'tonight' for a same-day game; otherwise the relative-day ladder.
+
+    Used to be a bare time-of-day cutoff with no idea how far away the game
+    was, so any channel that existed a day early — racing weekends where the
+    race channel is created alongside Saturday practice (#550) — described a
+    Sunday race as happening "today". Same-day output is unchanged; earlier
+    channels now say "tomorrow", the weekday, or the date, exactly as
+    {relative_day} does.
+    """
+    return extract_relative_day(ctx, game_ctx)
 
 
 @register_variable(
     name="today_tonight_title",
     category=Category.DATETIME,
     suffix_rules=SuffixRules.ALL,
-    description="'Today' or 'Tonight' (title case)",
+    description="'Today'/'Tonight' for a same-day game; 'Tomorrow', weekday, or date (title case)",
 )
 def extract_today_tonight_title(ctx: TemplateContext, game_ctx: GameContext | None) -> str:
-    dt = _get_local_time(game_ctx)
-    if not dt:
-        return ""
-    return "Tonight" if dt.hour >= 17 else "Today"
+    """Title-case twin of {today_tonight}; see that variable for the #550 note."""
+    return extract_relative_day_title(ctx, game_ctx)
 
 
 @register_variable(

--- a/tests/templates/goldens/college_team.xml
+++ b/tests/templates/goldens/college_team.xml
@@ -61,19 +61,19 @@
   <programme start="20260712040000 +0000" stop="20260712100000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: College Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Kentucky Wildcats at Arkansas Razorbacks</sub-title>
-    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks sunday at 3:00 PM EDT.</desc>
     <icon src="ncaam/KentuckyWildcats/ArkansasRazorbacks/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712100000 +0000" stop="20260712160000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: College Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Kentucky Wildcats at Arkansas Razorbacks</sub-title>
-    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks sunday at 3:00 PM EDT.</desc>
     <icon src="ncaam/KentuckyWildcats/ArkansasRazorbacks/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712160000 +0000" stop="20260712190000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: College Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Kentucky Wildcats at Arkansas Razorbacks</sub-title>
-    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 21-6 Kentucky Wildcats travel to Auburn Hills, MI to play the 20-7 Arkansas Razorbacks sunday at 3:00 PM EDT.</desc>
     <icon src="ncaam/KentuckyWildcats/ArkansasRazorbacks/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712190000 +0000" stop="20260712220000 +0000" channel="teamarr-team-1">

--- a/tests/templates/goldens/default_team.xml
+++ b/tests/templates/goldens/default_team.xml
@@ -61,19 +61,19 @@
   <programme start="20260712040000 +0000" stop="20260712100000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: NBA Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Chicago Bulls at Boston Celtics</sub-title>
-    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics sunday at 3:00 PM EDT.</desc>
     <icon src="nba/ChicagoBulls/BostonCeltics/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712100000 +0000" stop="20260712160000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: NBA Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Chicago Bulls at Boston Celtics</sub-title>
-    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics sunday at 3:00 PM EDT.</desc>
     <icon src="nba/ChicagoBulls/BostonCeltics/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712160000 +0000" stop="20260712190000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: NBA Basketball at 3:00 PM EDT</title>
     <sub-title lang="en">Chicago Bulls at Boston Celtics</sub-title>
-    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics today at 3:00 PM EDT.</desc>
+    <desc lang="en">The 6-6 Chicago Bulls travel to Auburn Hills, MI to play the 10-2 Boston Celtics sunday at 3:00 PM EDT.</desc>
     <icon src="nba/ChicagoBulls/BostonCeltics/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712190000 +0000" stop="20260712220000 +0000" channel="teamarr-team-1">

--- a/tests/templates/goldens/soccer_team.xml
+++ b/tests/templates/goldens/soccer_team.xml
@@ -67,19 +67,19 @@
   <programme start="20260712040000 +0000" stop="20260712100000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: Premier League Soccer at 3:00 PM EDT</title>
     <sub-title lang="en">Liverpool vs Chelsea</sub-title>
-    <desc lang="en">Liverpool face Chelsea at The Palace today at 3:00 PM EDT.</desc>
+    <desc lang="en">Liverpool face Chelsea at The Palace sunday at 3:00 PM EDT.</desc>
     <icon src="epl/Liverpool/Chelsea/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712100000 +0000" stop="20260712160000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: Premier League Soccer at 3:00 PM EDT</title>
     <sub-title lang="en">Liverpool vs Chelsea</sub-title>
-    <desc lang="en">Liverpool face Chelsea at The Palace today at 3:00 PM EDT.</desc>
+    <desc lang="en">Liverpool face Chelsea at The Palace sunday at 3:00 PM EDT.</desc>
     <icon src="epl/Liverpool/Chelsea/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712160000 +0000" stop="20260712190000 +0000" channel="teamarr-team-1">
     <title lang="en">Coming up: Premier League Soccer at 3:00 PM EDT</title>
     <sub-title lang="en">Liverpool vs Chelsea</sub-title>
-    <desc lang="en">Liverpool face Chelsea at The Palace today at 3:00 PM EDT.</desc>
+    <desc lang="en">Liverpool face Chelsea at The Palace sunday at 3:00 PM EDT.</desc>
     <icon src="epl/Liverpool/Chelsea/cover.png?style=1&amp;logo=true&amp;fallback=true" />
   </programme>
   <programme start="20260712190000 +0000" stop="20260712213000 +0000" channel="teamarr-team-1">

--- a/tests/templates/test_today_tonight.py
+++ b/tests/templates/test_today_tonight.py
@@ -1,0 +1,103 @@
+"""{today_tonight} knows how far away the game is (#550).
+
+It used to be a bare 5pm cutoff — "today" or "tonight" — with no idea of the
+game's date. A racing weekend creates the race channel alongside Saturday
+practice, so all Saturday the pregame filler read "... Race from Iowa Speedway
+today at 3:30 PM EDT" for a Sunday race. Same-day output is unchanged; earlier
+channels now follow {relative_day}'s ladder.
+"""
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.templates.context import GameContext, TeamChannelContext, TemplateContext
+from teamarr.templates.variables.datetime import (
+    extract_today_tonight,
+    extract_today_tonight_title,
+)
+
+TZ = ZoneInfo("America/New_York")
+# A Saturday morning, the moment the race channel appeared in the report.
+NOW = datetime(2026, 8, 8, 8, 47, tzinfo=UTC)
+
+
+def _team(tid: str, name: str) -> Team:
+    return Team(
+        id=tid,
+        provider="nascar",
+        name=name,
+        short_name=name,
+        abbreviation=name[:3].upper(),
+        league="nascar-cup",
+        sport="racing",
+    )
+
+
+def _event(start: datetime) -> Event:
+    return Event(
+        id="5620",
+        provider="nascar",
+        name="Iowa Corn 350",
+        short_name="Iowa Corn 350",
+        start_time=start,
+        league="nascar-cup",
+        sport="racing",
+        status=EventStatus(state="pre"),
+        home_team=_team("h", "Field"),
+        away_team=_team("a", "Field"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def frozen_clock(monkeypatch):
+    frozen = NOW.astimezone(TZ)
+    monkeypatch.setattr("teamarr.templates.variables.datetime.now_user", lambda: frozen)
+    monkeypatch.setattr(
+        "teamarr.templates.variables.datetime.to_user_tz", lambda dt: dt.astimezone(TZ)
+    )
+
+
+def _ctx(gc: GameContext) -> TemplateContext:
+    tc = TeamChannelContext(team_id="h", league="nascar-cup", sport="racing", team_name="Field")
+    return TemplateContext(game_context=gc, team_config=tc, team_stats=None)
+
+
+def _render(start: datetime) -> tuple[str, str]:
+    gc = GameContext(event=_event(start))
+    ctx = _ctx(gc)
+    return extract_today_tonight(ctx, gc), extract_today_tonight_title(ctx, gc)
+
+
+def test_sunday_race_seen_on_saturday_is_tomorrow():
+    """The exact report: race Sunday 19:30Z, channel created Saturday 08:47Z."""
+    assert _render(datetime(2026, 8, 9, 19, 30, tzinfo=UTC)) == ("tomorrow", "Tomorrow")
+
+
+def test_same_day_afternoon_is_still_today():
+    assert _render(datetime(2026, 8, 8, 19, 30, tzinfo=UTC)) == ("today", "Today")
+
+
+def test_same_day_evening_is_still_tonight():
+    assert _render(datetime(2026, 8, 8, 23, 30, tzinfo=UTC)) == ("tonight", "Tonight")
+
+
+def test_a_few_days_out_names_the_weekday():
+    assert _render(datetime(2026, 8, 11, 19, 30, tzinfo=UTC)) == ("tuesday", "Tuesday")
+
+
+def test_a_week_out_gives_the_date():
+    assert _render(datetime(2026, 8, 20, 19, 30, tzinfo=UTC)) == ("Aug 20", "Aug 20")
+
+
+def test_last_game_stays_time_of_day():
+    """.last games are in the past; the ladder treats them as same-day words."""
+    assert _render(NOW - timedelta(days=2)) == ("today", "Today")
+
+
+def test_no_event_is_empty():
+    gc = GameContext(event=None)
+    ctx = _ctx(gc)
+    assert extract_today_tonight(ctx, gc) == ""


### PR DESCRIPTION
Closes the remaining half of #550 (bead `dpn4`). The create-threshold half landed in #593.

## Problem

`{today_tonight}` / `{today_tonight_title}` were a bare 5pm cutoff — `"tonight" if hour >= 17 else "today"` — with no awareness of the game's date. Any channel that exists more than a day before its event described it as "today". Racing made it visible: the race channel is created alongside Saturday practice, so all Saturday the pregame filler read *"Iowa Corn 350 … today at 3:30 PM EDT"* for a Sunday race.

## Change

Scope decision: **extend in place** rather than add a variable. Same-day output is byte-identical (`today`/`tonight`, same cutoff); only games that are *not* today change, and for those the old output was simply wrong. Both variables now defer to `{relative_day}`'s existing ladder: `tomorrow` → weekday → `Aug 20`. No new variable, so no count churn; descriptions and `docs/guide/epg/variables.md` rows updated.

## Tests

`tests/templates/test_today_tonight.py` (7): the exact report (Sunday race seen Saturday → `tomorrow`), same-day afternoon/evening unchanged, weekday, date, `.last` games stay time-of-day, no event → empty.

Starter XMLTV goldens regenerated: 9 `<desc>` lines across the three starter templates change `today` → `sunday` for a fixture game several days out — the bug, fixed, in the goldens.

Gates: ruff clean, suite green (2636), frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsrjBwMK9ofAMHbLvuMzSG
