### PR TITLE
fix(refresh): score of 0 no longer treated as missing in refresh overlay (#680)

### DIFF
--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -726,6 +726,12 @@ class SportsDataService:
                 # when present, even if state is unchanged (other status fields
                 # like clock/period may have updated).
                 overlay[field_name] = fresh_val if fresh_val is not None else orig_val
+            elif field_name in ("home_score", "away_score"):
+                # A score of 0 is a real value (#680): the falsy check below
+                # made a shutout side's fresh 0 fall back to the original —
+                # None before the game — so {home_team_score}/{final_score}
+                # rendered empty. For scores, only None means "not provided".
+                overlay[field_name] = fresh_val if fresh_val is not None else orig_val
             else:
                 overlay[field_name] = fresh_val if fresh_val else orig_val
         return replace(event, **overlay)

--- a/tests/providers/test_refresh_event_status_additive.py
+++ b/tests/providers/test_refresh_event_status_additive.py
@@ -149,6 +149,37 @@ class TestRefreshIsAdditive:
         # Empty broadcasts from summary shouldn't wipe the original list.
         assert result.broadcasts == ["FOX"]
 
+    def test_zero_score_overlays_from_fresh(self):
+        """#680: a shutout side's 0 is a real score, not a missing value.
+
+        The overlay's falsy check treated a fresh 0 like None and fell back to
+        the original's pre-game None, leaving {home_team_score} and
+        {final_score} empty whenever a team was shut out.
+        """
+        original = _make_event(status_state="in_progress")  # scores still None
+        fresh = _make_event(status_state="final", home_score=0, away_score=3)
+        service = SportsDataService(providers=[])
+        with (
+            patch.object(service, "get_event", return_value=fresh),
+            patch.object(service._cache, "delete"),
+        ):
+            result = service.refresh_event_status(original)
+        assert result.home_score == 0
+        assert result.away_score == 3
+
+    def test_zero_zero_draw_overlays_from_fresh(self):
+        """#680 edge: 0-0 (a soccer draw in progress) populates both sides."""
+        original = _make_event(status_state="scheduled")
+        fresh = _make_event(status_state="in_progress", home_score=0, away_score=0)
+        service = SportsDataService(providers=[])
+        with (
+            patch.object(service, "get_event", return_value=fresh),
+            patch.object(service._cache, "delete"),
+        ):
+            result = service.refresh_event_status(original)
+        assert result.home_score == 0
+        assert result.away_score == 0
+
     def test_static_fields_never_replaced(self):
         original = _make_event()
         # Adversarial fresh: pretend summary returned wrong league/sport/start_time.


### PR DESCRIPTION
Fixes #680.

**Root cause:** `refresh_event_status` overlays fresh game-state fields with `fresh_val if fresh_val else orig_val`. A score of **0** is falsy, so a shutout side's fresh 0 fell back to the original event's pre-game `None` — leaving `{home_team_score}`, `{away_team_score}`, and `{final_score}` (which requires both sides non-None) empty for the whole game.

**Fix:** `home_score`/`away_score` overlay on `is not None`; all other refresh fields keep the falsy fallback (empty broadcasts/editorial from the summary endpoint must still not clobber, per #201).

**Tests:** two regression cases (0–3 shutout, 0–0 draw) in `test_refresh_event_status_additive.py`. Full suite 2691 passed, ruff clean, frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsrjBwMK9ofAMHbLvuMzSG