### PR TITLE
fix(matching): name filter/skip outcomes and gated candidates instead of 'unmatched' (#662)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,8 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 - Tennis programmes (mf7.9, #642): `TennisMatcher.match_program` — binds only with a tournament clue AND (player pair OR court) from title|sub_title|description; pair → one match, court → that court's matches inside the programme slot; otherwise `FailedReason.TENNIS_MATCHUP_UNKNOWN`, surfaced on the linear stream's result via `_epg_tennis_unknown` in `_reconcile_epg`. Never a tournament-wide fan-out (the 2026-07-05 regression).
 - Docs: `docs/guide/matching/program-matching.md`.
 
+**Failure taxonomy** (`epg_failed_matches.reason`, #661/#662): a real `FailedReason` value, or a prefixed verdict — `filtered:<FilteredReason>` (not_event, league_not_included, regex, stale) and `skipped:<exclusion>` (unclassifiable linear names, name_match_disabled, team_streams_disabled). Bare `"unmatched"` is the unreachable last resort. `candidates_gated` = every candidate was skipped before scoring (search window / EPG anchor / sport hint); `no_event_found` = candidates were scored and none cleared the floor. `detail` carries the near-miss summary over *scored* candidates only; `exclusion_reason` rides alongside. Frontend labels: `RunHistoryTable.tsx::getFailedReasonLabel`.
+
 ## Plans & Roadmap
 
 Feature planning lives in beads: `bd list --label roadmap`

--- a/frontend/src/components/RunHistoryTable.tsx
+++ b/frontend/src/components/RunHistoryTable.tsx
@@ -90,7 +90,16 @@ function getFailedReasonLabel(reason: string): string {
     tennis_tournament_mismatch: "Different tournament",
     tennis_matchup_unknown: "Tennis matchup not known",
     date_mismatch: "Date mismatch",
+    candidates_gated: "No candidate in window",
     unmatched: "Unmatched",
+    "filtered:not_event": "Not an event",
+    "filtered:league_not_included": "League not enabled",
+    "filtered:include_regex": "Excluded by include pattern",
+    "filtered:exclude_regex": "Excluded by exclude pattern",
+    "filtered:stale": "Stale stream",
+    "skipped:unclassifiable": "Linear channel (no matchup)",
+    "skipped:name_match_disabled": "Stream Name matching off",
+    "skipped:team_streams_disabled": "Team matching off",
   }
   return labels[reason] || reason
 }

--- a/teamarr/consumers/event_group_processor/persistence.py
+++ b/teamarr/consumers/event_group_processor/persistence.py
@@ -14,6 +14,10 @@ from teamarr.services.stream_filter import FilterResult
 
 logger = logging.getLogger(__name__)
 
+# Per-source skips that are not match failures (#662): the matcher never ran
+# for these, so they carry no FailedReason. Persisted under a "skipped:" prefix.
+_SKIP_REASONS = frozenset({"unclassifiable", "name_match_disabled", "team_streams_disabled"})
+
 
 class MatchPersistence:
     """Saves per-stream match outcomes to the stats tables.
@@ -148,10 +152,23 @@ class MatchPersistence:
                 parsed_team2 = getattr(result, "parsed_team2", None)
                 detected_league = getattr(result, "detected_league", None)
 
-                # Get detailed failure reason if available
-                failed_reason = "unmatched"
+                # Name the outcome honestly (#662). Most rows that used to land
+                # here as the bare string "unmatched" were never match failures:
+                # they were filter verdicts (not an event, league not enabled,
+                # regex) or per-source skips (linear channel names, a matching
+                # type switched off) that only reached this branch because it
+                # is the catch-all. 38% of one install's "failures" were these.
+                # They stay persisted — an EPG-only group still wants its
+                # linear channels listed — but under a prefix that says what
+                # they are, so the failure taxonomy is only real failures.
                 if result.failed_reason:
                     failed_reason = result.failed_reason.value
+                elif result.filtered_reason:
+                    failed_reason = f"filtered:{result.filtered_reason.value}"
+                elif result.exclusion_reason in _SKIP_REASONS:
+                    failed_reason = f"skipped:{result.exclusion_reason}"
+                else:
+                    failed_reason = "unmatched"
 
                 failed_list.append(
                     FailedMatch(

--- a/teamarr/consumers/matching/result.py
+++ b/teamarr/consumers/matching/result.py
@@ -98,6 +98,12 @@ class FailedReason(Enum):
 
     # Event lookup failures
     NO_EVENT_FOUND = "no_event_found"  # Teams matched, league detected, no game scheduled
+    # Candidates existed but every one was skipped before scoring — outside the
+    # search window, past the EPG anchor tolerance, or a sport-hint mismatch —
+    # so nothing was ever compared (#662). Distinct from NO_EVENT_FOUND, where
+    # candidates were scored and none cleared the floor; the near-miss detail
+    # used to show 100/100 for an event the loop never looked at.
+    CANDIDATES_GATED = "candidates_gated"
 
     # Event card failures (UFC, boxing)
     NO_EVENT_CARD_MATCH = "no_event_card_match"  # Could not match to event card

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -680,7 +680,10 @@ class TeamMatcher:
 
         # If match failed with NO_EVENT_FOUND, try reverse alias resolution
         # This handles cases where classifier couldn't detect league but user has aliases
-        if result.is_failed and result.failed_reason == FailedReason.NO_EVENT_FOUND:
+        if result.is_failed and result.failed_reason in (
+            FailedReason.NO_EVENT_FOUND,
+            FailedReason.CANDIDATES_GATED,
+        ):
             retry_result = self._try_reverse_alias_match(ctx, all_events, leagues_to_search)
             if retry_result and retry_result.is_matched:
                 result = retry_result
@@ -1182,6 +1185,12 @@ class TeamMatcher:
         best_stream_date_dist: int = 999  # Days from the stream's declared date (#474)
         date_rejected = 0  # Candidates gated by a trusted stream date (#474)
         fixture_rejected = 0  # Candidates in a league these teams never meet in
+        # Candidates skipped before scoring (window / EPG anchor / sport hint),
+        # and the ones that actually reached the scorer (#662). The near-miss
+        # summary reads the latter: reporting 100/100 for an event the loop
+        # never scored sent triage after the fixture gate for a window miss.
+        gated_rejected = 0
+        scored: list[Event] = []
 
         # Which leagues could these two sides actually play each other in (epic
         # goax)? Resolved once per stream, not per candidate — it depends only on
@@ -1197,6 +1206,7 @@ class TeamMatcher:
         for league, event in events:
             # Validate event is within search window (lifecycle handles exclusions)
             if not ctx.is_event_in_search_window(event):
+                gated_rejected += 1
                 continue
 
             # EPG anchored matching (bead t5e): the candidate must air within the
@@ -1207,6 +1217,7 @@ class TeamMatcher:
             if ctx.anchor_dt is not None:
                 anchor_dist = abs(int((event.start_time - ctx.anchor_dt).total_seconds()))
                 if anchor_dist > ANCHOR_MATCH_TOLERANCE_SECONDS:
+                    gated_rejected += 1
                     continue
 
             event_date = _local_date(event.start_time, ctx.user_tz)
@@ -1234,6 +1245,7 @@ class TeamMatcher:
             # sport naming inconsistencies (e.g., "Football" vs "soccer")
             if ctx.classified.sport_hint and not ctx.classified.league_hint:
                 if not _sport_hint_matches(ctx.classified.sport_hint, event.sport):
+                    gated_rejected += 1
                     continue
 
             # Fixture gate (epic goax). Both stream sides name real teams, and
@@ -1256,6 +1268,8 @@ class TeamMatcher:
             ):
                 fixture_rejected += 1
                 continue
+
+            scored.append(event)
 
             # Try alias match first (100% confidence)
             match_result = self._check_alias_match(team1_normalized, team2_normalized, event)
@@ -1384,6 +1398,11 @@ class TeamMatcher:
             # meet (epic goax). "No event found" would send the user hunting for
             # a scheduling gap that isn't there.
             reason = FailedReason.FIXTURE_NOT_IN_LEAGUE
+        elif gated_rejected and not scored:
+            # Every candidate was skipped before scoring — nothing was ever
+            # compared, so "no event found" would be a claim about scores that
+            # never happened (#662).
+            reason = FailedReason.CANDIDATES_GATED
         else:
             reason = FailedReason.NO_EVENT_FOUND
 
@@ -1396,11 +1415,13 @@ class TeamMatcher:
         )
         near_miss = self._near_miss_summary(
             ctx,
-            [e for _, e in events],
+            scored,
             team1_normalized,
             team2_normalized,
             date_rejected,
         )
+        if gated_rejected:
+            near_miss = f"{near_miss}; gated={gated_rejected}"
         logger.debug("[NEAR_MISS] stream_id=%d %s", ctx.stream_id, near_miss)
         return MatchOutcome.failed(
             reason,

--- a/tests/matching/test_failure_taxonomy.py
+++ b/tests/matching/test_failure_taxonomy.py
@@ -1,0 +1,203 @@
+"""Failure records say why (#662).
+
+38% of one install's persisted "failures" carried the literal string
+"unmatched" — not a FailedReason, just persistence's catch-all for anything
+that was neither matched nor an exception. Those rows were filter verdicts and
+per-source skips, not match failures. And `no_event_found` absorbed candidates
+that were never scored at all (outside the search window, past the EPG anchor,
+sport-hint mismatch), while the near-miss summary printed 100/100 for one of
+them — sending triage after the fixture gate for a window miss.
+"""
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.result import FailedReason, FilteredReason, ResultCategory
+from teamarr.consumers.matching.team_matcher import MatchContext
+from teamarr.core.types import Event, EventStatus, Team
+from tests.fakes import make_team_matcher
+
+TODAY = datetime.now(UTC).date()
+
+
+def _team(name: str, abbr: str) -> Team:
+    return Team(
+        id=f"t-{abbr}",
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation=abbr,
+        league="college-football",
+        sport="football",
+    )
+
+
+def _event(days_from_today: int, sport: str = "football") -> Event:
+    start = datetime.combine(TODAY, datetime.min.time(), tzinfo=UTC) + timedelta(
+        days=days_from_today, hours=23
+    )
+    return Event(
+        id=f"e{days_from_today}",
+        provider="espn",
+        name="Wagner Seahawks at Robert Morris Colonials",
+        short_name="WAG at RMU",
+        start_time=start,
+        home_team=_team("Robert Morris Colonials", "RMU"),
+        away_team=_team("Wagner Seahawks", "WAG"),
+        status=EventStatus(state="scheduled"),
+        league="college-football",
+        sport=sport,
+    )
+
+
+def _match(stream: str, event: Event, *, anchor=None):
+    classified = classify_stream(stream)
+    matcher = make_team_matcher()
+    ctx = MatchContext(
+        stream_name=stream,
+        stream_id=1,
+        group_id=1,
+        target_date=TODAY,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+        classified=classified,
+        team1=classified.team1,
+        team2=classified.team2,
+        anchor_dt=anchor,
+    )
+    return matcher._match_against_events(ctx, [event], "college-football")
+
+
+class TestGatedCandidatesAreNamed:
+    def test_scoring_still_matches_the_in_window_event(self):
+        result = _match("Wagner vs Robert Morris", _event(0))
+        assert result.category is ResultCategory.MATCHED
+
+    def test_only_candidate_outside_search_window_is_gated_not_no_event(self):
+        """Both sides would score 100 — the loop just never looked."""
+        result = _match("Wagner vs Robert Morris", _event(-45))
+        assert result.failed_reason is FailedReason.CANDIDATES_GATED
+        assert "gated=1" in (result.detail or "")
+
+    def test_only_candidate_past_epg_anchor_tolerance_is_gated(self):
+        event = _event(0)
+        anchor = event.start_time + timedelta(hours=6)
+        result = _match("Wagner vs Robert Morris", event, anchor=anchor)
+        assert result.failed_reason is FailedReason.CANDIDATES_GATED
+
+    def test_sport_hint_mismatch_is_gated(self):
+        # "Basketball:" gives a sport hint with no league hint; the candidate is football.
+        result = _match("Basketball: Wagner vs Robert Morris", _event(0))
+        assert result.failed_reason is FailedReason.CANDIDATES_GATED
+
+    def test_scored_but_low_candidate_is_still_no_event_found(self):
+        result = _match("Duke vs Clemson", _event(0))
+        assert result.failed_reason is FailedReason.NO_EVENT_FOUND
+
+    def test_near_miss_reads_only_scored_candidates(self):
+        """A gated event must not show up as a 100/100 near miss."""
+        result = _match("Wagner vs Robert Morris", _event(-45))
+        assert "100" not in (result.detail or "")
+
+
+class TestPersistedReasonsAreHonest:
+    @pytest.fixture
+    def run_and_group(self, db_conn):
+        from teamarr.database.stats import create_run, save_run
+
+        run = create_run(db_conn, run_type="full_epg")
+        run.complete()
+        save_run(db_conn, run)
+        db_conn.execute("INSERT INTO event_epg_groups (id, name, leagues) VALUES (1, 'G', '[]')")
+        return run
+
+    def _persist(self, db_conn, run, results):
+        from teamarr.consumers.event_group_processor.persistence import MatchPersistence
+        from teamarr.consumers.matching import BatchMatchResult
+        from teamarr.database.stats import get_failed_matches
+
+        MatchPersistence()._save_match_details(
+            db_conn,
+            run_id=run.id,
+            group_id=1,
+            group_name="G",
+            streams=[{"id": r.stream_id, "name": r.stream_name} for r in results],
+            match_result=BatchMatchResult(results=list(results)),
+        )
+        return {row["stream_id"]: row["reason"] for row in get_failed_matches(db_conn, run.id)}
+
+    def test_filter_and_skip_outcomes_are_not_unmatched(self, db_conn, run_and_group):
+        from teamarr.consumers.matching.matcher import MatchedStreamResult
+
+        results = [
+            MatchedStreamResult(
+                stream_name="ESPN",
+                stream_id=1,
+                matched=False,
+                exclusion_reason="unclassifiable",
+            ),
+            MatchedStreamResult(
+                stream_name="NFL: A vs B",
+                stream_id=2,
+                matched=False,
+                exclusion_reason="name_match_disabled",
+            ),
+            MatchedStreamResult(
+                stream_name="Bills",
+                stream_id=3,
+                matched=False,
+                exclusion_reason="team_streams_disabled",
+            ),
+            MatchedStreamResult(
+                stream_name="News Hour",
+                stream_id=4,
+                matched=False,
+                filtered_reason=FilteredReason.NOT_EVENT,
+                exclusion_reason="not_event",
+            ),
+            MatchedStreamResult(
+                stream_name="NHL: A vs B",
+                stream_id=5,
+                matched=False,
+                filtered_reason=FilteredReason.LEAGUE_NOT_INCLUDED,
+                exclusion_reason="league_not_included",
+            ),
+            MatchedStreamResult(
+                stream_name="A vs B",
+                stream_id=6,
+                matched=False,
+                failed_reason=FailedReason.NO_EVENT_FOUND,
+                exclusion_reason="no_event_found",
+            ),
+        ]
+        reasons = self._persist(db_conn, run_and_group, results)
+        assert reasons == {
+            1: "skipped:unclassifiable",
+            2: "skipped:name_match_disabled",
+            3: "skipped:team_streams_disabled",
+            4: "filtered:not_event",
+            5: "filtered:league_not_included",
+            6: "no_event_found",
+        }
+        assert "unmatched" not in reasons.values()
+
+    def test_placeholder_and_unsupported_sport_are_still_not_persisted(
+        self, db_conn, run_and_group
+    ):
+        from teamarr.consumers.matching.matcher import MatchedStreamResult
+
+        results = [
+            MatchedStreamResult(
+                stream_name="---", stream_id=1, matched=False, exclusion_reason="placeholder"
+            ),
+            MatchedStreamResult(
+                stream_name="Diving",
+                stream_id=2,
+                matched=False,
+                exclusion_reason="sport_not_supported",
+            ),
+        ]
+        assert self._persist(db_conn, run_and_group, results) == {}


### PR DESCRIPTION
Closes #662. Rescoped per the review on the issue: the numbers were right, the cause wasn't.

## What the `unmatched` rows actually were

`failed_reason=None` is almost never a matcher failure — all 30 `MatchOutcome.failed(` sites pass a real reason. The rows landing as the bare string `"unmatched"` are **filter verdicts and per-source skips** that only reached the failure branch because it is persistence's catch-all: `unclassifiable` (linear names like "ESPN"), `name_match_disabled` (every non-linear stream in an EPG-only group), `team_streams_disabled`, `FilteredReason.NOT_EVENT`, `LEAGUE_NOT_INCLUDED`. `MatchedStreamResult.filtered_reason` was already carried through; persistence ignored it.

They stay persisted (an EPG-only group still wants its linear channels listed) but under a prefix that says what they are: `filtered:not_event`, `skipped:name_match_disabled`, … Bare `"unmatched"` is now the unreachable last resort. `placeholder` / `sport_not_supported` are still not persisted.

## The 100/100 → `no_event_found` case

Not the fixture gate — the reason ladder already emits `FIXTURE_NOT_IN_LEAGUE`. It came from three *uncounted* `continue`s in the candidate loop (search window, EPG anchor tolerance, sport-hint mismatch), while `_near_miss_summary` scored the raw pre-gate list and happily printed 100/100 for an event the loop never looked at.

- New `FailedReason.CANDIDATES_GATED` — reported when every candidate was skipped before scoring and none reached the scorer. `no_event_found` now means what its docstring says: candidates were scored, none cleared the floor.
- The near-miss summary reads only the candidates that reached the scorer, with `gated=N` appended.
- The reverse-alias retry (`match_multi_league`) fires for the new reason as well as `NO_EVENT_FOUND`, so nothing that used to get a second chance loses it.

## Surface

No CHECK constraint, no dedupe key, no dropdown enumerates reasons; API `?reason=` is a free string. One label block in `RunHistoryTable.tsx`. `streams.unmatched` run-summary counts are unchanged (same rows persisted, different `reason`). `CLAUDE.md` gains a failure-taxonomy paragraph.

## Tests

`tests/matching/test_failure_taxonomy.py` (8): in-window match still matches; only-candidate outside the window / past the anchor / sport-hint mismatch → `candidates_gated` with `gated=1` in detail; scored-but-low stays `no_event_found`; a gated event never appears as a 100/100 near miss; persistence round-trips six outcome shapes to their prefixed reasons with no `unmatched` among them; placeholder/unsupported-sport still not persisted.

Gates: ruff clean, `2636 passed`, frontend builds, ESLint clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsrjBwMK9ofAMHbLvuMzSG

