### PR TITLE
fix(channels): reclaim feed-separated channels when the toggle goes off (#672)

### DIFF
--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -71,6 +71,15 @@ Feed **identification** always runs — every stream's resolved feed team *and* 
 | **Detect Team Names** | On | Also match team names in stream names (e.g., "Orioles Feed") |
 | **Feed Label Style** | Team Name | How feed channels are labeled — see below |
 
+### Turning It Off
+
+Turning the master toggle off un-splits on the **next generation run**: the
+existing `…-feed-<team>` channels are deleted and their streams re-land on the
+event's shared channel in that same pass, freeing the channel numbers the feed
+block held. Only events matched by that run are reclaimed — a feed channel for
+an event that isn't in today's slate keeps its normal end-of-event deletion
+rather than being pulled mid-broadcast.
+
 ### Label Styles
 
 Controls the label appended to channel names when a feed team is detected (always in the form `(<label> Feed)`):

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -7,6 +7,7 @@ resolution and UFC/racing segment expansion of the matched-stream list.
 import logging
 from collections.abc import Callable
 from datetime import date, datetime, timedelta
+from sqlite3 import Connection
 from typing import TYPE_CHECKING, Any
 
 from teamarr.consumers.event_group_processor.stream_fetcher import (
@@ -37,6 +38,7 @@ class StreamMatching:
         _shared_events: Any
         _get_all_known_leagues: Any
         _load_sport_durations: Any
+        _get_lifecycle_service: Any
 
     def _match_streams(
         self,
@@ -504,6 +506,70 @@ class StreamMatching:
                 )
 
         return matched_streams
+
+    def _cleanup_feed_separated_channels(
+        self,
+        group: EventEPGGroup,
+        conn: Connection,
+        passed_event_ids: set[str],
+    ) -> int:
+        """Reclaim feed-separated channels after the master toggle is turned off (#672).
+
+        Disabling ``feed_separation.enabled`` makes ``_resolve_feed_teams``
+        stop populating ``feed_team``, so every lookup this run carries
+        ``feed_team_id=None``. ``find_existing_channel`` then constrains on
+        ``feed_team_id IS NULL`` and matches (or creates) the base channel —
+        the rows already carrying a feed team are never returned, so they are
+        never synced, never renamed and never deleted. They sat beside a
+        freshly created duplicate base channel until their scheduled deletion,
+        consuming the numbers of their feed block the whole time.
+
+        Scoped to events that survived the team filter this run, so every
+        deleted feed channel has a base channel to land on in the same pass —
+        feed channels for events not matched today keep their normal
+        end-of-event deletion rather than being dropped mid-broadcast.
+
+        Args:
+            group: The event group being processed
+            conn: Database connection
+            passed_event_ids: Segment-aware event IDs that passed team filtering
+
+        Returns:
+            Number of channels deleted.
+        """
+        from teamarr.database.channels import get_managed_channels_for_group
+
+        if not passed_event_ids:
+            return 0
+
+        reclaimable = [
+            ch
+            for ch in get_managed_channels_for_group(conn, group.id)
+            if getattr(ch, "feed_team_id", None) and ch.event_id in passed_event_ids
+        ]
+        if not reclaimable:
+            return 0
+
+        # Built lazily: constructing the lifecycle service scans Dispatcharr for
+        # externally occupied numbers, which is wasted work on the overwhelmingly
+        # common run where the toggle is off and no feed channels are left.
+        lifecycle_service = self._get_lifecycle_service()
+
+        deleted = 0
+        for channel in reclaimable:
+            if lifecycle_service.delete_managed_channel(
+                conn, channel.id, reason="feed_separation_disabled"
+            ):
+                deleted += 1
+                logger.info(
+                    "[FEED] Reclaimed feed channel '%s' (event_id=%s, feed_team_id=%s) "
+                    "— feed separation is off",
+                    channel.channel_name,
+                    channel.event_id,
+                    channel.feed_team_id,
+                )
+
+        return deleted
 
     @staticmethod
     def _broadcast_name_in_stream(name_norm: str, stream_norm: str) -> bool:

--- a/teamarr/consumers/event_group_processor/processor.py
+++ b/teamarr/consumers/event_group_processor/processor.py
@@ -754,6 +754,21 @@ class EventGroupProcessor(
                 result.channels_deleted = cleanup_count
                 logger.info("[EVENT_EPG] Cleaned up %d channels due to team filter", cleanup_count)
 
+            # Reclaim feed-separated channels once the master toggle goes off (#672).
+            # Runs BEFORE channel processing so the freed streams re-land on the base
+            # channel in this same pass instead of duplicating it for a day.
+            if not feed_settings.enabled:
+                feed_cleanup_count = self._cleanup_feed_separated_channels(
+                    group, conn, passed_event_ids
+                )
+                if feed_cleanup_count > 0:
+                    result.channels_deleted += feed_cleanup_count
+                    logger.info(
+                        "[EVENT_EPG] Reclaimed %d feed-separated channel(s) — "
+                        "feed separation is off",
+                        feed_cleanup_count,
+                    )
+
             # Build stream dict for cleanup (fingerprint-based content change detection)
             current_streams = {sid: s for s in streams if (sid := s.get("id"))}
 
@@ -767,7 +782,9 @@ class EventGroupProcessor(
                 result.channels_created = len(lifecycle_result.created)
                 result.channels_existing = len(lifecycle_result.existing)
                 result.channels_skipped = len(lifecycle_result.skipped)
-                result.channels_deleted = len(lifecycle_result.deleted)
+                # += : the team-filter and feed-separation sweeps above already
+                # counted their deletions into this field.
+                result.channels_deleted += len(lifecycle_result.deleted)
                 result.channel_errors = len(lifecycle_result.errors)
                 # Add lifecycle exclusions to total
                 result.streams_excluded += len(lifecycle_result.excluded)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -127,6 +127,7 @@ class FakeChannel:
     league: str | None = None
     event_epg_group_id: int | None = 1
     event_id: str | None = None
+    feed_team_id: str | None = None
 
 
 @dataclass

--- a/tests/test_feed_separation.py
+++ b/tests/test_feed_separation.py
@@ -1120,3 +1120,207 @@ class TestResolveFeedTeamsMatchedSide:
         # team names stays a shared feed.
         stream = {"name": "Pittsburgh Pirates vs Miami Marlins"}
         assert self._resolve(stream, event, matched_side=None) is None
+
+
+# ===========================================================================
+# Reclaiming feed channels after the master toggle goes off (#672)
+# ===========================================================================
+
+
+class TestCleanupFeedSeparatedChannels:
+    """_cleanup_feed_separated_channels un-splits after the toggle goes off.
+
+    With separation off every lookup carries feed_team_id=None, so
+    find_existing_channel constrains on `feed_team_id IS NULL` and never
+    returns the rows that already carry a feed team — they were neither
+    synced nor deleted, and sat beside a freshly created duplicate base
+    channel until their scheduled deletion.
+    """
+
+    @staticmethod
+    def _cleanup(channels, passed_event_ids, delete_ok=True):
+        from unittest.mock import MagicMock, patch
+
+        from teamarr.consumers.event_group_processor.matching import StreamMatching
+        from tests.fakes import FakeGroup
+
+        processor = StreamMatching()
+        lifecycle = MagicMock()
+        lifecycle.delete_managed_channel.return_value = delete_ok
+        processor._get_lifecycle_service = lambda: lifecycle
+
+        with patch(
+            "teamarr.database.channels.get_managed_channels_for_group",
+            return_value=channels,
+        ):
+            deleted = processor._cleanup_feed_separated_channels(
+                FakeGroup(), MagicMock(), passed_event_ids
+            )
+        return deleted, lifecycle
+
+    def test_deletes_feed_channels_for_matched_events(self):
+        from tests.fakes import FakeChannel
+
+        channels = [
+            FakeChannel(id=1, event_id="401874913", feed_team_id=None),
+            FakeChannel(id=2, event_id="401874913", feed_team_id="2"),
+            FakeChannel(id=3, event_id="401874913", feed_team_id="10"),
+        ]
+        deleted, lifecycle = self._cleanup(channels, {"401874913"})
+        assert deleted == 2
+        deleted_ids = [c.args[1] for c in lifecycle.delete_managed_channel.call_args_list]
+        assert deleted_ids == [2, 3]
+
+    def test_base_channel_is_never_deleted(self):
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=1, event_id="401874913", feed_team_id=None)]
+        deleted, lifecycle = self._cleanup(channels, {"401874913"})
+        assert deleted == 0
+        lifecycle.delete_managed_channel.assert_not_called()
+
+    def test_unmatched_event_keeps_its_feed_channel(self):
+        # No base channel would be created for it this run, so dropping the
+        # feed channel would take a live broadcast off the air. It falls to
+        # its normal end-of-event deletion instead.
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=2, event_id="401816721", feed_team_id="19")]
+        deleted, lifecycle = self._cleanup(channels, {"401874913"})
+        assert deleted == 0
+        lifecycle.delete_managed_channel.assert_not_called()
+
+    def test_segment_aware_event_ids_match(self):
+        # Channel identity stores the segment-aware id, and so does
+        # passed_event_ids — a segmented feed channel must still be reclaimed.
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=2, event_id="600053-prelims", feed_team_id="2")]
+        deleted, _ = self._cleanup(channels, {"600053-prelims"})
+        assert deleted == 1
+
+    def test_empty_passed_set_is_a_noop(self):
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=2, event_id="401874913", feed_team_id="2")]
+        deleted, lifecycle = self._cleanup(channels, set())
+        assert deleted == 0
+        lifecycle.delete_managed_channel.assert_not_called()
+
+    def test_failed_deletion_is_not_counted(self):
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=2, event_id="401874913", feed_team_id="2")]
+        deleted, _ = self._cleanup(channels, {"401874913"}, delete_ok=False)
+        assert deleted == 0
+
+    def test_deletion_reason_is_recorded(self):
+        from tests.fakes import FakeChannel
+
+        channels = [FakeChannel(id=2, event_id="401874913", feed_team_id="2")]
+        _, lifecycle = self._cleanup(channels, {"401874913"})
+        assert (
+            lifecycle.delete_managed_channel.call_args.kwargs["reason"]
+            == "feed_separation_disabled"
+        )
+
+
+class TestToggleGatesTheCleanupPass:
+    """The reclaim runs only while the master toggle is off (#672).
+
+    Pipeline-level guard: _process_group_internal must not reach the sweep
+    while separation is enabled — that would delete the very channels the
+    feature just created.
+    """
+
+    @staticmethod
+    def _run_pipeline(db_conn, db_factory, monkeypatch, *, separation_enabled):
+        from datetime import date
+        from unittest.mock import MagicMock
+
+        from teamarr.consumers.channel_lifecycle import StreamProcessResult
+        from teamarr.consumers.event_group_processor import EventGroupProcessor
+        from teamarr.consumers.matching.matcher import BatchMatchResult
+        from teamarr.database.groups import create_group, get_group
+        from teamarr.database.settings import update_feed_separation_settings
+        from teamarr.services.stream_filter import FilterResult
+        from tests.fakes import make_event
+
+        cur = db_conn.execute(
+            "INSERT INTO templates (name, template_type) VALUES ('T', 'event')"
+        )
+        db_conn.execute(
+            "INSERT INTO subscription_templates (template_id) VALUES (?)", (cur.lastrowid,)
+        )
+        gid = create_group(db_conn, name="G", leagues=["nfl"])
+        update_feed_separation_settings(db_conn, enabled=separation_enabled)
+        db_conn.commit()
+        group = get_group(db_conn, gid)
+
+        proc = EventGroupProcessor(db_factory=db_factory, service=MagicMock())
+        streams = [{"id": 11, "name": "Team A vs Team B"}]
+        event = make_event(
+            home_team=MockTeam(
+                id="1",
+                provider="espn",
+                name="Team A",
+                short_name="A",
+                abbreviation="TA",
+                league="nfl",
+                sport="football",
+            ),
+            away_team=MockTeam(
+                id="2",
+                provider="espn",
+                name="Team B",
+                short_name="B",
+                abbreviation="TB",
+                league="nfl",
+                sport="football",
+            ),
+        )
+        monkeypatch.setattr(proc, "_fetch_streams", lambda g: list(streams))
+        monkeypatch.setattr(
+            proc,
+            "_filter_streams",
+            lambda s, g: (list(streams), FilterResult(total_input=1, passed_count=1)),
+        )
+        monkeypatch.setattr(proc, "_match_streams", lambda *a, **k: BatchMatchResult())
+        monkeypatch.setattr(
+            proc,
+            "_build_matched_stream_list",
+            lambda *a, **k: [{"stream": streams[0], "event": event}],
+        )
+        monkeypatch.setattr(proc, "_enrich_matched_events", lambda ms: ms)
+        reached: list = []
+        monkeypatch.setattr(
+            proc,
+            "_process_channels",
+            lambda *a, **k: reached.append("_process_channels") or StreamProcessResult(),
+        )
+        monkeypatch.setattr(proc, "_generate_xmltv", lambda *a, **k: ("", 0, 0, 0, 0))
+
+        calls: list = []
+        monkeypatch.setattr(
+            proc,
+            "_cleanup_feed_separated_channels",
+            lambda g, conn, passed: calls.append(passed) or 0,
+        )
+
+        result = proc._process_group_internal(db_conn, group, date(2026, 3, 1))
+        # Guard the guard: an exception upstream would also produce zero calls.
+        assert result.errors == []
+        assert reached == ["_process_channels"]
+        return calls
+
+    def test_sweep_runs_when_separation_is_off(self, db_conn, db_factory, monkeypatch):
+        calls = self._run_pipeline(
+            db_conn, db_factory, monkeypatch, separation_enabled=False
+        )
+        assert calls == [{"123"}]
+
+    def test_sweep_skipped_when_separation_is_on(self, db_conn, db_factory, monkeypatch):
+        calls = self._run_pipeline(
+            db_conn, db_factory, monkeypatch, separation_enabled=True
+        )
+        assert calls == []


