### PR TITLE
feat(ordering): bulk-refresh cached stream stats before scoring (#576, #616)

### DIFF
--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -45,7 +45,7 @@ Any rule type can be used as a Scoring rule or a Priority rule.
 | **Everything Else** | Optional catch-all baseline for any stream not matched by a Priority rule. Only meaningful as a **Priority** rule — it sets the band unmatched streams land in. | Everything else → priority 99 |
 
 {: .note }
-**Stream Stats** values come from Dispatcharr's stream probe and are cached per stream. The cache refreshes when you *view a channel's streams* in the Dashboard (and the stats are missing or older than an hour) — generation itself never probes, it uses whatever is cached. Practical consequence: a Stream Stats comparison rule may not match a channel's streams until you've opened that channel in the Dashboard at least once. For the comparison operators, a stream with no value is treated as not matching; the **Unknown** operator matches exactly those streams.
+**Stream Stats** values come from Dispatcharr's stream probe and are cached per stream. Teamarr refreshes that cache in two places: at the start of generation's ordering step, in one bulk pull covering every stream on a live channel, and when you *view a channel's streams* in the Dashboard (where it re-pulls if the stats are missing or older than an hour). The generation refresh runs only when your ruleset actually contains a Stream Stats rule, so rulesets built from M3U / Group / Regex pay nothing for it. Teamarr never probes streams itself — it reads whatever Dispatcharr last measured, so a stream Dispatcharr has not probed still has no values. For the comparison operators, a stream with no value is treated as not matching; the **Unknown** operator matches exactly those streams.
 
 ### Points
 

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -1095,12 +1095,17 @@ def _apply_stream_ordering(
         get_ordered_stream_ids,
         update_stream_priority,
     )
+    from teamarr.database.channels.streams import (
+        get_active_dispatcharr_stream_ids,
+        refresh_stream_stats_bulk,
+    )
     from teamarr.database.settings import get_stream_ordering_settings
 
     reorder_result: dict = {
         "channels_reordered": 0,
         "streams_reordered": 0,
         "windows_synced": 0,
+        "stats_refreshed": 0,
     }
     try:
         with db_factory() as conn:
@@ -1135,6 +1140,28 @@ def _apply_stream_ordering(
 
             all_channels = get_all_managed_channels(conn, include_deleted=False)
             total_channels = len(all_channels)
+
+            # stats_metric rules score against the cached stream_stats column,
+            # and until now that column was only ever refreshed by the streams
+            # page — one endpoint, driven by a human opening a channel (#576,
+            # #616). Every scheduled run therefore ordered on whatever numbers
+            # happened to be cached, which on a real install means months old or
+            # absent entirely. Pull them once, in bulk, before any priority is
+            # computed.
+            #
+            # Skipped outright when no rule reads stats: the fetch buys nothing
+            # for a ruleset built from m3u/group/regex, and most are.
+            if ordering_service and any(
+                rule.type == "stats_metric" for rule in ordering_settings.rules
+            ):
+                stat_stream_ids = get_active_dispatcharr_stream_ids(conn)
+                refreshed = refresh_stream_stats_bulk(conn, stat_stream_ids)
+                reorder_result["stats_refreshed"] = refreshed
+                logger.info(
+                    "[ORDERING] Refreshed stats for %d/%d stream(s) before scoring",
+                    refreshed,
+                    len(stat_stream_ids),
+                )
 
             for idx, channel in enumerate(all_channels):
                 streams = get_channel_streams(conn, channel.id)

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -545,13 +545,102 @@ def reorder_channel_streams(
     return updated_count
 
 
+# Dispatcharr's by-ids endpoint is requested with page_size=1000, so a longer id
+# list would be silently truncated at the page boundary — every stream past the
+# first thousand would keep whatever stats it already had, which reads as "the
+# refresh ran" rather than as an error. Chunk to match.
+STATS_BATCH_SIZE = 1000
+
+
+def get_active_dispatcharr_stream_ids(conn: Connection) -> list[int]:
+    """Distinct Dispatcharr stream ids attached to channels Teamarr still owns.
+
+    The population an ordering pass is about to score: streams still on a
+    channel (``removed_at IS NULL``) whose channel has not been soft-deleted.
+    Distinct because one stream is routinely attached to several event channels
+    and only needs fetching once.
+    """
+    cursor = conn.execute(
+        """SELECT DISTINCT s.dispatcharr_stream_id
+           FROM managed_channel_streams s
+           JOIN managed_channels mc ON mc.id = s.managed_channel_id
+           WHERE s.removed_at IS NULL
+             AND mc.deleted_at IS NULL
+             AND s.dispatcharr_stream_id IS NOT NULL"""
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
+def refresh_stream_stats_bulk(conn: Connection, stream_ids: list[int]) -> int:
+    """Fetch and cache stream_stats for many Dispatcharr streams in one pass.
+
+    Pulls from Dispatcharr's ``/api/channels/streams/by-ids/`` endpoint in
+    chunks of ``STATS_BATCH_SIZE`` and writes the ``stream_stats`` /
+    ``stream_stats_updated_at`` columns. Streams Dispatcharr has not probed
+    return ``stream_stats=null`` and are left unchanged rather than blanked —
+    absent stats and stats that read zero mean different things to a
+    ``stats_metric`` rule, and only one of them is true.
+
+    The write is keyed on ``dispatcharr_stream_id`` alone, not on a channel: a
+    stream sitting on six event channels is fetched once and lands on all six
+    rows. That is the whole reason this exists next to the per-channel call —
+    ordering a full catalogue through the single-channel path costs one HTTP
+    round trip per channel, which is why the ordering pass never made it.
+
+    Args:
+        conn: Database connection
+        stream_ids: Dispatcharr stream ids to refresh
+
+    Returns:
+        Number of distinct streams whose stats were written
+    """
+    ids = sorted({int(sid) for sid in stream_ids if sid is not None})
+    if not ids:
+        return 0
+
+    client = get_dispatcharr_client()
+    if client is None:
+        return 0
+
+    updated = 0
+    for start in range(0, len(ids), STATS_BATCH_SIZE):
+        chunk = ids[start : start + STATS_BATCH_SIZE]
+        stats_list = client.get_stream_stats_by_ids(chunk)
+        if not stats_list:
+            continue
+        for entry in stats_list:
+            sid = entry.get("id")
+            raw_stats = entry.get("stream_stats")
+            updated_at = entry.get("stream_stats_updated_at")
+            if sid is None or raw_stats is None:
+                continue
+            stats_json = json.dumps(raw_stats) if isinstance(raw_stats, dict) else raw_stats
+            result = conn.execute(
+                """UPDATE managed_channel_streams
+                   SET stream_stats = ?, stream_stats_updated_at = ?
+                   WHERE dispatcharr_stream_id = ? AND removed_at IS NULL""",
+                (stats_json, updated_at, sid),
+            )
+            if result.rowcount > 0:
+                updated += 1
+
+    if updated:
+        logger.debug(
+            "[STREAM STATS] Updated stats for %d/%d stream(s) in %d batch(es)",
+            updated,
+            len(ids),
+            (len(ids) + STATS_BATCH_SIZE - 1) // STATS_BATCH_SIZE,
+        )
+    return updated
+
+
 def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
     """Fetch and cache stream_stats from Dispatcharr for a managed channel's active streams.
 
-    Pulls stats from Dispatcharr's /api/channels/streams/by-ids/ endpoint and
-    updates the stream_stats / stream_stats_updated_at columns in
-    managed_channel_streams. Streams Dispatcharr hasn't probed yet return
-    stream_stats=null and are left unchanged.
+    Thin wrapper over :func:`refresh_stream_stats_bulk` scoped to one channel's
+    streams. Those streams may also be attached elsewhere, so the refresh can
+    touch rows on other channels too — that is a strictly fresher cache for the
+    same single fetch, never a stale one.
 
     Args:
         conn: Database connection
@@ -570,35 +659,7 @@ def refresh_stream_stats(conn: Connection, managed_channel_id: int) -> int:
     if not stream_ids:
         return 0
 
-    client = get_dispatcharr_client()
-    if client is None:
-        return 0
-
-    stats_list = client.get_stream_stats_by_ids(stream_ids)
-    if not stats_list:
-        return 0
-
-    updated = 0
-    for entry in stats_list:
-        sid = entry.get("id")
-        raw_stats = entry.get("stream_stats")
-        updated_at = entry.get("stream_stats_updated_at")
-        if sid is None or raw_stats is None:
-            continue
-        stats_json = json.dumps(raw_stats) if isinstance(raw_stats, dict) else raw_stats
-        result = conn.execute(
-            """UPDATE managed_channel_streams
-               SET stream_stats = ?, stream_stats_updated_at = ?
-               WHERE managed_channel_id = ? AND dispatcharr_stream_id = ? AND removed_at IS NULL""",
-            (stats_json, updated_at, managed_channel_id, sid),
-        )
-        if result.rowcount > 0:
-            updated += 1
-
-    if updated:
-        logger.debug("[STREAM STATS] Updated stats for %d/%d streams on channel %d",
-                     updated, len(stream_ids), managed_channel_id)
-    return updated
+    return refresh_stream_stats_bulk(conn, stream_ids)
 
 
 def get_stream_match_details(

--- a/tests/epg/test_generation_helpers.py
+++ b/tests/epg/test_generation_helpers.py
@@ -8,11 +8,14 @@ Each helper is exercised against a real temp database (conftest db fixtures):
   configured global range (#146) and stays quiet otherwise.
 - _apply_stream_ordering applies rules to stream priorities in the DB, runs
   as a window-sync-only pass without rules, and converts internal failures
-  into an "error" result key instead of raising (generation must not die).
+  into an "error" result key instead of raising (generation must not die). It
+  also bulk-refreshes cached Dispatcharr stream stats before scoring, but only
+  when a stats_metric rule is actually present (#576, #616).
 """
 
 import json
 
+import teamarr.database.channels.streams as streams_mod
 from teamarr.consumers.generation import (
     _apply_stream_ordering,
     _refresh_m3u_accounts,
@@ -242,3 +245,85 @@ def test_ended_event_gets_rule_order(db_factory, db_conn, monkeypatch):
     _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
 
     assert _RecordingChannelManager.pushes == [(555, {"streams": [101, 100]})]
+
+
+# ---------------------------------------------------------------------------
+# _apply_stream_ordering — pre-scoring stats refresh (#576, #616)
+# ---------------------------------------------------------------------------
+
+
+class _StatsStub:
+    """Records the id lists an ordering pass asks Dispatcharr for."""
+
+    def __init__(self, stats_list=None):
+        self._stats_list = stats_list or []
+        self.calls = []
+
+    def get_stream_stats_by_ids(self, stream_ids):
+        self.calls.append(list(stream_ids))
+        return self._stats_list
+
+
+def _set_rules(conn, rules):
+    conn.execute(
+        "UPDATE settings SET stream_ordering_rules = ? WHERE id = 1", (json.dumps(rules),)
+    )
+    conn.commit()
+
+
+def test_ordering_refreshes_stats_once_before_scoring(db_factory, db_conn, monkeypatch):
+    _seed_channel_with_streams(db_conn)
+    _set_rules(db_conn, [
+        {
+            "type": "stats_metric",
+            "value": "ffmpeg_output_bitrate|>=|5000",
+            "priority": 99,
+            "mode": "score",
+            "points": 10,
+        }
+    ])
+    stub = _StatsStub([
+        {
+            "id": 100,
+            "stream_stats": {"ffmpeg_output_bitrate": 9000},
+            "stream_stats_updated_at": "t",
+        },
+    ])
+    monkeypatch.setattr(streams_mod, "get_dispatcharr_client", lambda: stub)
+
+    result = _apply_stream_ordering(db_factory, None, _noop_progress)
+
+    # One bulk call for the whole pass, not one per channel.
+    assert stub.calls == [[100, 101]]
+    assert result["stats_refreshed"] == 1
+    # And the freshly pulled number is what got scored.
+    assert json.loads(
+        db_conn.execute(
+            "SELECT stream_stats FROM managed_channel_streams "
+            "WHERE dispatcharr_stream_id = 100"
+        ).fetchone()["stream_stats"]
+    ) == {"ffmpeg_output_bitrate": 9000}
+
+
+def test_ordering_skips_the_fetch_when_no_rule_reads_stats(db_factory, db_conn, monkeypatch):
+    _seed_channel_with_streams(db_conn)
+    _set_rules(db_conn, [{"type": "regex", "value": "(?i)1080p", "priority": 1}])
+    stub = _StatsStub()
+    monkeypatch.setattr(streams_mod, "get_dispatcharr_client", lambda: stub)
+
+    result = _apply_stream_ordering(db_factory, None, _noop_progress)
+
+    # A ruleset built from m3u/group/regex gains nothing from the fetch.
+    assert stub.calls == []
+    assert result["stats_refreshed"] == 0
+
+
+def test_ordering_without_rules_never_fetches_stats(db_factory, db_conn, monkeypatch):
+    _seed_channel_with_streams(db_conn)
+    stub = _StatsStub()
+    monkeypatch.setattr(streams_mod, "get_dispatcharr_client", lambda: stub)
+
+    result = _apply_stream_ordering(db_factory, None, _noop_progress)
+
+    assert stub.calls == []
+    assert result["stats_refreshed"] == 0

--- a/tests/lifecycle/test_stream_stats.py
+++ b/tests/lifecycle/test_stream_stats.py
@@ -10,6 +10,10 @@ The DB stores managed_channel_streams.stream_stats as a JSON string.
 - clear_stream_stats drops the cached stats when a group's match cache is
   cleared, so they get freshly pulled on the next run — like everything else
   the cache clear resets.
+- get_active_dispatcharr_stream_ids / refresh_stream_stats_bulk are the
+  ordering pass's route to the same data (#576, #616): one chunked fetch for
+  every stream on a live channel, written to every row that holds it, instead
+  of one HTTP round trip per channel.
 """
 
 import json
@@ -17,7 +21,12 @@ import json
 import pytest
 
 import teamarr.database.channels.streams as streams_mod
-from teamarr.database.channels.streams import clear_stream_stats, refresh_stream_stats
+from teamarr.database.channels.streams import (
+    clear_stream_stats,
+    get_active_dispatcharr_stream_ids,
+    refresh_stream_stats,
+    refresh_stream_stats_bulk,
+)
 from teamarr.database.channels.types import ManagedChannelStream
 
 
@@ -263,3 +272,157 @@ def test_clear_all_nulls_every_active_stream(db_conn):
     assert _stats_row(db_conn, 200)["stream_stats"] is None
     # Removed stream untouched.
     assert _stats_row(db_conn, 300)["stream_stats"] is not None
+
+
+# ---------------------------------------------------------------------------
+# get_active_dispatcharr_stream_ids — the population an ordering pass scores
+# ---------------------------------------------------------------------------
+
+
+def _insert_deleted_channel(db_conn) -> int:
+    cur = db_conn.execute(
+        "INSERT INTO managed_channels (event_id, event_provider, tvg_id, channel_name, deleted_at) "
+        "VALUES ('e2', 'espn', 'tvg-2', 'Gone', '2026-08-01 00:00:00')"
+    )
+    return cur.lastrowid
+
+
+def test_active_ids_excludes_removed_streams(db_conn):
+    cid = _insert_channel(db_conn)
+    _insert_stream(db_conn, cid, 100)
+    _insert_stream(db_conn, cid, 101, removed=True)
+    db_conn.commit()
+
+    assert get_active_dispatcharr_stream_ids(db_conn) == [100]
+
+
+def test_active_ids_excludes_soft_deleted_channels(db_conn):
+    live = _insert_channel(db_conn)
+    dead = _insert_deleted_channel(db_conn)
+    _insert_stream(db_conn, live, 100)
+    _insert_stream(db_conn, dead, 200)
+    db_conn.commit()
+
+    assert get_active_dispatcharr_stream_ids(db_conn) == [100]
+
+
+def test_active_ids_dedupes_a_stream_on_several_channels(db_conn):
+    first = _insert_channel(db_conn)
+    second = _insert_channel(db_conn)
+    _insert_stream(db_conn, first, 100)
+    _insert_stream(db_conn, second, 100)
+    db_conn.commit()
+
+    # One fetch, not one per channel — the reason the bulk path exists.
+    assert get_active_dispatcharr_stream_ids(db_conn) == [100]
+
+
+# ---------------------------------------------------------------------------
+# refresh_stream_stats_bulk — one fetch for the whole ordering population
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_empty_ids_returns_zero_without_client(db_conn, patch_client):
+    install, _ = patch_client
+    stub = _StubClient([{"id": 1, "stream_stats": {"x": 1}, "stream_stats_updated_at": "t"}])
+    install(stub)
+
+    assert refresh_stream_stats_bulk(db_conn, []) == 0
+    assert stub.calls == []
+
+
+def test_bulk_client_none_returns_zero(db_conn, patch_client):
+    install, _ = patch_client
+    install(None)
+    cid = _insert_channel(db_conn)
+    _insert_stream(db_conn, cid, 100)
+    db_conn.commit()
+
+    assert refresh_stream_stats_bulk(db_conn, [100]) == 0
+
+
+def test_bulk_writes_one_stream_onto_every_channel_holding_it(db_conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([
+        {"id": 100, "stream_stats": {"alive": False}, "stream_stats_updated_at": "t"},
+    ]))
+    first = _insert_channel(db_conn)
+    second = _insert_channel(db_conn)
+    _insert_stream(db_conn, first, 100)
+    _insert_stream(db_conn, second, 100)
+    db_conn.commit()
+
+    # Counted once — the return is distinct streams, matching the per-channel
+    # contract — but both rows carry the verdict.
+    assert refresh_stream_stats_bulk(db_conn, [100]) == 1
+    rows = db_conn.execute(
+        "SELECT stream_stats FROM managed_channel_streams WHERE dispatcharr_stream_id = 100"
+    ).fetchall()
+    assert len(rows) == 2
+    assert all(json.loads(r["stream_stats"]) == {"alive": False} for r in rows)
+
+
+def test_bulk_dedupes_and_sorts_requested_ids(db_conn, patch_client):
+    install, _ = patch_client
+    stub = _StubClient([])
+    install(stub)
+
+    refresh_stream_stats_bulk(db_conn, [101, 100, 101, 100])
+
+    assert stub.calls == [[100, 101]]
+
+
+def test_bulk_chunks_at_the_endpoint_page_size(db_conn, patch_client, monkeypatch):
+    install, _ = patch_client
+    stub = _StubClient([])
+    install(stub)
+    # The real cap is 1000; shrink it so the boundary is testable.
+    monkeypatch.setattr(streams_mod, "STATS_BATCH_SIZE", 2)
+
+    refresh_stream_stats_bulk(db_conn, [1, 2, 3, 4, 5])
+
+    assert stub.calls == [[1, 2], [3, 4], [5]]
+
+
+def test_bulk_leaves_unprobed_streams_alone(db_conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([
+        {"id": 100, "stream_stats": None, "stream_stats_updated_at": None},
+        {"id": 101, "stream_stats": {"alive": True}, "stream_stats_updated_at": "t"},
+    ]))
+    cid = _insert_channel(db_conn)
+    _insert_stream(db_conn, cid, 100)
+    _insert_stream(db_conn, cid, 101)
+    db_conn.commit()
+
+    # Absent stats and stats reading zero are different claims; only one is true.
+    assert refresh_stream_stats_bulk(db_conn, [100, 101]) == 1
+    assert _stats_row(db_conn, 100)["stream_stats"] is None
+
+
+def test_bulk_skips_removed_rows(db_conn, patch_client):
+    install, _ = patch_client
+    install(_StubClient([
+        {"id": 100, "stream_stats": {"alive": True}, "stream_stats_updated_at": "t"},
+    ]))
+    cid = _insert_channel(db_conn)
+    _insert_stream(db_conn, cid, 100, removed=True)
+    db_conn.commit()
+
+    assert refresh_stream_stats_bulk(db_conn, [100]) == 0
+    assert _stats_row(db_conn, 100)["stream_stats"] is None
+
+
+def test_per_channel_refresh_still_scopes_its_fetch_to_that_channel(db_conn, patch_client):
+    install, _ = patch_client
+    stub = _StubClient([])
+    install(stub)
+    mine = _insert_channel(db_conn)
+    theirs = _insert_channel(db_conn)
+    _insert_stream(db_conn, mine, 100)
+    _insert_stream(db_conn, theirs, 200)
+    db_conn.commit()
+
+    refresh_stream_stats(db_conn, mine)
+
+    assert stub.calls == [[100]]


### PR DESCRIPTION
Phase 1 of `teamarrv2-20ep`. Closes the stale-by-default half of #576 and all of #616.

## The bug

`stats_metric` rules score against `managed_channel_streams.stream_stats`. That column had exactly one writer — `api/routes/channels.py:368`, the channel-detail route behind the Dashboard's streams panel. `_apply_stream_ordering` never refreshed it.

So every scheduled generation ordered on whatever a human had last happened to open. On the install this was found against:

- `stream_stats_updated_at` values running back to **March and June**
- **2 of 2,790** live streams on undeleted channels carried stats at all

A rule set whose only measurement-driven lever is `stats_metric` was, in practice, ordering on nothing.

## The change

The ordering step now pulls current stats in one chunked bulk call before any priority is computed.

- **`get_active_dispatcharr_stream_ids(conn)`** — distinct Dispatcharr stream ids on channels still live (`removed_at IS NULL`, `deleted_at IS NULL`). Distinct because one stream routinely sits on several event channels.
- **`refresh_stream_stats_bulk(conn, stream_ids)`** — chunked at `STATS_BATCH_SIZE = 1000` to match the by-ids endpoint's own `page_size=1000`. Without the chunk a longer list truncates at the page boundary and every stream past the first thousand keeps its old stats, which reads as "the refresh ran" rather than as an error. The write keys on `dispatcharr_stream_id` alone, so a stream on six channels is fetched once and lands on all six rows.
- **`refresh_stream_stats(conn, managed_channel_id)`** keeps its signature and its documented per-channel return, now as a thin wrapper.

On that install: **3 chunked calls instead of 367 per-channel round trips.**

### Gating

The fetch runs only when the rule set actually contains a `stats_metric` rule. A ruleset built from m3u/group/regex gains nothing from it and pays nothing for it.

No TTL. The bead's phase 2 wants a 5–10 minute reorder cadence, and a staleness gate there would just reintroduce the same class of bug one layer up; one bulk call per generation run is cheap enough to always be correct instead.

### Unprobed streams

Dispatcharr returns `stream_stats=null` for streams it has not probed. Those rows are left alone rather than blanked — absent stats and stats reading zero are different claims to a `stats_metric` rule, and only one of them is true. The `Unknown` operator still matches exactly those streams.

## Not in this PR

Left on the bead deliberately:

- phase 2, the scheduled reorder mini-task (needs the sandbox PATCH-during-playback gate first)
- route ordering writing through `_safe_update_channel`
- reconciliation detecting order drift

## Tests

`2657 passed`, ruff clean, frontend builds.

New coverage in `tests/lifecycle/test_stream_stats.py` (chunk boundary, id dedupe, one stream onto every channel holding it, unprobed left alone, removed rows skipped, per-channel wrapper still scopes its fetch) and `tests/epg/test_generation_helpers.py` (one bulk call per pass not per channel, skipped when no rule reads stats, skipped when there are no rules).

## Docs

`docs/guide/channels/stream-priority.md` — the note under **Stream Stats** said generation "never probes, it uses whatever is cached" and that a rule "may not match until you've opened that channel in the Dashboard." Both were true and are now not.