### PR TITLE
fix(ordering): live-event #1 pin yields to a dead or blank measurement (#670)

### DIFF
--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -84,7 +84,9 @@ The **Specific Team's Feed** rule first checks the **resolved feed team** stored
 
 While an event is airing, scheduled generation runs won't displace the channel's top stream — the one a viewer is most likely watching. Rule changes still take effect in the background (priorities are recomputed and stored), and new streams that match mid-event are added **below** the current #1, but the top slot itself stays put until the event ends. The first run after the event restores full rule ordering.
 
-A **manually triggered** generation run bypasses this pin — that's your escape hatch if the pinned stream is the wrong one: fix your rules (or remove the bad stream) and hit Generate.
+The pin holds because the top slot is presumed to be what somebody is watching. When a probe contradicts that — the cached [Stream Stats](#rule-types) say the stream is **dead or a black screen** — the pin releases and normal rule ordering takes the top slot, because a stream that isn't there is not one anybody is watching. Only an actual measurement lifts it: a stream with no stats, or stats that say nothing about liveness, stays pinned, since not knowing a stream is dead is not the same as knowing it is.
+
+A **manually triggered** generation run bypasses this pin entirely — that's your escape hatch if the pinned stream is the wrong one for any other reason: fix your rules (or remove the bad stream) and hit Generate.
 
 ## Why is a stream ordered this way?
 

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -1177,6 +1177,32 @@ def _apply_stream_ordering(
                 ):
                     pre_order = get_ordered_stream_ids(conn, channel.id)
                     pinned_top = pre_order[0] if pre_order else None
+                    # The pin's premise is that slot 1 is what somebody is
+                    # watching. A probe saying the stream is dead or a black
+                    # screen contradicts that premise, and the pin has to yield
+                    # to it (#670): an in-flight session has already failed over
+                    # to slot 2, while every new tune-in pays the failover
+                    # again. Holding it would also silently undo the demotion a
+                    # stats_metric rule just made — the priority lands in the DB
+                    # and never reaches Dispatcharr — for the whole live window.
+                    #
+                    # Only a measurement lifts the pin. No stats, absent keys
+                    # and unreadable stats all leave it in place, because those
+                    # say nothing about the stream and holding when nothing is
+                    # known is exactly what the pin is for.
+                    if pinned_top is not None:
+                        top = next(
+                            (s for s in streams if s.dispatcharr_stream_id == pinned_top), None
+                        )
+                        if top is not None and top.measured_dead_or_blank:
+                            logger.info(
+                                "[STREAM_AUDIT] pin: ch='%s' (d_id=%s) live event — "
+                                "released stream %d from #1, measured dead/blank (#670)",
+                                channel.channel_name,
+                                channel.dispatcharr_channel_id,
+                                pinned_top,
+                            )
+                            pinned_top = None
 
                 reordered_count = 0
                 if ordering_service:

--- a/teamarr/database/channels/types.py
+++ b/teamarr/database/channels/types.py
@@ -151,6 +151,29 @@ class ManagedChannelStream:
     stream_stats: dict | None = None
     stream_stats_updated_at: datetime | None = None
 
+    @property
+    def measured_dead_or_blank(self) -> bool:
+        """Whether a probe has actually found this stream unwatchable (#670).
+
+        Reads two conventional keys out of the cached ``stream_stats``: ``alive``
+        false, or ``blank_detected`` true. Both are written by whatever probed
+        the stream — Teamarr never probes anything itself.
+
+        Deliberately three-state in effect, not two. This is False when there
+        are no stats, when the keys are absent, and when they are present but
+        unreadable, because *not knowing* a stream is dead is not the same as
+        knowing it is alive, and every caller here acts on the difference. A
+        zero bitrate is likewise not consulted: an unmeasured stream reports
+        zero exactly as a dead one does, and only these two keys distinguish
+        them.
+        """
+        stats = self.stream_stats
+        if not isinstance(stats, dict):
+            return False
+        if "alive" in stats and stats["alive"] is not None and not stats["alive"]:
+            return True
+        return bool(stats.get("blank_detected"))
+
     @classmethod
     def from_row(cls, row: dict) -> "ManagedChannelStream":
         """Create from database row dict."""

--- a/tests/epg/test_generation_helpers.py
+++ b/tests/epg/test_generation_helpers.py
@@ -327,3 +327,82 @@ def test_ordering_without_rules_never_fetches_stats(db_factory, db_conn, monkeyp
 
     assert stub.calls == []
     assert result["stats_refreshed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _apply_stream_ordering — the pin yields to a dead/blank measurement (#670)
+# ---------------------------------------------------------------------------
+
+
+def _set_stats(conn, dispatcharr_stream_id, stats):
+    """Cache stream_stats against a stream, as a refresh would have."""
+    conn.execute(
+        "UPDATE managed_channel_streams SET stream_stats = ? WHERE dispatcharr_stream_id = ?",
+        (stats if isinstance(stats, str) or stats is None else json.dumps(stats),
+         dispatcharr_stream_id),
+    )
+    conn.commit()
+
+
+def test_pin_releases_an_incumbent_measured_dead(db_factory, db_conn, monkeypatch):
+    # Without this the demotion lands in the DB and never reaches Dispatcharr:
+    # the pin puts the dead stream straight back at #1 for the whole live
+    # window, which is precisely the slot where failover order costs something.
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 100, {"alive": False, "ffmpeg_output_bitrate": 0})
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [101, 100]})]
+
+
+def test_pin_releases_an_incumbent_measured_blank(db_factory, db_conn, monkeypatch):
+    # A black screen is up, answers, and is worth nothing to a viewer.
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 100, {"alive": True, "blank_detected": True})
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [101, 100]})]
+
+
+def test_pin_holds_for_an_incumbent_measured_alive(db_factory, db_conn, monkeypatch):
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 100, {"alive": True, "ffmpeg_output_bitrate": 8000})
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [100, 101]})]
+
+
+def test_pin_holds_when_stats_say_nothing_about_liveness(db_factory, db_conn, monkeypatch):
+    # Stats from a probe that reports resolution but no liveness verdict. Not
+    # knowing a stream is dead is not knowing it is alive, and the pin's whole
+    # job is to hold when nothing is known.
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 100, {"resolution": "1920x1080", "source_fps": 60})
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [100, 101]})]
+
+
+def test_pin_holds_when_stats_are_unreadable(db_factory, db_conn, monkeypatch):
+    # Malformed JSON decodes to None. A parse failure must not read as a death.
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 100, "{not valid json")
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [100, 101]})]
+
+
+def test_pin_ignores_a_dead_stream_that_is_not_the_incumbent(db_factory, db_conn, monkeypatch):
+    # Only slot 1 is pinned, so only slot 1's health can lift the pin. A dead
+    # challenger changes nothing about whether the incumbent stays put.
+    _seed_live_channel(db_conn, live=True)
+    _set_stats(db_conn, 101, {"alive": False})
+
+    _run_ordering_with_recorder(db_factory, monkeypatch, manual=False)
+
+    assert _RecordingChannelManager.pushes == [(555, {"streams": [100, 101]})]