### PR DESCRIPTION
Closes the un-split gap reported in #672.

## Problem

Turning Feed Separation off only stopped *new* feed channels from being created. A user disabling it saw:

```
#600 teamarr-event-401874913            Boston Red Sox @ New York Yankees
#601 teamarr-event-401874913-feed-2     … (Red Sox Feed)
#602 teamarr-event-401874913-feed-10    … (Yankees Feed)
```

all three `In Sync`, with no way to clear them short of Reset All.

With the toggle off, `_resolve_feed_teams` stops populating `feed_team`, so every lookup carries `feed_team_id=None`. `find_existing_channel`'s consolidate branch then adds `feed_team_id IS NULL` to the WHERE clause and matches (or creates) the base channel — the rows already carrying a feed team are never returned. That also puts `_sync_existing_channel` out of reach, which is why `syncer.py`'s existing un-split rename (`if fs.enabled:`) never fired and the names kept their `(Red Sox Feed)` suffix. `cleanup_deleted_streams` is stream-driven and sees no rotation, since a feed channel's `event_id` is the plain event id.

Net effect: duplicate channels per event, with the stale feed block holding its channel numbers, until the scheduled deletion at event end.

## Fix

A sweep in `_process_group_internal`, gated on the toggle being off and placed before channel processing, so the freed streams re-land on the base channel **in the same pass** rather than duplicating it for a day.

Scoped to events that passed the team filter this run — every deleted feed channel is therefore guaranteed a base channel to land on. A feed channel for an event not in today's slate keeps its normal end-of-event deletion rather than being pulled mid-broadcast.

The lifecycle service is built lazily, after the reclaimable set is known: constructing it scans Dispatcharr for externally occupied numbers, wasted on the overwhelmingly common run where the toggle is off and nothing is left to reclaim.

## Drive-by

`result.channels_deleted = len(lifecycle_result.deleted)` was clobbering the team-filter sweep's count a few lines above it. Changed to `+=` so both sweeps and the lifecycle deletions are reported.

## Tests

`TestCleanupFeedSeparatedChannels` covers the sweep directly (base channel spared, unmatched events spared, segment-aware ids, failed deletions uncounted, deletion reason). `TestToggleGatesTheCleanupPass` drives the real `_process_group_internal` in both toggle states and asserts the run completed error-free and reached `_process_channels` — without that guard the toggle-on case passed for the wrong reason (an unrelated stub mismatch was aborting the pipeline before the call site).

Gates: `ruff` clean, 2666 passed, frontend build clean. Docs: "Turning It Off" section added to `docs/guide/channels/consolidation.md`.