### PR TITLE
fix(numbering): one block per start, per-team float scope, Everything Else + most-specific-first page (#677)

### DIFF
--- a/docs/guide/channels/index.md
+++ b/docs/guide/channels/index.md
@@ -27,7 +27,7 @@ The channels themselves are inspected on the **Dashboard**'s [Managed Channels t
 |------|----------------|
 | **[Lifecycle](lifecycle)** | When event channels are created and deleted, and the pre/post-event buffers |
 | **[Consolidation](consolidation)** | Whether multiple streams for one event merge into a single channel or split apart — plus exception keywords and feed separation |
-| **[Numbering](numbering)** | The channel range, pinned blocks for teams/leagues/sports, number stability, and channel ordering in the lineup |
+| **[Numbering](numbering)** | Priority teams, pinned blocks for teams/leagues/sports, sport & league order, the Everything Else range, and number stability |
 | **[Stream Priority](stream-priority)** | Rules that decide which stream plays first inside a consolidated channel |
 | **[Dispatcharr Output](output)** | How channels are written to Dispatcharr — profiles, channel groups, group modes, and per-league overrides |
 

--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -39,13 +39,16 @@ A pinned block gives a **team**, **league**, or **sport** its own block of chann
 
 Rules:
 
-- **Most specific wins.** A channel goes to the team block if either team is pinned, else the league block, else the sport block, else the channel range. When both teams are pinned, the **home** team's block wins; among equals, the block higher in the list wins — use the arrows to reorder.
+- **Most specific wins.** A channel goes to the team block if either team is pinned, else the league block, else the sport block, else the channel range. When both teams are pinned, the **home** team's block wins.
+- **Each start belongs to one block.** Teamarr refuses a second block at a start that's already taken unless both carry the same group name (then they share it). Pinning "Brewers at 550" *and* "MLB at 550" is not a way to put the Brewers first — it would merge both into one block in normal lineup order. To float a team to the top of its league's block, add it under [Priority Teams](#channel-ordering); to give it its own numbers, pick a different start.
 - **A team pin follows the team everywhere** — league games and cup games alike, matched by name within the sport (the same rule Priority Teams use).
 - **Feeds stay together.** Home/away feeds and keyword variants of one game land on adjacent numbers inside the block, exactly as in the channel range.
 - **Blocks spill forward.** A block with more channels than room simply continues past its start; the next block skips over it (you'll see a ⚠ in the effective-layout preview). Set an **end channel** (under *advanced*) if you'd rather overflow into the channel range.
 - **Disable** a block with its switch to keep it without applying it.
 
-Block changes are saved immediately and queue a re-grid in Gapped/Strict modes, so they take effect on the next generation. The **effective layout** strip under the list shows where today's channels would land under the current blocks.
+Block changes are saved immediately and queue a re-grid in Gapped/Strict modes, so they take effect on the next generation. The list is shown in placement order (lowest start first), and the **effective layout** strip under it shows where today's channels would land under the current blocks.
+
+Inside every block, channels follow the same [channel ordering](#channel-ordering) as the range: priority teams first, then sport and league order, then start time. A **sport** block is the simplest way to keep all of one sport together — soccer at 500 numbers every soccer league back-to-back in your league order, with no per-league starts to maintain.
 
 {: .note }
 **Upgrading from Manual mode.** Manual mode's per-league starting channels became league-scoped pinned blocks automatically — same starts, same numbers. Leagues that had no configured start now share the channel range in priority order instead of each restarting at the range start (which could hand two leagues the same number).
@@ -93,11 +96,11 @@ Number Stability applies **inside every pinned block** as well as the channel ra
 
 Channel ordering controls *where channels land in the lineup* — distinct from [Stream Priority](stream-priority), which orders streams *inside* a channel.
 
-**Priority Teams** — add teams here and their channels float to the very top of the channel list, ahead of all sport/league/time ordering. A team floats up wherever it plays (league and cup), matched by name within its sport. This is purely an ordering preference — it has no connection to the [Teams](../epg/teams) page or EPG generation.
+**Priority Teams** — add teams here and their channels float to the top of whichever block they number in: the top of the channel range, or the top of their league's pinned block if one exists (pin MLB at 550 and make the Brewers a priority team, and every Brewers game sits at the start of the MLB block). A team floats up wherever it plays (league and cup), matched by name within its sport. This is purely an ordering preference — it has no connection to the [Teams](../epg/teams) page or EPG generation.
 
-The **Sort Priority Order** list lets you drag and drop sports and leagues into your preferred order. Higher items get lower channel numbers. Click **Auto-populate** to pre-fill with all currently subscribed sports and leagues.
+**Sport & League Order** — the order sports and leagues take inside the channel range and inside every pinned block. Drag sports to reorder; expand a sport to reorder its leagues. Higher in the list = lower channel numbers; games within a league sort by start time; sports and leagues not in the list go last. Click **Auto-populate** to pre-fill with all currently subscribed sports and leagues.
 
-The full order is: **Priority Teams → Sport → League → Event time**, with two deterministic tie-breakers after that — event id, then main channel before its keyword variants (your Spanish feed always sorts right after the main channel).
+The full order, applied inside each block and inside the range, is: **Priority Teams → Sport → League → Event time**, with two deterministic tie-breakers after that — event id, then main channel before its keyword variants (your Spanish feed always sorts right after the main channel).
 
 {: .note }
 Channel numbers are updated on the next EPG generation run.

--- a/docs/guide/channels/numbering.md
+++ b/docs/guide/channels/numbering.md
@@ -9,20 +9,31 @@ nav_order: 3
 
 How channel numbers are assigned and how channels are ordered within the lineup.
 
-![Channels → Numbering — range, pinned blocks, and number-stability options](../../assets/images/channels-numbering.png)
+![Channels → Numbering — priority teams, pinned blocks, ordering, and number-stability options](../../assets/images/channels-numbering.png)
 
-Numbers come from two places: **pinned blocks** you define for the teams, leagues,
-or sports you care about, and the **channel range** for everything else. Channels
-are ordered by priority inside each.
+The page lists rules **most-specific first** — a channel takes the first rule that
+matches it:
 
-## Channel Range
+1. **[Priority Teams](#priority-teams)** — a team's games float to the top of its league, its sport, or everything.
+2. **[Pinned Blocks](#pinned-blocks)** — a team, league, or sport gets its own block of numbers starting wherever you say.
+3. **[Sport & League Order](#sport--league-order)** — the lineup order used inside every block and in Everything Else.
+4. **[Everything Else](#everything-else)** — the range for whatever no block claims.
+5. **[Number Stability](#number-stability)** — whether numbers may move while a game is live (global; applies inside all of the above).
 
-| Field | Description |
-|-------|-------------|
-| **Channel Range Start** | First channel number for everything that isn't pinned. |
-| **Channel Range End** | Last channel number — leave empty for no upper limit. If a run fills the range, allocation stops there (with a log warning) rather than numbering past the end. |
+Priority Teams, Pinned Blocks, and Sport & League Order save as you edit; Everything
+Else and Number Stability save with the button at the bottom.
 
-Teamarr automatically **skips numbers already used by non-Teamarr channels** in Dispatcharr, and logs a warning when the configured range overlaps external channels. Setting the range start above your existing channels (e.g., 1000 if you use 1–500) is still tidier — contiguous blocks without skips — but collisions are prevented either way.
+## Priority Teams
+
+Add a team and its games float to the top of a scope you pick per team:
+
+| Scope | Meaning |
+|-------|---------|
+| **Top of its league** (default) | First among that league's games; the sport and league order is untouched. Pin MLB at 550 and set the Brewers here, and every Brewers game sits at the start of the MLB block. |
+| **Top of its sport** | First among every league in the sport — Tigers above all baseball, MiLB included. |
+| **Top of everything** | Ahead of every sport and league. (This was the only behaviour before v2.15; existing entries were kept on it.) |
+
+A team floats up wherever it plays (league and cup), matched by name within its sport. Pinned blocks are carved out *after* the lineup is sorted, so a priority team only moves relative to the other channels in the same block. This is purely an ordering preference — it has no connection to the [Teams](../epg/teams) page or EPG generation.
 
 ## Pinned Blocks
 
@@ -33,25 +44,41 @@ A pinned block gives a **team**, **league**, or **sport** its own block of chann
 | 800 | Team · Detroit Lions | The Lions team channel and every Lions game, from 800 |
 | 850 | Group "Big events" · FIFA World Cup, Olympics | Both competitions share one block from 850 |
 | 1700 | League · NFL | Every other NFL game from 1700 |
-| 8000 | *(channel range start)* | Everything else |
+| 8000 | *(Everything Else start)* | Everything else |
 
 **Add block** picks the scope (the team picker, a league, or a sport), a start channel, and optionally a group name. Blocks that share a group name *and* start share one block of numbers — type an existing group's name and its start fills in.
 
 Rules:
 
-- **Most specific wins.** A channel goes to the team block if either team is pinned, else the league block, else the sport block, else the channel range. When both teams are pinned, the **home** team's block wins.
-- **Each start belongs to one block.** Teamarr refuses a second block at a start that's already taken unless both carry the same group name (then they share it). Pinning "Brewers at 550" *and* "MLB at 550" is not a way to put the Brewers first — it would merge both into one block in normal lineup order. To float a team to the top of its league's block, add it under [Priority Teams](#channel-ordering); to give it its own numbers, pick a different start.
+- **Most specific wins.** A channel goes to the team block if either team is pinned, else the league block, else the sport block, else Everything Else. When both teams are pinned, the **home** team's block wins.
+- **A block can start anywhere** — above, below, or inside the Everything Else range. Everything Else flows around it (range 101+, Lions at 105: everything else uses 101–104, the Lions block 105–106, everything else resumes at 107).
+- **Each start belongs to one block.** Teamarr refuses a second block at a start that's already taken unless both carry the same group name (then they share it). Pinning "Brewers at 550" *and* "MLB at 550" is not a way to put the Brewers first — it would merge both into one block in normal lineup order. To float a team to the top of its league's block, add it under [Priority Teams](#priority-teams); to give it its own numbers, pick a different start.
 - **A team pin follows the team everywhere** — league games and cup games alike, matched by name within the sport (the same rule Priority Teams use).
-- **Feeds stay together.** Home/away feeds and keyword variants of one game land on adjacent numbers inside the block, exactly as in the channel range.
-- **Blocks spill forward.** A block with more channels than room simply continues past its start; the next block skips over it (you'll see a ⚠ in the effective-layout preview). Set an **end channel** (under *advanced*) if you'd rather overflow into the channel range.
+- **Feeds stay together.** Home/away feeds and keyword variants of one game land on adjacent numbers inside the block, exactly as in Everything Else.
+- **Blocks spill forward.** A block with more channels than room simply continues past its start; the next block skips over it (you'll see a ⚠ in the effective-layout preview). Set an **end channel** (under *advanced*) if you'd rather overflow into Everything Else.
 - **Disable** a block with its switch to keep it without applying it.
 
-Block changes are saved immediately and queue a re-grid in Gapped/Strict modes, so they take effect on the next generation. The list is shown in placement order (lowest start first), and the **effective layout** strip under it shows where today's channels would land under the current blocks.
+Block changes are saved immediately and queue a re-grid in Gapped/Strict modes, so they take effect on the next generation. The list is shown in placement order (lowest start first), and the **effective layout** strip under it shows where today's channels would land — Everything Else included, wherever it falls.
 
-Inside every block, channels follow the same [channel ordering](#channel-ordering) as the range: priority teams first, then sport and league order, then start time. A **sport** block is the simplest way to keep all of one sport together — soccer at 500 numbers every soccer league back-to-back in your league order, with no per-league starts to maintain.
+Inside every block, channels follow the same [Sport & League Order](#sport--league-order) as Everything Else: priority teams first, then sport and league order, then start time. A **sport** block is the simplest way to keep all of one sport together — soccer at 500 numbers every soccer league back-to-back in your league order, with no per-league starts to maintain.
 
 {: .note }
-**Upgrading from Manual mode.** Manual mode's per-league starting channels became league-scoped pinned blocks automatically — same starts, same numbers. Leagues that had no configured start now share the channel range in priority order instead of each restarting at the range start (which could hand two leagues the same number).
+**Upgrading from Manual mode.** Manual mode's per-league starting channels became league-scoped pinned blocks automatically — same starts, same numbers. Leagues that had no configured start now share Everything Else in lineup order instead of each restarting at the range start (which could hand two leagues the same number).
+
+## Sport & League Order
+
+The order sports and leagues take inside Everything Else and inside every pinned block. Drag sports to reorder; expand a sport to reorder its leagues. Higher in the list = lower channel numbers; games within a league sort by start time; sports and leagues not in the list go last. Click **Auto-populate** to pre-fill with all currently subscribed sports and leagues.
+
+The full order, applied inside each block and inside Everything Else, is: **Priority Teams (everything) → Sport → Priority Teams (sport) → League → Priority Teams (league) → Event time**, with two deterministic tie-breakers after that — event id, then main channel before its keyword variants (your Spanish feed always sorts right after the main channel).
+
+## Everything Else
+
+| Field | Description |
+|-------|-------------|
+| **Everything Else Start** | First channel number for channels no pinned block claims. |
+| **Everything Else End** | Last channel number for those channels — leave empty for no upper limit. If a run fills the range, allocation stops there (with a log warning) rather than numbering past the end. Pinned blocks are not limited by it. |
+
+Teamarr automatically **skips numbers already used by non-Teamarr channels** in Dispatcharr (and by pinned blocks that start inside this range), and logs a warning when the configured range overlaps external channels. Setting the start above your existing channels (e.g., 1000 if you use 1–500) is still tidier — contiguous blocks without skips — but collisions are prevented either way.
 
 ## Number Stability
 
@@ -87,20 +114,7 @@ Reset Time is the **server's** local time. In Docker this is usually UTC unless 
 
 You don't have to wait for the daily window. **Re-grid channels now** (shown in Gapped/Strict modes only) queues a one-shot re-layout that runs on the **next generation** — renumbering every channel back into priority order and reclaiming gaps, regardless of the reset time and even if the daily re-layout is turned off. The flag clears once that run completes.
 
-Changing the **gap size**, switching **stability mode**, adjusting the **channel range**, editing **pinned blocks**, or reordering **sort priority / priority teams** queues the same re-grid automatically, so the change takes effect on the next run instead of silently waiting for the daily reset.
+Changing the **gap size**, switching **stability mode**, adjusting **Everything Else**, editing **pinned blocks**, or changing **Sport & League Order / Priority Teams** queues the same re-grid automatically, so the change takes effect on the next run instead of silently waiting for the daily reset.
 
 {: .note }
-Number Stability applies **inside every pinned block** as well as the channel range: with Gapped and gap size 3, a block starting at 800 lays out 800, 803, 806…; the daily re-layout re-grids each block from its own start.
-
-## Channel Ordering
-
-Channel ordering controls *where channels land in the lineup* — distinct from [Stream Priority](stream-priority), which orders streams *inside* a channel.
-
-**Priority Teams** — add teams here and their channels float to the top of whichever block they number in: the top of the channel range, or the top of their league's pinned block if one exists (pin MLB at 550 and make the Brewers a priority team, and every Brewers game sits at the start of the MLB block). A team floats up wherever it plays (league and cup), matched by name within its sport. This is purely an ordering preference — it has no connection to the [Teams](../epg/teams) page or EPG generation.
-
-**Sport & League Order** — the order sports and leagues take inside the channel range and inside every pinned block. Drag sports to reorder; expand a sport to reorder its leagues. Higher in the list = lower channel numbers; games within a league sort by start time; sports and leagues not in the list go last. Click **Auto-populate** to pre-fill with all currently subscribed sports and leagues.
-
-The full order, applied inside each block and inside the range, is: **Priority Teams → Sport → League → Event time**, with two deterministic tie-breakers after that — event id, then main channel before its keyword variants (your Spanish feed always sorts right after the main channel).
-
-{: .note }
-Channel numbers are updated on the next EPG generation run.
+Number Stability applies **inside every pinned block** as well as Everything Else: with Gapped and gap size 3, a block starting at 800 lays out 800, 803, 806…; the daily re-layout re-grids each block from its own start.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -51,7 +51,7 @@ For an **EPG-matched** event channel, **red is usually normal** — it just mean
 
 ### Channel numbers colliding with existing channels
 
-Teamarr automatically skips numbers used by non-Teamarr channels, but for a clean block set the **Channel Range Start** in [Channels → Numbering](channels/numbering) to a range that doesn't overlap your existing Dispatcharr channels.
+Teamarr automatically skips numbers used by non-Teamarr channels, but for a clean block set the **Everything Else Start** in [Channels → Numbering](channels/numbering) to a range that doesn't overlap your existing Dispatcharr channels.
 
 ### Stale logos in media server
 

--- a/docs/reference/architecture/channel-numbering.md
+++ b/docs/reference/architecture/channel-numbering.md
@@ -46,8 +46,9 @@ channel. Precedence:
 4. **Sport** pin
 5. Default lane
 
-Within one level, ties break by the block's `sort_order` (the drag order in
-the UI). Team matching is `(sport, team_name)` case-insensitive on either side
+Within one level a channel can match only one row (one league, one sport,
+one team per side), so there is no user-facing tie-break; `(sort_order, id)`
+remains as a deterministic fallback for legacy rows. Team matching is `(sport, team_name)` case-insensitive on either side
 of the event — the same key `channel_priority_teams` uses — so a team pin
 follows the club into cup competitions. A team pin covers both the team's
 dedicated team channel and every event channel it plays in.
@@ -67,6 +68,18 @@ sticky modes, exactly as changing the channel range does.
   existing invariant ("gap only between events") holds inside every lane.
 - A **group** is just several rows with the same `start` and `label`; there
   is no separate table. "850 — Big events: World Cup, Olympics" is two rows.
+- **A start belongs to one block.** `LaneResolver` keys lanes on `start`
+  alone, so any two rows at one start *are* one lane whatever their labels.
+  Because users read "Brewers at 550 + MLB at 550" as "Brewers first in the
+  MLB block" (it is not — the merged lane sorts in normal lineup order, which
+  is the 2.14.0 Discord confusion), `add_numbering_exception` and
+  `update_numbering_exception` raise `StartConflict` (→ HTTP 400 with a
+  what-to-do-instead message) unless every existing row at that start shares
+  the new row's non-empty label (case-insensitive). Toggling `enabled` alone
+  never re-validates, so rows created before this rule keep working. The
+  reorder endpoint and UI arrows were removed with it — they never changed
+  placement (lanes place in ascending `start`), only the never-exercised
+  within-level tie-break.
 
 ## Stability modes inside lanes
 
@@ -133,6 +146,6 @@ CREATE TABLE numbering_exceptions (
 );
 ```
 
-API: `/api/v1/numbering-exceptions` (list, create, update, delete, reorder,
-`preview` = effective layout of today's channels). UI: Channels → Numbering →
-Pinned Blocks.
+API: `/api/v1/numbering-exceptions` (list — ascending start —, create,
+update, delete, `preview` = effective layout of today's channels). UI:
+Channels → Numbering → Pinned Blocks.

--- a/docs/reference/architecture/channel-numbering.md
+++ b/docs/reference/architecture/channel-numbering.md
@@ -22,7 +22,7 @@ range of numbers with its own start:
 | Lane | Where it comes from |
 |------|---------------------|
 | Pinned block | One row in `numbering_exceptions` (a team, league or sport pin), or several rows sharing a start under one label (a *group*) |
-| Default | The global channel range (`channel_range_start` / `channel_range_end`) |
+| Default | "Everything Else" in the UI — the global channel range (`channel_range_start` / `channel_range_end`) |
 
 The allocator runs the **same placement code per lane** — compact, gap or
 strict, sticky locks, daily re-layout — with the lane's start in place of the
@@ -94,6 +94,27 @@ sticky modes, exactly as changing the channel range does.
 The sticky allocator's "invalid anchor" rule — a locked channel whose number
 is outside its range is re-placed — now uses the **lane's** range, so moving
 a block (say Lions from 800 to 900) re-places those channels on the next run.
+
+## Global sort and priority-team scope
+
+`get_all_channels_sorted` produces one ordered list that every lane is then
+partitioned from. The key is
+
+```
+(all_tier, sport_pri, sport_tier, league_pri, league_tier, event_time, event_id, keyword)
+```
+
+where the three `*_tier` values (0 = floats, 1 = normal) come from
+`channel_priority_teams.scope` — `'all'` sets every tier, `'sport'` sets
+`sport_tier` + `league_tier`, `'league'` only `league_tier`. A team listed
+several times keeps its broadest scope. The column was added by reconciliation
+with `DEFAULT 'all'`, so pre-scope rows keep the old float-above-everything
+behaviour; new rows default to `'league'`. Because lanes are cut after the
+sort, a priority team moves only relative to channels in its own lane.
+
+The API for the preview (`GET /numbering-exceptions/preview`) returns lanes
+sorted by start so the default lane appears where it actually sits when a
+block starts below or inside the range.
 
 ## Creation-time allocation
 

--- a/frontend/src/api/numberingExceptions.ts
+++ b/frontend/src/api/numberingExceptions.ts
@@ -1,8 +1,9 @@
 import { api } from "./client"
 
 // Pinned channel-number blocks (#333). A block numbers a team / league / sport
-// from a fixed start; rows sharing start + label form a group. Everything
-// unmatched numbers from the global channel range.
+// from a fixed start; a start belongs to one block, and rows may share a start
+// only under the same group name. Everything unmatched numbers from the global
+// channel range.
 
 export type NumberingScope = "team" | "league" | "sport"
 
@@ -74,12 +75,6 @@ export async function updateNumberingException(
 
 export async function deleteNumberingException(id: number): Promise<{ success: boolean }> {
   return api.delete(`/numbering-exceptions/${id}`)
-}
-
-export async function reorderNumberingExceptions(
-  orderedIds: number[]
-): Promise<{ success: boolean }> {
-  return api.put("/numbering-exceptions/reorder", { ordered_ids: orderedIds })
 }
 
 export async function getNumberingPreview(): Promise<LanePreview[]> {

--- a/frontend/src/api/sortPriorities.ts
+++ b/frontend/src/api/sortPriorities.ts
@@ -64,7 +64,10 @@ export async function autoPopulateSortPriorities(): Promise<AutoPopulateResponse
   return api.post("/sort-priorities/auto-populate", {})
 }
 
-// Priority Teams — a team-level tier that floats channels above sport/league order
+// Priority Teams — a team-level tier that floats channels to the top of a scope:
+// everything ('all'), its sport, or its league.
+export type PriorityTeamScope = "all" | "sport" | "league"
+
 export interface PriorityTeam {
   id: number
   provider: string
@@ -72,18 +75,30 @@ export interface PriorityTeam {
   team_name: string
   league: string | null
   sport: string
+  scope: PriorityTeamScope
 }
 
 export async function getPriorityTeams(): Promise<PriorityTeam[]> {
   return api.get("/sort-priorities/teams")
 }
 
-export async function addPriorityTeam(team: TeamFilterEntry): Promise<PriorityTeam> {
+export async function addPriorityTeam(
+  team: TeamFilterEntry,
+  scope: PriorityTeamScope = "league"
+): Promise<PriorityTeam> {
   return api.post("/sort-priorities/teams", {
     provider: team.provider,
     team_id: team.team_id,
     league: team.league,
+    scope,
   })
+}
+
+export async function updatePriorityTeamScope(
+  id: number,
+  scope: PriorityTeamScope
+): Promise<PriorityTeam> {
+  return api.put(`/sort-priorities/teams/${id}`, { scope })
 }
 
 export async function deletePriorityTeam(id: number): Promise<void> {

--- a/frontend/src/components/PinnedBlocks.tsx
+++ b/frontend/src/components/PinnedBlocks.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { ArrowDown, ArrowUp, LoaderCircle, Pin, Plus, Trash2 } from "lucide-react"
+import { LoaderCircle, Pin, Plus, Trash2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -27,7 +27,6 @@ import {
   useDeleteNumberingException,
   useNumberingExceptions,
   useNumberingPreview,
-  useReorderNumberingExceptions,
   useUpdateNumberingException,
 } from "@/hooks/useNumberingExceptions"
 import type { NumberingException, NumberingScope } from "@/api/numberingExceptions"
@@ -36,9 +35,10 @@ import type { TeamFilterEntry } from "@/api/types"
 /**
  * Channels → Numbering → Pinned Blocks (#333).
  *
- * A block pins a team / league / sport to a fixed channel start; rows sharing a
- * start + label form a group. Most specific wins (team › league › sport), then
- * list order. Everything unmatched numbers from the global range. Edits arm a
+ * A block pins a team / league / sport to a fixed channel start. A start belongs
+ * to one block; rows may share a start only under the same group name (the
+ * server rejects any other collision). Most specific wins (team › league ›
+ * sport). Everything unmatched numbers from the global range. Edits arm a
  * re-grid in sticky modes, so the change lands on the next generation.
  */
 
@@ -57,7 +57,6 @@ const SCOPE_VARIANT: Record<NumberingScope, "default" | "secondary" | "outline">
 export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
   const { data: blocks, isLoading } = useNumberingExceptions()
   const { data: preview } = useNumberingPreview()
-  const reorder = useReorderNumberingExceptions()
   const remove = useDeleteNumberingException()
   const update = useUpdateNumberingException()
   const { data: sportsData } = useSports()
@@ -66,18 +65,6 @@ export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
   const [addOpen, setAddOpen] = useState(false)
 
   const sorted = useMemo(() => blocks ?? [], [blocks])
-
-  const move = async (index: number, dir: -1 | 1) => {
-    const next = [...sorted]
-    const j = index + dir
-    if (j < 0 || j >= next.length) return
-    ;[next[index], next[j]] = [next[j], next[index]]
-    try {
-      await reorder.mutateAsync(next.map((b) => b.id))
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to reorder")
-    }
-  }
 
   const onDelete = async (b: NumberingException) => {
     try {
@@ -117,8 +104,9 @@ export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
             <CardDescription>
               Give a team, league, or sport its own block of channel numbers. Everything else
               numbers from the channel range start ({rangeStart}). Most specific wins:
-              Team › League › Sport; use the arrows to break ties. Blocks spill forward if
-              they fill up.
+              Team › League › Sport. Each start belongs to one block — to put a team first
+              inside its league&apos;s block, use Priority Teams below. Blocks spill forward
+              if they fill up.
             </CardDescription>
           </div>
           <Button size="sm" onClick={() => setAddOpen(true)}>
@@ -137,31 +125,11 @@ export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
           </p>
         ) : (
           <div className="border rounded-md divide-y">
-            {sorted.map((b, i) => (
+            {sorted.map((b) => (
               <div
                 key={b.id}
                 className={`flex items-center gap-3 px-3 py-2 ${b.enabled ? "" : "opacity-60"}`}
               >
-                <div className="flex flex-col">
-                  <button
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                    disabled={i === 0 || reorder.isPending}
-                    onClick={() => move(i, -1)}
-                    aria-label="Move up"
-                  >
-                    <ArrowUp className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                    disabled={i === sorted.length - 1 || reorder.isPending}
-                    onClick={() => move(i, 1)}
-                    aria-label="Move down"
-                  >
-                    <ArrowDown className="h-3.5 w-3.5" />
-                  </button>
-                </div>
                 <Input
                   type="number"
                   min={1}
@@ -445,7 +413,8 @@ function AddBlockDialog({
             </div>
           </div>
           <p className="text-xs text-muted-foreground -mt-2">
-            Blocks that share a group name and start share one block of numbers.
+            Each start belongs to one block. To share a block between several teams, leagues,
+            or sports, give them the same group name and start.
           </p>
 
           {showEnd ? (

--- a/frontend/src/components/PinnedBlocks.tsx
+++ b/frontend/src/components/PinnedBlocks.tsx
@@ -102,11 +102,11 @@ export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
               <Pin className="h-4 w-4" /> Pinned Blocks
             </CardTitle>
             <CardDescription>
-              Give a team, league, or sport its own block of channel numbers. Everything else
-              numbers from the channel range start ({rangeStart}). Most specific wins:
-              Team › League › Sport. Each start belongs to one block — to put a team first
-              inside its league&apos;s block, use Priority Teams below. Blocks spill forward
-              if they fill up.
+              Give a team, league, or sport its own block of channel numbers, starting
+              anywhere — above, below, or inside the Everything Else range ({rangeStart}+),
+              which flows around it. Most specific wins: Team › League › Sport. Each start
+              belongs to one block — to put a team first inside its league&apos;s block, use
+              Priority Teams above. Blocks spill forward if they fill up.
             </CardDescription>
           </div>
           <Button size="sm" onClick={() => setAddOpen(true)}>
@@ -121,7 +121,7 @@ export function PinnedBlocks({ rangeStart }: { rangeStart: number }) {
           </div>
         ) : sorted.length === 0 ? (
           <p className="text-sm text-muted-foreground py-2">
-            No pinned blocks. All channels number from {rangeStart} in priority order.
+            No pinned blocks. All channels number from {rangeStart} in lineup order.
           </p>
         ) : (
           <div className="border rounded-md divide-y">
@@ -324,8 +324,8 @@ function AddBlockDialog({
         <DialogHeader>
           <DialogTitle>Add pinned block</DialogTitle>
           <DialogDescription>
-            Channels matching this scope number from the block start instead of the
-            channel range.
+            Channels matching this scope number from the block start instead of
+            Everything Else. The start can be anywhere.
           </DialogDescription>
         </DialogHeader>
 
@@ -429,7 +429,7 @@ function AddBlockDialog({
                 placeholder="No limit"
               />
               <p className="text-xs text-muted-foreground">
-                When the block is full, extra channels overflow to the channel range instead
+                When the block is full, extra channels overflow to Everything Else instead
                 of spilling forward.
               </p>
             </div>

--- a/frontend/src/components/SortPriorityManager.tsx
+++ b/frontend/src/components/SortPriorityManager.tsx
@@ -34,7 +34,8 @@ function teamKey(provider: string, teamId: string, league: string | null | undef
 
 /**
  * Priority Teams — a team-level tier that floats a followed team's channels to
- * the top of the global channel list, ahead of sport/league/time ordering.
+ * the top of whichever block they land in (a pinned block or the channel
+ * range), ahead of sport/league/time ordering.
  * Reuses TeamPicker: the saved list IS the picker's selection; add/remove diff
  * against the server list and fire the matching mutation.
  */
@@ -92,9 +93,10 @@ function PriorityTeamsCard() {
       <CardHeader>
         <CardTitle className="text-base">Priority Teams</CardTitle>
         <CardDescription>
-          Channels for these teams float to the top of the channel list, before any
-          sport/league/time ordering. A team floats up wherever it plays. Ordering only —
-          unrelated to the Teams page or EPG.
+          Channels for these teams float to the top of whichever block they number in —
+          the channel range, or their league&apos;s pinned block — ahead of the sport/league/time
+          order. A team floats up wherever it plays. Ordering only — unrelated to the Teams
+          page or EPG.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -231,9 +233,12 @@ export function SortPriorityManager({ showWhenSortBy = "sport_league_time", curr
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-base">Sort Priority Order</CardTitle>
+              <CardTitle className="text-base">Sport &amp; League Order</CardTitle>
               <CardDescription>
-                Drag sports to reorder. Expand to reorder leagues within each sport.
+                The order sports and leagues take inside the channel range and inside every
+                pinned block: higher in this list = lower channel numbers. Games within a
+                league sort by start time. Drag sports to reorder; expand to reorder leagues
+                within each sport. Unlisted sports/leagues go last.
               </CardDescription>
             </div>
             <Button

--- a/frontend/src/components/SortPriorityManager.tsx
+++ b/frontend/src/components/SortPriorityManager.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { LoaderCircle, WandSparkles } from "lucide-react"
+import { LoaderCircle, Star, Trash2, WandSparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Select } from "@/components/ui/select"
+import { useSports } from "@/hooks/useSports"
+import { getSportDisplayName } from "@/lib/utils"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   HierarchicalSortable,
@@ -17,8 +20,13 @@ import {
   usePriorityTeams,
   useAddPriorityTeam,
   useDeletePriorityTeam,
+  useUpdatePriorityTeamScope,
 } from "@/hooks/useSortPriorities"
-import type { SortPriorityReorderItem } from "@/api/sortPriorities"
+import type {
+  PriorityTeam,
+  PriorityTeamScope,
+  SortPriorityReorderItem,
+} from "@/api/sortPriorities"
 import type { TeamFilterEntry } from "@/api/types"
 import { getTeamPickerLeagues } from "@/api/teams"
 
@@ -27,22 +35,26 @@ interface SortPriorityManagerProps {
   currentSortBy: string
 }
 
-/** Stable identity for a team across PriorityTeam ↔ TeamFilterEntry. */
-function teamKey(provider: string, teamId: string, league: string | null | undefined): string {
-  return `${provider}:${teamId}:${league ?? ""}`
-}
+const SCOPE_OPTIONS: { value: PriorityTeamScope; label: string; hint: string }[] = [
+  { value: "league", label: "Top of its league", hint: "first among its league's games" },
+  { value: "sport", label: "Top of its sport", hint: "first among every league in its sport" },
+  { value: "all", label: "Top of everything", hint: "ahead of every sport and league" },
+]
 
 /**
  * Priority Teams — a team-level tier that floats a followed team's channels to
- * the top of whichever block they land in (a pinned block or the channel
- * range), ahead of sport/league/time ordering.
- * Reuses TeamPicker: the saved list IS the picker's selection; add/remove diff
- * against the server list and fire the matching mutation.
+ * the top of a scope: its league (default), its sport, or everything. Pinned
+ * blocks partition the lineup after sorting, so the float only moves a team
+ * relative to other channels in the same block. One row per team with a scope
+ * select; the TeamPicker (single-select, always empty) is the "add" control.
  */
-function PriorityTeamsCard() {
+export function PriorityTeamsCard() {
   const { data: priorityTeams, isLoading } = usePriorityTeams()
   const addMutation = useAddPriorityTeam()
   const deleteMutation = useDeletePriorityTeam()
+  const scopeMutation = useUpdatePriorityTeamScope()
+  const { data: sportsData } = useSports()
+  const sportsMap = sportsData?.sports
 
   // Offer teams from every league that has cached teams.
   const { data: leagueData } = useQuery({
@@ -55,69 +67,107 @@ function PriorityTeamsCard() {
     [leagueData],
   )
 
-  const selectedTeams: TeamFilterEntry[] = useMemo(
-    () =>
-      (priorityTeams ?? []).map((t) => ({
-        provider: t.provider,
-        team_id: t.provider_team_id,
-        league: t.league ?? "",
-        name: t.team_name,
-      })),
-    [priorityTeams],
-  )
-
-  const handleChange = async (next: TeamFilterEntry[]) => {
-    const current = priorityTeams ?? []
-    const nextKeys = new Set(next.map((t) => teamKey(t.provider, t.team_id, t.league)))
-    const currentKeys = new Set(
-      current.map((t) => teamKey(t.provider, t.provider_team_id, t.league)),
-    )
-
-    const added = next.filter((t) => !currentKeys.has(teamKey(t.provider, t.team_id, t.league)))
-    const removed = current.filter(
-      (t) => !nextKeys.has(teamKey(t.provider, t.provider_team_id, t.league)),
-    )
-
+  const onAdd = async (picked: TeamFilterEntry[]) => {
+    const team = picked[picked.length - 1]
+    if (!team) return
     try {
-      await Promise.all([
-        ...added.map((t) => addMutation.mutateAsync(t)),
-        ...removed.map((t) => deleteMutation.mutateAsync(t.id)),
-      ])
+      await addMutation.mutateAsync({ team, scope: "league" })
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to update priority teams")
+      toast.error(err instanceof Error ? err.message : "Failed to add priority team")
+    }
+  }
+
+  const onScope = async (id: number, scope: PriorityTeamScope) => {
+    try {
+      await scopeMutation.mutateAsync({ id, scope })
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to update priority team")
+    }
+  }
+
+  const onRemove = async (t: PriorityTeam) => {
+    try {
+      await deleteMutation.mutateAsync(t.id)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove priority team")
     }
   }
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Priority Teams</CardTitle>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Star className="h-4 w-4" /> Priority Teams
+        </CardTitle>
         <CardDescription>
-          Channels for these teams float to the top of whichever block they number in —
-          the channel range, or their league&apos;s pinned block — ahead of the sport/league/time
-          order. A team floats up wherever it plays. Ordering only — unrelated to the Teams
-          page or EPG.
+          Float a team&apos;s games to the top of its league, its sport, or everything.
+          A team floats up wherever it plays (league and cup). Inside a pinned block the
+          float applies within that block. Ordering only — unrelated to the Teams page or
+          EPG.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-3">
         {isLoading ? (
           <div className="flex items-center justify-center py-6">
             <LoaderCircle className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
+        ) : (priorityTeams ?? []).length > 0 ? (
+          <div className="border rounded-md divide-y">
+            {(priorityTeams ?? []).map((t) => (
+              <div key={t.id} className="flex items-center gap-3 px-3 py-2">
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm truncate">{t.team_name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {getSportDisplayName(t.sport, sportsMap)}
+                    {t.league ? ` · ${t.league}` : ""}
+                  </div>
+                </div>
+                <Select
+                  value={t.scope}
+                  onChange={(e) => onScope(t.id, e.target.value as PriorityTeamScope)}
+                  className="w-44 h-8 text-sm"
+                  aria-label="Float scope"
+                  title={SCOPE_OPTIONS.find((o) => o.value === t.scope)?.hint}
+                >
+                  {SCOPE_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </Select>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-destructive"
+                  onClick={() => onRemove(t)}
+                  disabled={deleteMutation.isPending}
+                  aria-label="Remove priority team"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
         ) : (
-          <TeamPicker
-            leagues={leagues}
-            selectedTeams={selectedTeams}
-            onSelectionChange={handleChange}
-            placeholder="Add a priority team…"
-          />
+          <p className="text-sm text-muted-foreground py-1">
+            No priority teams. Games number in Sport &amp; League order, then by start time.
+          </p>
         )}
+        <TeamPicker
+          leagues={leagues}
+          selectedTeams={[]}
+          onSelectionChange={onAdd}
+          placeholder="Add a priority team…"
+          singleSelect
+        />
       </CardContent>
     </Card>
   )
 }
 
-export function SortPriorityManager({ showWhenSortBy = "sport_league_time", currentSortBy }: SortPriorityManagerProps) {
+/** Sport & League Order — the lineup order used inside every pinned block and
+ * in Everything Else. Higher = lower channel numbers. */
+export function SportLeagueOrderCard({ showWhenSortBy = "sport_league_time", currentSortBy }: SortPriorityManagerProps) {
   const { data: priorities, isLoading, refetch } = useSortPriorities()
   const reorderMutation = useReorderSortPriorities()
   const autoPopulateMutation = useAutoPopulateSortPriorities()
@@ -227,8 +277,6 @@ export function SortPriorityManager({ showWhenSortBy = "sport_league_time", curr
   }
 
   return (
-    <div className="space-y-4">
-      <PriorityTeamsCard />
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
@@ -266,6 +314,5 @@ export function SortPriorityManager({ showWhenSortBy = "sport_league_time", curr
           />
         </CardContent>
       </Card>
-    </div>
   )
 }

--- a/frontend/src/components/SortPriorityManager.tsx
+++ b/frontend/src/components/SortPriorityManager.tsx
@@ -1,8 +1,18 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { LoaderCircle, Star, Trash2, WandSparkles } from "lucide-react"
+import { LoaderCircle, Plus, Star, Trash2, WandSparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { RadioCards } from "@/components/ui/radio-cards"
 import { Select } from "@/components/ui/select"
 import { useSports } from "@/hooks/useSports"
 import { getSportDisplayName } from "@/lib/utils"
@@ -36,9 +46,9 @@ interface SortPriorityManagerProps {
 }
 
 const SCOPE_OPTIONS: { value: PriorityTeamScope; label: string; hint: string }[] = [
-  { value: "league", label: "Top of its league", hint: "first among its league's games" },
-  { value: "sport", label: "Top of its sport", hint: "first among every league in its sport" },
-  { value: "all", label: "Top of everything", hint: "ahead of every sport and league" },
+  { value: "league", label: "Top of its league", hint: "First among its league's games; sport and league order untouched." },
+  { value: "sport", label: "Top of its sport", hint: "First among every league in its sport." },
+  { value: "all", label: "Top of everything", hint: "Ahead of every sport and league." },
 ]
 
 /**
@@ -67,11 +77,19 @@ export function PriorityTeamsCard() {
     [leagueData],
   )
 
-  const onAdd = async (picked: TeamFilterEntry[]) => {
-    const team = picked[picked.length - 1]
+  const [addOpen, setAddOpen] = useState(false)
+  const [pick, setPick] = useState<TeamFilterEntry[]>([])
+  const [pickScope, setPickScope] = useState<PriorityTeamScope>("league")
+
+  const onAdd = async () => {
+    const team = pick[0]
     if (!team) return
     try {
-      await addMutation.mutateAsync({ team, scope: "league" })
+      await addMutation.mutateAsync({ team, scope: pickScope })
+      toast.success(`${team.name} added — re-grid queued for the next generation`)
+      setPick([])
+      setPickScope("league")
+      setAddOpen(false)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to add priority team")
     }
@@ -96,15 +114,22 @@ export function PriorityTeamsCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base flex items-center gap-2">
-          <Star className="h-4 w-4" /> Priority Teams
-        </CardTitle>
-        <CardDescription>
-          Float a team&apos;s games to the top of its league, its sport, or everything.
-          A team floats up wherever it plays (league and cup). Inside a pinned block the
-          float applies within that block. Ordering only — unrelated to the Teams page or
-          EPG.
-        </CardDescription>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Star className="h-4 w-4" /> Priority Teams
+            </CardTitle>
+            <CardDescription>
+              Float a team&apos;s games to the top of its league, its sport, or everything.
+              A team floats up wherever it plays (league and cup). Inside a pinned block the
+              float applies within that block. Ordering only — unrelated to the Teams page
+              or EPG.
+            </CardDescription>
+          </div>
+          <Button size="sm" onClick={() => setAddOpen(true)}>
+            <Plus className="h-4 w-4 mr-1" /> Add team
+          </Button>
+        </div>
       </CardHeader>
       <CardContent className="space-y-3">
         {isLoading ? (
@@ -153,14 +178,57 @@ export function PriorityTeamsCard() {
             No priority teams. Games number in Sport &amp; League order, then by start time.
           </p>
         )}
-        <TeamPicker
-          leagues={leagues}
-          selectedTeams={[]}
-          onSelectionChange={onAdd}
-          placeholder="Add a priority team…"
-          singleSelect
-        />
       </CardContent>
+
+      <Dialog
+        open={addOpen}
+        onOpenChange={(v) => {
+          if (!v) {
+            setPick([])
+            setPickScope("league")
+          }
+          setAddOpen(v)
+        }}
+      >
+        <DialogContent className="max-w-lg" onClose={() => setAddOpen(false)}>
+          <DialogHeader>
+            <DialogTitle>Add priority team</DialogTitle>
+            <DialogDescription>
+              Pick a team and how far its games float in the lineup.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <RadioCards
+              name="priority-scope"
+              value={pickScope}
+              onChange={(v) => setPickScope(v as PriorityTeamScope)}
+              options={SCOPE_OPTIONS.map((o) => ({
+                value: o.value,
+                label: o.label,
+                description: o.hint,
+              }))}
+            />
+            <div className="space-y-2">
+              <Label>Team</Label>
+              <TeamPicker
+                leagues={leagues}
+                selectedTeams={pick}
+                onSelectionChange={(t) => setPick(t.slice(-1))}
+                placeholder="Pick a team…"
+                singleSelect
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={onAdd} disabled={pick.length !== 1 || addMutation.isPending}>
+              {addMutation.isPending ? "Adding…" : "Add team"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }
@@ -283,7 +351,7 @@ export function SportLeagueOrderCard({ showWhenSortBy = "sport_league_time", cur
             <div>
               <CardTitle className="text-base">Sport &amp; League Order</CardTitle>
               <CardDescription>
-                The order sports and leagues take inside the channel range and inside every
+                The order sports and leagues take inside Everything Else and inside every
                 pinned block: higher in this list = lower channel numbers. Games within a
                 league sort by start time. Drag sports to reorder; expand to reorder leagues
                 within each sport. Unlisted sports/leagues go last.

--- a/frontend/src/hooks/useNumberingExceptions.ts
+++ b/frontend/src/hooks/useNumberingExceptions.ts
@@ -4,7 +4,6 @@ import {
   createNumberingException,
   updateNumberingException,
   deleteNumberingException,
-  reorderNumberingExceptions,
   getNumberingPreview,
 } from "@/api/numberingExceptions"
 import type {
@@ -53,14 +52,6 @@ export function useDeleteNumberingException() {
   const invalidate = useInvalidate()
   return useMutation({
     mutationFn: (id: number) => deleteNumberingException(id),
-    onSuccess: invalidate,
-  })
-}
-
-export function useReorderNumberingExceptions() {
-  const invalidate = useInvalidate()
-  return useMutation({
-    mutationFn: (ids: number[]) => reorderNumberingExceptions(ids),
     onSuccess: invalidate,
   })
 }

--- a/frontend/src/hooks/useSortPriorities.ts
+++ b/frontend/src/hooks/useSortPriorities.ts
@@ -6,8 +6,9 @@ import {
   getPriorityTeams,
   addPriorityTeam,
   deletePriorityTeam,
+  updatePriorityTeamScope,
 } from "@/api/sortPriorities"
-import type { SortPriorityReorderItem } from "@/api/sortPriorities"
+import type { PriorityTeamScope, SortPriorityReorderItem } from "@/api/sortPriorities"
 import type { TeamFilterEntry } from "@/api/types"
 
 export function useSortPriorities() {
@@ -53,7 +54,20 @@ export function useAddPriorityTeam() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (team: TeamFilterEntry) => addPriorityTeam(team),
+    mutationFn: ({ team, scope }: { team: TeamFilterEntry; scope?: PriorityTeamScope }) =>
+      addPriorityTeam(team, scope),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["priority-teams"] })
+    },
+  })
+}
+
+export function useUpdatePriorityTeamScope() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, scope }: { id: number; scope: PriorityTeamScope }) =>
+      updatePriorityTeamScope(id, scope),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["priority-teams"] })
     },

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { RadioCards } from "@/components/ui/radio-cards"
-import { SortPriorityManager } from "@/components/SortPriorityManager"
+import { PriorityTeamsCard, SportLeagueOrderCard } from "@/components/SortPriorityManager"
 import { PinnedBlocks } from "@/components/PinnedBlocks"
 import { Button } from "@/components/ui/button"
 import { requestChannelRelayout } from "@/api/settings"
@@ -19,12 +19,13 @@ import {
 import type { LifecycleSettings, ChannelNumberingSettings } from "@/api/settings"
 
 /**
- * Channels → Numbering. The lineup pipeline: the channel range every unpinned
- * channel numbers from (lifecycle blob), pinned blocks (#333, their own table
- * — saved immediately), number stability (channel-numbering blob), and sort
- * priority. Save full-PUTs the range + stability blobs; this page leaves the
- * consolidation mode and lifecycle timing/buffers untouched, and since only
- * one Channels view mounts at a time the full-PUT is safe.
+ * Channels → Numbering, listed most-specific first (a channel takes the first
+ * rule that matches it): Priority Teams and Pinned Blocks (own tables, saved
+ * immediately), Sport & League Order (saved immediately), then Everything Else
+ * (the range in the lifecycle blob) and Number Stability (channel-numbering
+ * blob) under one Save. This page leaves the consolidation mode and lifecycle
+ * timing/buffers untouched, and since only one Channels view mounts at a time
+ * the full-PUT is safe.
  */
 export function ChannelNumbering() {
   const { data: settings } = useSettings()
@@ -112,18 +113,35 @@ export function ChannelNumbering() {
 
   return (
     <div className="space-y-3">
+      <p className="text-sm text-muted-foreground px-1">
+        Rules are listed most-specific first — a channel takes the first one that matches
+        it. Priority Teams and Pinned Blocks save as you edit; the rest save with the button
+        at the bottom.
+      </p>
+
+      {/* 1. Priority Teams — team-level float (own table, saved immediately) */}
+      <PriorityTeamsCard />
+
+      {/* 2. Pinned Blocks — team › league › sport starts (own table, saved immediately) */}
+      <PinnedBlocks rangeStart={rangeStartNum} />
+
+      {/* 3. Sport & League Order — lineup order inside every block and Everything Else */}
+      <SportLeagueOrderCard currentSortBy="sport_league_time" showWhenSortBy="sport_league_time" />
+
+      {/* 4. Everything Else — the range for whatever no block claims */}
       <Card>
         <CardHeader>
-          <CardTitle>Channel Range</CardTitle>
+          <CardTitle>Everything Else</CardTitle>
           <CardDescription>
-            Where channels number from. Pinned blocks below carve out their own ranges;
-            everything else numbers from here in priority order.
+            Channels that don&apos;t belong to a pinned block number from here, in
+            Sport &amp; League order. Numbers already used by your other Dispatcharr
+            channels — or by a pinned block that starts inside this range — are skipped.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="ch-range-start-num">Channel Range Start</Label>
+              <Label htmlFor="ch-range-start-num">Everything Else Start</Label>
               <Input
                 id="ch-range-start-num"
                 type="number"
@@ -144,11 +162,11 @@ export function ChannelNumbering() {
                 }}
               />
               <p className="text-xs text-muted-foreground">
-                First channel number for everything that isn&apos;t pinned
+                First number for channels no pinned block claims
               </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="ch-range-end-num">Channel Range End</Label>
+              <Label htmlFor="ch-range-end-num">Everything Else End</Label>
               <Input
                 id="ch-range-end-num"
                 type="number"
@@ -175,22 +193,26 @@ export function ChannelNumbering() {
                 placeholder="No limit"
               />
               <p className="text-xs text-muted-foreground">
-                Last channel number (leave empty for no limit)
+                Last number for these channels (leave empty for no limit). Pinned blocks are
+                not limited by it.
               </p>
             </div>
           </div>
+        </CardContent>
+      </Card>
 
-          {/* Number Stability — applies inside every block and the range */}
-          <div className="space-y-3 pt-2 border-t">
-            <div>
-              <Label className="text-sm font-medium">Number Stability</Label>
-              <p className="text-xs text-muted-foreground mt-1">
-                Controls whether a channel can be renumbered while an event is
-                live. Dispatcharr relies on stable numbers, so a game shouldn&apos;t
-                move when another event starts or ends. Applies inside every pinned
-                block as well as the channel range.
-              </p>
-            </div>
+      {/* 5. Number Stability — global; applies inside every block and Everything Else */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Number Stability</CardTitle>
+          <CardDescription>
+            Whether a channel can be renumbered while its event is live. Dispatcharr
+            relies on stable numbers, so a game shouldn&apos;t move when another event
+            starts or ends. Applies inside every pinned block as well as Everything Else.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-3">
             <RadioCards
               name="channel-stability-mode"
               value={channelNumbering.channel_stability_mode}
@@ -256,7 +278,7 @@ export function ChannelNumbering() {
                       })
                     }
                   />
-                  Daily re-layout (reclaim gaps &amp; restore priority order)
+                  Daily re-layout (reclaim gaps &amp; restore lineup order)
                 </label>
                 {channelNumbering.channel_daily_reset_enabled && (
                   <div className="space-y-2 max-w-xs">
@@ -296,10 +318,10 @@ export function ChannelNumbering() {
                         : "Re-grid channels now"}
                   </Button>
                   <p className="text-xs text-muted-foreground">
-                    Renumber every channel back into priority order on the next
-                    generation, without waiting for the daily window. Use after
-                    changing the gap size, mode, sort priority, or pinned blocks.
-                    (These changes also queue a re-grid automatically.)
+                    Renumber every channel back into lineup order on the next
+                    generation, without waiting for the daily window. Changing the gap
+                    size, mode, priority teams, pinned blocks, or Sport &amp; League order
+                    queues this automatically.
                   </p>
                 </div>
               </div>
@@ -312,20 +334,12 @@ export function ChannelNumbering() {
               pending={updateChannelNumbering.isPending || updateLifecycle.isPending}
             />
             <p className="text-xs text-muted-foreground mt-2">
-              Channel numbers will be updated on the next EPG generation.
+              Saves Everything Else and Number Stability. Channel numbers update on the
+              next EPG generation.
             </p>
           </div>
         </CardContent>
       </Card>
-
-      {/* Pinned Blocks — saved immediately, not part of the Save above */}
-      <PinnedBlocks rangeStart={rangeStartNum} />
-
-      {/* Channel Ordering — lineup sort priority (within sport → league → time) */}
-      <SortPriorityManager
-        currentSortBy="sport_league_time"
-        showWhenSortBy="sport_league_time"
-      />
     </div>
   )
 }

--- a/frontend/src/pages/channels/ChannelNumbering.tsx
+++ b/frontend/src/pages/channels/ChannelNumbering.tsx
@@ -115,8 +115,8 @@ export function ChannelNumbering() {
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground px-1">
         Rules are listed most-specific first — a channel takes the first one that matches
-        it. Priority Teams and Pinned Blocks save as you edit; the rest save with the button
-        at the bottom.
+        it. The first three sections save as you edit; Everything Else and Number Stability
+        save with the button at the bottom.
       </p>
 
       {/* 1. Priority Teams — team-level float (own table, saved immediately) */}

--- a/teamarr/api/routes/numbering_exceptions.py
+++ b/teamarr/api/routes/numbering_exceptions.py
@@ -220,6 +220,8 @@ def preview_layout():
                     spills_into_next=spills,
                 )
             )
+        # Read like the dial: a block may start below (or inside) Everything Else.
+        out.sort(key=lambda m: m.start)
         return out
 
 

--- a/teamarr/api/routes/numbering_exceptions.py
+++ b/teamarr/api/routes/numbering_exceptions.py
@@ -1,8 +1,9 @@
 """Numbering exceptions (pinned channel-number blocks, #333) endpoints.
 
-CRUD over ``numbering_exceptions`` plus a reorder endpoint (UI drag order is
-the within-level tie-break) and an effective-layout preview that shows where
-today's channels would land under the current blocks.
+CRUD over ``numbering_exceptions`` plus an effective-layout preview that shows
+where today's channels would land under the current blocks. A start belongs
+to one block (or one named group); conflicting starts are rejected with a
+400 whose detail says what to do instead.
 """
 
 from fastapi import APIRouter, HTTPException, status
@@ -10,10 +11,10 @@ from pydantic import BaseModel, Field
 
 from teamarr.database import get_db
 from teamarr.database.numbering_exceptions import (
+    StartConflict,
     add_numbering_exception,
     delete_numbering_exception,
     get_numbering_exceptions,
-    reorder_numbering_exceptions,
     update_numbering_exception,
 )
 
@@ -72,10 +73,6 @@ class NumberingExceptionUpdate(BaseModel):
     label: str | None = None
     clear_label: bool = False
     enabled: bool | None = None
-
-
-class NumberingExceptionReorder(BaseModel):
-    ordered_ids: list[int]
 
 
 class LanePreviewModel(BaseModel):
@@ -144,27 +141,30 @@ def _with_counts(conn, exceptions) -> list[NumberingExceptionModel]:
 
 @router.get("", response_model=list[NumberingExceptionModel])
 def list_numbering_exceptions():
-    """List pinned blocks in precedence order (drag order)."""
+    """List pinned blocks in placement order (ascending start)."""
     with get_db() as conn:
         return _with_counts(conn, get_numbering_exceptions(conn))
 
 
 @router.post("", response_model=NumberingExceptionModel)
 def create_numbering_exception(data: NumberingExceptionCreate):
-    """Add a pinned block."""
+    """Add a pinned block. 400 if the start is already used by another block."""
     with get_db() as conn:
-        created = add_numbering_exception(
-            conn,
-            scope=data.scope,
-            start=data.start,
-            end=data.end,
-            label=data.label,
-            sport=data.sport,
-            league_code=data.league_code,
-            provider=data.provider,
-            provider_team_id=data.team_id,
-            team_league=data.team_league,
-        )
+        try:
+            created = add_numbering_exception(
+                conn,
+                scope=data.scope,
+                start=data.start,
+                end=data.end,
+                label=data.label,
+                sport=data.sport,
+                league_code=data.league_code,
+                provider=data.provider,
+                provider_team_id=data.team_id,
+                team_league=data.team_league,
+            )
+        except StartConflict as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
         if created is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -174,14 +174,6 @@ def create_numbering_exception(data: NumberingExceptionCreate):
                 ),
             )
         return _with_counts(conn, [created])[0]
-
-
-@router.put("/reorder")
-def reorder(data: NumberingExceptionReorder):
-    """Persist drag order (the tie-break within a precedence level)."""
-    with get_db() as conn:
-        reorder_numbering_exceptions(conn, data.ordered_ids)
-    return {"success": True}
 
 
 @router.get("/preview", response_model=list[LanePreviewModel])
@@ -233,16 +225,21 @@ def preview_layout():
 
 @router.put("/{exception_id}", response_model=NumberingExceptionModel)
 def update(exception_id: int, data: NumberingExceptionUpdate):
-    """Update a block's start / end / label / enabled."""
+    """Update a block's start / end / label / enabled. 400 on a start conflict."""
     with get_db() as conn:
-        updated = update_numbering_exception(
-            conn,
-            exception_id,
-            start=data.start,
-            end=None if data.clear_end else (data.end if data.end is not None else ...),
-            label=None if data.clear_label else (data.label if data.label is not None else ...),
-            enabled=data.enabled,
-        )
+        try:
+            updated = update_numbering_exception(
+                conn,
+                exception_id,
+                start=data.start,
+                end=None if data.clear_end else (data.end if data.end is not None else ...),
+                label=None
+                if data.clear_label
+                else (data.label if data.label is not None else ...),
+                enabled=data.enabled,
+            )
+        except StartConflict as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
         if updated is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/teamarr/api/routes/sort_priorities.py
+++ b/teamarr/api/routes/sort_priorities.py
@@ -57,7 +57,7 @@ class AutoPopulateResponse(BaseModel):
 
 
 class PriorityTeamModel(BaseModel):
-    """A team whose channels float to the top of the global channel list."""
+    """A team whose channels float to the top of its scope in the lineup."""
 
     id: int
     provider: str
@@ -65,17 +65,25 @@ class PriorityTeamModel(BaseModel):
     team_name: str
     league: str | None = None
     sport: str
+    scope: str = "all"  # 'all' | 'sport' | 'league'
 
 
 class PriorityTeamCreate(BaseModel):
     """Add a priority team (a TeamPicker ``TeamFilterEntry``).
 
-    Name + sport are resolved server-side from ``team_cache``.
+    Name + sport are resolved server-side from ``team_cache``. ``scope`` is how
+    far the team floats: top of everything, of its sport, or of its league
+    (default).
     """
 
     provider: str
     team_id: str
     league: str | None = None
+    scope: str = "league"
+
+
+class PriorityTeamUpdate(BaseModel):
+    scope: str
 
 
 # =============================================================================
@@ -178,7 +186,7 @@ def create_sort_priority(data: SortPriorityCreate):
 
 @router.get("/teams", response_model=list[PriorityTeamModel])
 def get_priority_teams():
-    """List teams whose channels float to the top of the global channel list."""
+    """List priority teams and how far each floats (all / sport / league)."""
     from teamarr.database.priority_teams import get_priority_teams
 
     with get_db() as conn:
@@ -198,14 +206,32 @@ def add_priority_team(data: PriorityTeamCreate):
             provider=data.provider,
             provider_team_id=data.team_id,
             league=data.league,
+            scope=data.scope,
         )
 
     if team is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Team not found in cache — refresh the team directory and try again",
+            detail="Team not found in cache (or invalid scope) — refresh the team "
+            "directory and try again",
         )
 
+    return PriorityTeamModel(**team)
+
+
+@router.put("/teams/{team_pk}", response_model=PriorityTeamModel)
+def update_priority_team(team_pk: int, data: PriorityTeamUpdate):
+    """Change how far a priority team floats: 'all', 'sport', or 'league'."""
+    from teamarr.database.priority_teams import update_priority_team_scope
+
+    with get_db() as conn:
+        team = update_priority_team_scope(conn, team_pk, data.scope)
+
+    if team is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Priority team not found or invalid scope",
+        )
     return PriorityTeamModel(**team)
 
 

--- a/teamarr/database/channel_numbers.py
+++ b/teamarr/database/channel_numbers.py
@@ -437,8 +437,11 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
         if p.league_code is not None
     }
 
-    # Priority teams: (sport_lower, team_name_lower) keys; a channel floats to the
-    # top if either its home or away team matches one (see channel_priority_teams).
+    # Priority teams: {(sport_lower, team_name_lower): scope}; a channel floats
+    # when either its home or away team matches one. The scope decides *where*
+    # the float tier slots into the key: 'all' ahead of sport order, 'sport'
+    # ahead of league order within its sport, 'league' ahead of time within its
+    # league (see channel_priority_teams).
     priority_keys = get_priority_team_match_keys(conn)
 
     # 2. Get all channels from enabled groups with event info.
@@ -494,7 +497,8 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
             }
         )
 
-    # 3. Sort by: priority team → sport priority → league priority → time → event_id → keyword
+    # 3. Sort by: priority team (all) → sport → priority team (sport) → league →
+    #    priority team (league) → time → event_id → keyword
     def sort_key(ch):
         sport = ch.get("sport") or ""
         league = ch.get("league") or ""
@@ -505,12 +509,15 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
         sport_lower = sport.lower()
         league_lower = league.lower()
 
-        # Priority-team tier (0 = priority, 1 = normal): match either team by name
-        # within sport. Sorts first so followed teams lead, then normal ordering.
+        # Priority-team tiers (0 = priority, 1 = normal), one per scope: match
+        # either team by name within sport; the broadest matching scope wins.
         home = (ch.get("home_team") or "").lower()
         away = (ch.get("away_team") or "").lower()
-        is_priority = (sport_lower, home) in priority_keys or (sport_lower, away) in priority_keys
-        priority_tier = 0 if is_priority else 1
+        sides = ((sport_lower, home), (sport_lower, away))
+        scopes = {priority_keys[k] for k in sides if k in priority_keys}
+        all_tier = 0 if "all" in scopes else 1
+        sport_tier = 0 if scopes & {"all", "sport"} else 1
+        league_tier = 0 if scopes else 1
 
         sport_pri = sport_order.get(sport_lower, 9999)
         league_pri = league_order.get((sport_lower, league_lower), 9999)
@@ -531,7 +538,10 @@ def get_all_channels_sorted(conn: Connection) -> list[dict]:
         # Main channel (no keyword) sorts before keyword channels
         keyword_sort = (0, "") if not keyword else (1, keyword)
 
-        return (priority_tier, sport_pri, league_pri, event_date, str(event_id), keyword_sort)
+        return (
+            all_tier, sport_pri, sport_tier, league_pri, league_tier,
+            event_date, str(event_id), keyword_sort,
+        )
 
     sorted_channels = sorted(channels, key=sort_key)
 

--- a/teamarr/database/numbering_exceptions.py
+++ b/teamarr/database/numbering_exceptions.py
@@ -8,8 +8,15 @@ channel range — the *default lane*.
 
 Every channel resolves to exactly one lane via :func:`resolve_lane`:
 most specific wins (home-team pin › away-team pin › league › sport ›
-default), ties broken by ``sort_order``. Resolution reads only fields that
-never change during an event, so a channel's lane is stable for its lifetime.
+default). Resolution reads only fields that never change during an event, so
+a channel's lane is stable for its lifetime.
+
+A start belongs to one block. Two rows may share a start only as members of
+the same named group — the lane is keyed on ``start``, so an ungrouped
+collision ("Brewers at 550" *and* "MLB at 550") would silently merge into one
+block ordered by the normal lineup sort, which is never what the user meant
+(they want Priority Teams, or a different start). :func:`add_numbering_exception`
+and :func:`update_numbering_exception` raise :class:`StartConflict` instead.
 
 The allocator in :mod:`teamarr.database.channel_numbers` runs the same
 placement code (compact / gap / strict) inside each lane. See
@@ -101,6 +108,10 @@ def _row_to_exception(row: sqlite3.Row) -> NumberingException:
     )
 
 
+class StartConflict(ValueError):
+    """A block start is already used by another block outside this group."""
+
+
 def _table_exists(conn: Connection) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'numbering_exceptions'"
@@ -116,18 +127,17 @@ def _table_exists(conn: Connection) -> bool:
 def get_numbering_exceptions(
     conn: Connection, *, enabled_only: bool = False
 ) -> list[NumberingException]:
-    """All pinned blocks in precedence order (sort_order, then id).
+    """All pinned blocks in placement order (ascending start, then id).
 
-    This is the UI list order: the reorder arrows edit ``sort_order``, so the
-    list must follow it rather than ``start`` or a move would be invisible.
-    Placement order (ascending start) is derived separately by
-    ``LaneResolver.lanes``.
+    This is the UI list order too, so the list reads like the effective
+    layout: lower starts first, group members adjacent.
     """
     if not _table_exists(conn):
         return []
     where = "WHERE enabled = 1" if enabled_only else ""
     rows = conn.execute(
-        f"SELECT {_COLUMNS} FROM numbering_exceptions {where} ORDER BY sort_order ASC, id ASC"
+        f"SELECT {_COLUMNS} FROM numbering_exceptions {where} "
+        "ORDER BY start ASC, sort_order ASC, id ASC"
     ).fetchall()
     return [_row_to_exception(r) for r in rows]
 
@@ -169,6 +179,37 @@ def _validate(scope: str, start: int, end: int | None) -> str | None:
     return None
 
 
+def _check_start_conflict(
+    conn: Connection, start: int, label: str | None, *, exclude_id: int | None = None
+) -> None:
+    """Raise :class:`StartConflict` unless ``start`` is free or every block
+    already at ``start`` is in the same non-empty group ``label``."""
+    if not _table_exists(conn):
+        return
+    rows = conn.execute(
+        "SELECT id, scope, sport, league_code, team_name, label FROM numbering_exceptions "
+        "WHERE start = ? AND (? IS NULL OR id != ?) ORDER BY id",
+        (int(start), exclude_id, exclude_id),
+    ).fetchall()
+    if not rows:
+        return
+    label = (label or "").strip()
+    if label and all((r["label"] or "").strip().lower() == label.lower() for r in rows):
+        return
+    r = rows[0]
+    holder = r["team_name"] or r["league_code"] or r["sport"] or "another block"
+    hint = (
+        f'Give it the group name "{r["label"]}" to share that block, '
+        if r["label"]
+        else "Give both blocks the same group name to share it, "
+    )
+    raise StartConflict(
+        f"Channel {start} already starts the {holder} block. {hint}"
+        "pick a different start, or use Priority Teams to put a team first "
+        "inside its league's block."
+    )
+
+
 def add_numbering_exception(
     conn: Connection,
     *,
@@ -192,11 +233,14 @@ def add_numbering_exception(
     - ``scope='sport'``: pass ``sport``.
 
     Returns the stored row, or ``None`` on validation / lookup failure.
+    Raises :class:`StartConflict` when ``start`` is taken by a block outside
+    the group ``label``.
     """
     err = _validate(scope, start, end)
     if err:
         logger.warning("[NUMBERING_EXC] %s", err)
         return None
+    _check_start_conflict(conn, start, label)
 
     team_name: str | None = None
     if scope == "team":
@@ -293,6 +337,8 @@ def update_numbering_exception(
         new_label = current.label
     else:
         new_label = (label.strip() or None) if isinstance(label, str) else None
+    if new_start != current.start or new_label != current.label:
+        _check_start_conflict(conn, new_start, new_label, exclude_id=exception_id)
     new_enabled = current.enabled if enabled is None else bool(enabled)
     conn.execute(
         """
@@ -314,16 +360,6 @@ def delete_numbering_exception(conn: Connection, exception_id: int) -> bool:
     return False
 
 
-def reorder_numbering_exceptions(conn: Connection, ordered_ids: list[int]) -> bool:
-    """Persist UI drag order as sort_order (the within-level tie-break)."""
-    for position, exception_id in enumerate(ordered_ids):
-        conn.execute(
-            "UPDATE numbering_exceptions SET sort_order = ?, updated_at = CURRENT_TIMESTAMP "
-            "WHERE id = ?",
-            (position, int(exception_id)),
-        )
-    _arm_relayout(conn)
-    return True
 
 
 # =============================================================================
@@ -336,6 +372,11 @@ class LaneResolver:
 
     Built once per allocation pass (``LaneResolver.load(conn)``) so resolving
     hundreds of channels costs no queries. ``default`` is the global range lane.
+
+    Within one precedence level a channel can only match one row (one league,
+    one sport, one home team, one away team), so the ``(sort_order, id)``
+    ordering below is just a deterministic fallback for legacy rows that were
+    created before starts became unique per group.
     """
 
     def __init__(self, exceptions: list[NumberingException], default: Lane):

--- a/teamarr/database/priority_teams.py
+++ b/teamarr/database/priority_teams.py
@@ -1,7 +1,14 @@
 """Channel priority-teams queries.
 
-A priority team floats its channels to the top of the global channel list,
-ahead of all sport/league/time ordering (see ``channel_numbers.get_all_channels_sorted``).
+A priority team floats its channels to the top of a *scope* in the lineup
+(see ``channel_numbers.get_all_channels_sorted``):
+
+- ``'all'``    — top of everything (ahead of sport/league order)
+- ``'sport'``  — first within its sport (sport order untouched)
+- ``'league'`` — first within its league (the default for new teams)
+
+Because pinned blocks partition the lineup *after* it is sorted, the scope
+only changes a team's position relative to other channels in the same block.
 This is purely an ordering preference and has no connection to the Teams page
 or EPG generation. Identity comes from ``team_cache``; channels are matched by
 ``(sport, team_name)`` against ``managed_channels.home_team``/``away_team``.
@@ -12,12 +19,26 @@ import sqlite3
 
 logger = logging.getLogger(__name__)
 
+SCOPES = ("all", "sport", "league")
+DEFAULT_SCOPE = "league"
+# Broadest wins when one team has several rows (one per league it was picked in).
+_SCOPE_BREADTH = {"all": 0, "sport": 1, "league": 2}
+
+
+def _has_scope_column(conn: sqlite3.Connection) -> bool:
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(channel_priority_teams)")}
+    return "scope" in cols
+
+
+def _scope_select(conn: sqlite3.Connection) -> str:
+    return "scope" if _has_scope_column(conn) else "'all' AS scope"
+
 
 def get_priority_teams(conn: sqlite3.Connection) -> list[dict]:
     """Return all configured priority teams, newest first."""
     cursor = conn.execute(
-        """
-        SELECT id, provider, provider_team_id, team_name, league, sport
+        f"""
+        SELECT id, provider, provider_team_id, team_name, league, sport, {_scope_select(conn)}
         FROM channel_priority_teams
         ORDER BY sport, team_name
         """
@@ -31,14 +52,19 @@ def add_priority_team(
     provider: str,
     provider_team_id: str,
     league: str | None,
+    scope: str = DEFAULT_SCOPE,
 ) -> dict | None:
     """Add a priority team, resolving its name + sport from ``team_cache``.
 
-    The frontend sends only ``(provider, team_id, league)`` (a ``TeamFilterEntry``);
-    we enrich from the cache so the match key and display name stay canonical.
-    Returns the stored row, or ``None`` if the team isn't in ``team_cache``.
-    Idempotent on ``(provider, provider_team_id, league)``.
+    The frontend sends only ``(provider, team_id, league)`` (a ``TeamFilterEntry``)
+    plus an optional ``scope``; we enrich from the cache so the match key and
+    display name stay canonical. Returns the stored row, or ``None`` if the
+    team isn't in ``team_cache`` or ``scope`` is invalid.
+    Idempotent on ``(provider, provider_team_id, league)`` (re-adding updates scope).
     """
+    if scope not in SCOPES:
+        logger.warning("[PRIORITY_TEAMS] invalid scope %r", scope)
+        return None
     lookup = conn.execute(
         """
         SELECT team_name, sport FROM team_cache
@@ -60,28 +86,55 @@ def add_priority_team(
     conn.execute(
         """
         INSERT INTO channel_priority_teams
-            (provider, provider_team_id, team_name, league, sport)
-        VALUES (?, ?, ?, ?, ?)
+            (provider, provider_team_id, team_name, league, sport, scope)
+        VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT(provider, provider_team_id, league) DO UPDATE SET
             team_name = excluded.team_name,
-            sport = excluded.sport
+            sport = excluded.sport,
+            scope = excluded.scope
         """,
-        (provider, provider_team_id, lookup["team_name"], league, lookup["sport"]),
+        (provider, provider_team_id, lookup["team_name"], league, lookup["sport"], scope),
     )
-    row = conn.execute(
-        """
-        SELECT id, provider, provider_team_id, team_name, league, sport
-        FROM channel_priority_teams
-        WHERE provider = ? AND provider_team_id = ? AND (league IS ? OR league = ?)
-        """,
-        (provider, provider_team_id, league, league),
-    ).fetchone()
+    row = _get_row(conn, provider, provider_team_id, league)
     if row:
         # Priority teams float to the top of the lineup; arm a one-shot re-grid so
         # the change applies on the next generation rather than at the daily reset.
         from teamarr.database.channel_numbers import arm_channel_relayout
 
         arm_channel_relayout(conn)
+    return dict(row) if row else None
+
+
+def _get_row(conn, provider, provider_team_id, league):
+    return conn.execute(
+        f"""
+        SELECT id, provider, provider_team_id, team_name, league, sport, {_scope_select(conn)}
+        FROM channel_priority_teams
+        WHERE provider = ? AND provider_team_id = ? AND (league IS ? OR league = ?)
+        """,
+        (provider, provider_team_id, league, league),
+    ).fetchone()
+
+
+def update_priority_team_scope(conn: sqlite3.Connection, team_pk: int, scope: str) -> dict | None:
+    """Change how far a priority team floats. Returns the row, or ``None`` if
+    the id is unknown or ``scope`` is invalid."""
+    if scope not in SCOPES:
+        logger.warning("[PRIORITY_TEAMS] invalid scope %r", scope)
+        return None
+    cursor = conn.execute(
+        "UPDATE channel_priority_teams SET scope = ? WHERE id = ?", (scope, team_pk)
+    )
+    if cursor.rowcount == 0:
+        return None
+    from teamarr.database.channel_numbers import arm_channel_relayout
+
+    arm_channel_relayout(conn)
+    row = conn.execute(
+        "SELECT id, provider, provider_team_id, team_name, league, sport, scope "
+        "FROM channel_priority_teams WHERE id = ?",
+        (team_pk,),
+    ).fetchone()
     return dict(row) if row else None
 
 
@@ -99,16 +152,23 @@ def delete_priority_team(conn: sqlite3.Connection, team_pk: int) -> bool:
     return False
 
 
-def get_priority_team_match_keys(conn: sqlite3.Connection) -> set[tuple[str, str]]:
-    """Return ``(sport_lower, team_name_lower)`` keys for fast channel matching.
+def get_priority_team_match_keys(conn: sqlite3.Connection) -> dict[tuple[str, str], str]:
+    """Return ``{(sport_lower, team_name_lower): scope}`` for fast channel matching.
 
     Sport-scoped name matching gives the "follow my team everywhere it plays"
     behaviour (a club's league + cup channels both float) while sport scoping
-    avoids cross-sport name collisions (NFL vs MLB "Cardinals").
+    avoids cross-sport name collisions (NFL vs MLB "Cardinals"). A team listed
+    several times (one row per league picked) keeps its broadest scope.
     """
-    cursor = conn.execute("SELECT sport, team_name FROM channel_priority_teams")
-    return {
-        (row["sport"].lower(), row["team_name"].lower())
-        for row in cursor.fetchall()
-        if row["sport"] and row["team_name"]
-    }
+    cursor = conn.execute(
+        f"SELECT sport, team_name, {_scope_select(conn)} FROM channel_priority_teams"
+    )
+    keys: dict[tuple[str, str], str] = {}
+    for row in cursor.fetchall():
+        if not (row["sport"] and row["team_name"]):
+            continue
+        key = (row["sport"].lower(), row["team_name"].lower())
+        scope = row["scope"] if row["scope"] in SCOPES else "all"
+        if key not in keys or _SCOPE_BREADTH[scope] < _SCOPE_BREADTH[keys[key]]:
+            keys[key] = scope
+    return keys

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -903,6 +903,10 @@ CREATE TABLE IF NOT EXISTS channel_priority_teams (
     team_name TEXT NOT NULL,                 -- Display + match key (e.g., 'Liverpool')
     league TEXT,                             -- League slug the team was picked from
     sport TEXT NOT NULL,                     -- Sport code (scopes name matching)
+    -- How far the team floats: top of everything, of its sport, or of its league.
+    -- DEFAULT 'all' preserves pre-scope behaviour for existing rows; new rows
+    -- are created with 'league' (see priority_teams.add_priority_team).
+    scope TEXT NOT NULL DEFAULT 'all' CHECK(scope IN ('all', 'sport', 'league')),
 
     -- One entry per team-in-league
     UNIQUE(provider, provider_team_id, league)

--- a/tests/lifecycle/test_numbering_lanes.py
+++ b/tests/lifecycle/test_numbering_lanes.py
@@ -458,7 +458,7 @@ def test_add_team_pin_resolves_from_cache_and_rejects_unknown():
     c = build()
     exc = pin(c, "team", 800, provider="espn", provider_team_id="8")
     assert (exc.team_name, exc.sport, exc.scope) == ("Detroit Lions", "football", "team")
-    assert ne.add_numbering_exception(c, scope="team", start=800, provider="espn",
+    assert ne.add_numbering_exception(c, scope="team", start=810, provider="espn",
                                       provider_team_id="nope") is None
 
 
@@ -466,7 +466,7 @@ def test_add_league_pin_resolves_sport():
     c = build()
     exc = pin(c, "league", 500, league_code="NFL")
     assert (exc.league_code, exc.sport) == ("nfl", "football")
-    assert ne.add_numbering_exception(c, scope="league", start=500, league_code="zzz") is None
+    assert ne.add_numbering_exception(c, scope="league", start=510, league_code="zzz") is None
 
 
 @pytest.mark.parametrize("kw", [
@@ -479,27 +479,68 @@ def test_validation_rejects(kw):
     assert ne.add_numbering_exception(c, **kw) is None
 
 
-def test_update_and_reorder():
+def test_update_range_and_label():
     c = build()
     a = pin(c, "league", 500, league_code="nfl")
-    b = pin(c, "league", 500, league_code="nba", label="Ball")
     upd = ne.update_numbering_exception(c, a.id, end=520, label="Football")
     assert (upd.end, upd.label) == (520, "Football")
     upd = ne.update_numbering_exception(c, a.id, end=None, label=None)
     assert (upd.end, upd.label) == (None, None)
     assert ne.update_numbering_exception(c, a.id, start=600, end=500) is None  # end < start
-    ne.reorder_numbering_exceptions(c, [b.id, a.id])
-    assert [e.id for e in ne.get_numbering_exceptions(c)] == [b.id, a.id]
 
 
-def test_list_order_follows_sort_order_not_start():
-    """The reorder arrows must visibly move rows: list order is sort_order, not start."""
+def test_list_order_is_placement_order():
+    """No reorder arrows any more: the list reads like the effective layout."""
     c = build()
     hi = pin(c, "league", 900, league_code="nfl")
     lo = pin(c, "league", 100, league_code="nba")
-    assert [e.id for e in ne.get_numbering_exceptions(c)] == [hi.id, lo.id]
-    ne.reorder_numbering_exceptions(c, [lo.id, hi.id])
     assert [e.id for e in ne.get_numbering_exceptions(c)] == [lo.id, hi.id]
-    # placement order is still by start
     resolver = ne.LaneResolver.load(c, cn._default_lane(c))
     assert [lane.start for lane in resolver.lanes()] == [100, 900, 101]
+
+
+# ---------------------------------------------------------------------------
+# A start belongs to one block (the "Brewers at 550 + MLB at 550" confusion)
+# ---------------------------------------------------------------------------
+
+
+def test_same_start_without_group_is_rejected():
+    c = build()
+    pin(c, "league", 550, league_code="mlb")
+    with pytest.raises(ne.StartConflict) as exc:
+        pin(c, "team", 550, provider="espn", provider_team_id="1", team_league="mlb")
+    assert "550" in str(exc.value) and "Priority Teams" in str(exc.value)
+    # Nothing was written.
+    assert len(ne.get_numbering_exceptions(c)) == 1
+
+
+def test_same_start_with_matching_group_is_allowed():
+    c = build()
+    pin(c, "league", 850, league_code="fifa.world", label="Big events")
+    pin(c, "league", 850, league_code="nhl", label="big events")  # case-insensitive
+    assert len(ne.get_numbering_exceptions(c)) == 2
+
+
+def test_same_start_with_different_group_is_rejected():
+    c = build()
+    pin(c, "league", 850, league_code="fifa.world", label="Big events")
+    with pytest.raises(ne.StartConflict) as exc:
+        pin(c, "league", 850, league_code="nhl", label="Hockey")
+    assert '"Big events"' in str(exc.value)
+    with pytest.raises(ne.StartConflict):
+        pin(c, "league", 850, league_code="nhl")  # no label at all
+
+
+def test_update_start_onto_another_block_is_rejected():
+    c = build()
+    a = pin(c, "league", 500, league_code="nfl")
+    b = pin(c, "league", 600, league_code="nba")
+    with pytest.raises(ne.StartConflict):
+        ne.update_numbering_exception(c, b.id, start=500)
+    assert ne.get_numbering_exception(c, b.id).start == 600
+    # Moving onto a group by adopting its label is fine.
+    ne.update_numbering_exception(c, a.id, label="Ball")
+    upd = ne.update_numbering_exception(c, b.id, start=500, label="Ball")
+    assert upd.start == 500
+    # Touching only `enabled` never re-validates (legacy same-start rows keep working).
+    assert ne.update_numbering_exception(c, b.id, enabled=False).enabled is False

--- a/tests/lifecycle/test_priority_teams.py
+++ b/tests/lifecycle/test_priority_teams.py
@@ -17,6 +17,7 @@ from teamarr.database.priority_teams import (
     delete_priority_team,
     get_priority_team_match_keys,
     get_priority_teams,
+    update_priority_team_scope,
 )
 from tests.helpers import SCHEMA_PATH
 
@@ -83,7 +84,34 @@ def test_delete_removes_row(conn):
 
 def test_match_keys_are_sport_scoped_lowercase(conn):
     add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1")
-    assert get_priority_team_match_keys(conn) == {("soccer", "liverpool")}
+    # New teams default to floating within their league.
+    assert get_priority_team_match_keys(conn) == {("soccer", "liverpool"): "league"}
+
+
+def test_scope_update_and_validation(conn):
+    row = add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1")
+    assert row["scope"] == "league"
+    assert update_priority_team_scope(conn, row["id"], "sport")["scope"] == "sport"
+    assert update_priority_team_scope(conn, row["id"], "bogus") is None
+    assert update_priority_team_scope(conn, 9999, "all") is None
+    assert add_priority_team(
+        conn, provider="espn", provider_team_id="364", league="eng.1", scope="bogus"
+    ) is None
+    # Re-adding is idempotent and updates scope.
+    row = add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1",
+                            scope="all")
+    assert row["scope"] == "all"
+    assert get_priority_team_match_keys(conn) == {("soccer", "liverpool"): "all"}
+
+
+def test_existing_rows_without_scope_column_float_everywhere(conn):
+    """Pre-scope installs (column added by reconciliation, DEFAULT 'all') keep
+    today's behaviour; a bare test schema without the column reads as 'all'."""
+    conn.execute("ALTER TABLE channel_priority_teams RENAME TO cpt_old")
+    conn.execute("CREATE TABLE channel_priority_teams (id INTEGER PRIMARY KEY, sport TEXT, "
+                 "team_name TEXT)")
+    conn.execute("INSERT INTO channel_priority_teams (sport, team_name) VALUES ('soccer', 'X')")
+    assert get_priority_team_match_keys(conn) == {("soccer", "x"): "all"}
 
 
 # ---------------------------------------------------------------------------
@@ -142,3 +170,55 @@ def test_priority_does_not_cross_sports(conn):
     conn.commit()
     # soccer Liverpool prioritized; the football "Liverpool" channel must not float.
     assert [c["id"] for c in get_all_channels_sorted(conn)] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Float scope: all / sport / league
+# ---------------------------------------------------------------------------
+
+
+def _lineup(conn):
+    """Two sports, two leagues each; Liverpool's (soccer, eng.1) game is the
+    latest event in the lowest-priority league of the lowest-priority sport."""
+    conn.executescript(
+        """
+        INSERT INTO channel_sort_priorities (sport, league_code, sort_priority) VALUES
+          ('football', NULL, 0), ('football', 'nfl', 0),
+          ('soccer', NULL, 1), ('soccer', 'usa.1', 0), ('soccer', 'eng.1', 1);
+        """
+    )
+    _add_channel(conn, ch_id=1, sport="football", league="nfl",
+                 home="Lions", away="Bears", date="2026-02-01T12:00:00Z")
+    _add_channel(conn, ch_id=2, sport="soccer", league="usa.1",
+                 home="LAFC", away="Galaxy", date="2026-02-01T12:00:00Z")
+    _add_channel(conn, ch_id=3, sport="soccer", league="eng.1",
+                 home="Arsenal", away="Chelsea", date="2026-02-01T12:00:00Z")
+    _add_channel(conn, ch_id=4, sport="soccer", league="eng.1",
+                 home="Liverpool", away="Everton", date="2026-02-09T12:00:00Z")
+    conn.commit()
+    assert [c["id"] for c in get_all_channels_sorted(conn)] == [1, 2, 3, 4]
+
+
+def _order(conn):
+    return [c["id"] for c in get_all_channels_sorted(conn)]
+
+
+def test_scope_league_floats_within_league_only(conn):
+    _lineup(conn)
+    add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1",
+                      scope="league")
+    assert _order(conn) == [1, 2, 4, 3]
+
+
+def test_scope_sport_floats_above_other_leagues_in_sport(conn):
+    _lineup(conn)
+    add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1",
+                      scope="sport")
+    assert _order(conn) == [1, 4, 2, 3]
+
+
+def test_scope_all_floats_above_everything(conn):
+    _lineup(conn)
+    add_priority_team(conn, provider="espn", provider_team_id="364", league="eng.1",
+                      scope="all")
+    assert _order(conn) == [4, 1, 2, 3]


### PR DESCRIPTION
Closes nothing (stays open until release per workflow) — see #677 for the full write-up.

- Reject same-start pinned blocks outside a shared group (400 with guidance); drop the dead reorder arrows/endpoint; list + preview in placement order.
- Priority Teams: per-team float scope (everything / sport / league; new default league, existing rows stay on everything) folded into the global sort key.
- 'Channel Range' → 'Everything Else'; split from Number Stability; page ordered most-specific first; 'Sort Priority Order' → 'Sport & League Order'.
- Docs rewritten to match. New tests: start-conflict rules, scope sort behaviour, no-scope-column fallback.

Gates: ruff clean, 2689 passed, frontend build OK. Verified in browser (dev instance, DRY_RUN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsrjBwMK9ofAMHbLvuMzSG