--- a/tests/lifecycle/test_stream_stats.py
+++ b/tests/lifecycle/test_stream_stats.py
@@ -426,3 +426,47 @@ def test_per_channel_refresh_still_scopes_its_fetch_to_that_channel(db_conn, pat
     refresh_stream_stats(db_conn, mine)
 
     assert stub.calls == [[100]]
+
+
+# ---------------------------------------------------------------------------
+# ManagedChannelStream.measured_dead_or_blank (#670)
+# ---------------------------------------------------------------------------
+
+
+def _stream_with(stats):
+    return ManagedChannelStream.from_row(_row(stats))
+
+
+def test_measured_dead_when_alive_is_false():
+    assert _stream_with({"alive": False}).measured_dead_or_blank is True
+
+
+def test_measured_dead_when_blank_detected():
+    assert _stream_with({"alive": True, "blank_detected": True}).measured_dead_or_blank is True
+
+
+def test_alive_stream_is_not_dead():
+    assert _stream_with({"alive": True}).measured_dead_or_blank is False
+
+
+def test_absent_stats_is_not_a_death():
+    # Not knowing is not knowing it is dead. Every caller acts on the gap.
+    assert _stream_with(None).measured_dead_or_blank is False
+
+
+def test_stats_without_liveness_keys_is_not_a_death():
+    assert _stream_with({"resolution": "1920x1080"}).measured_dead_or_blank is False
+
+
+def test_unreadable_stats_is_not_a_death():
+    assert _stream_with("{not valid json").measured_dead_or_blank is False
+
+
+def test_null_alive_is_not_a_death():
+    # An explicit null is the probe declining to say, not saying "dead".
+    assert _stream_with({"alive": None}).measured_dead_or_blank is False
+
+
+def test_zero_bitrate_alone_is_not_a_death():
+    # An unmeasured stream reports zero exactly as a dead one does.
+    assert _stream_with({"ffmpeg_output_bitrate": 0}).measured_dead_or_blank is False


### PR DESCRIPTION
Closes #670. Bead `teamarrv2-47ve`. Unblocks phase 2 of `teamarrv2-20ep`.

## The bug

The #232 pin holds a live channel's slot-1 stream at the front of the pushed list so a re-gen can't displace what a viewer is watching. It applied unconditionally — no check on whether that stream was still up.

So when a `stats_metric` rule demoted slot 1 because the cached stats said dead or blank:

1. the rule-truth priority **was** written to `managed_channel_streams`
2. the channel counted as reordered, so a push happened
3. the pin then lifted that same stream back to the front of `ordered_ids`

The demotion never reached Dispatcharr, and stayed undone for the whole live window — `[event_date, scheduled_delete_at]`, falling back to `event_date + 6h`.

Harmless while nothing could express liveness. It stops being harmless as soon as a rule can.

It also contradicts what #576's phase 2 is for. That bead's stated value is *"re-sorting 2..N mid-game is the value: failover lands on current best"* — and it inherits this pin. Slot 1 is the only slot where failover order costs anything, and it was the one slot frozen.

## The change

The pin's premise is that slot 1 is what somebody is watching. A probe saying the stream is dead or a black screen contradicts that premise: an in-flight session has already failed over to slot 2, while every new tune-in pays the failover again. So the pin releases and rule ordering takes the top slot.

`ManagedChannelStream.measured_dead_or_blank` reads two conventional keys out of the cached stats — `alive` false, or `blank_detected` true.

**Only a measurement lifts the pin.** It returns `False` for:

- no stats at all
- stats present, liveness keys absent (a probe that reports resolution and nothing else)
- an explicit `"alive": null` — the probe declining to say
- stats that failed to parse

Not knowing a stream is dead is not knowing it is alive, and holding when nothing is known is the pin's entire job.

A zero bitrate is deliberately **not** consulted: an unmeasured stream reports zero exactly as a dead one does, and only those two keys tell them apart.

Releases are logged under `[STREAM_AUDIT] pin:`, alongside the existing hold line. A pin that silently stops applying is as hard to reason about as one that silently applies.

Manual runs still bypass the pin wholesale, unchanged.

## Tests

`2657 passed` (dev baseline 2643, +14), ruff clean, frontend builds.

The three existing #232 tests pass untouched — they seed no stats, so the pin holds exactly as before.

New: pin releases on dead, releases on blank, holds on alive, holds when stats carry no liveness keys, holds on unreadable stats, and ignores a dead stream that isn't the incumbent (only slot 1 is pinned, so only slot 1's health can lift it). Plus eight unit tests on the property itself.

## Docs

`docs/guide/channels/stream-priority.md` — "Live events keep their #1 stream" now states the one condition under which they don't, and that only a real measurement counts.

## Note on ordering

Branched from `dev`, independent of #669 — the two can land in either order. Without #669 the pin reads whatever stats were last cached; still correct, just less timely.