### PR TITLE
feat: display extracted stream metadata in Preview modal (teamarrv2-m2za)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -45,6 +45,8 @@ Column headers sort, and a filter row narrows the list by name and status. Selec
 
 To see *which* streams matched or failed (and fix failures manually), use the **Matched**/**Failed** drill-downs in the [Dashboard](../dashboard)'s run history — the Sources table shows rates, not per-stream detail. The per-source **preview** button shows current stream matches without running a full generation.
 
+Preview lists each unmatched stream with what the classifier actually read out of its name — the two team names it parsed, and the date, time and timezone it extracted — plus the detected league as a dashed badge in the **League** column and the same failure reason the run-history **Failed** drill-down shows. When a stream fails, that line usually says why: a team name that swallowed the provider prefix, a date read in the wrong format, or a league hint pointing somewhere unexpected.
+
 {: .note }
 > The percentage is **stream coverage**: distinct streams matched ÷ eligible streams (always 0–100%). The hover tooltip shows **matches produced** — the total number of stream→event matches. With [EPG matching](../matching/program-matching), one linear stream (ESPN, FS1…) is time-shared across many events, so matches produced can far exceed the stream count. These are tracked separately so coverage stays a true health signal.
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -316,6 +316,12 @@ export interface PreviewStream {
   start_time: string | null
   from_cache: boolean
   exclusion_reason: string | null
+  parsed_team1?: string | null
+  parsed_team2?: string | null
+  detected_league?: string | null
+  extracted_date?: string | null
+  extracted_time?: string | null
+  extracted_tz?: string | null
 }
 
 export interface PreviewGroupResponse {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -316,6 +316,8 @@ export interface PreviewStream {
   start_time: string | null
   from_cache: boolean
   exclusion_reason: string | null
+  failed_reason?: string | null
+  detail?: string | null
   parsed_team1?: string | null
   parsed_team2?: string | null
   detected_league?: string | null

--- a/frontend/src/components/RunHistoryTable.tsx
+++ b/frontend/src/components/RunHistoryTable.tsx
@@ -26,7 +26,7 @@ import { VirtualizedTable } from "@/components/VirtualizedTable"
 import { useDateFormat } from "@/hooks/useDateFormat"
 import { getMatchedStreams, getFailedMatches } from "@/api/epg"
 import { getLeagues } from "@/api/teams"
-import { getLeagueDisplayName } from "@/lib/utils"
+import { getFailedReasonLabel, getLeagueDisplayName } from "@/lib/utils"
 import type { ProcessingRun, MatchedStream, FailedMatch } from "@/api/epg"
 
 // ---------------------------------------------------------------------------
@@ -71,38 +71,6 @@ function StatusIcon({ status }: { status: string }) {
     default:
       return <Clock className="h-4 w-4 text-muted-foreground" />
   }
-}
-
-function getFailedReasonLabel(reason: string): string {
-  const labels: Record<string, string> = {
-    teams_not_parsed: "Could not parse teams",
-    team1_not_found: "Team 1 not found",
-    team2_not_found: "Team 2 not found",
-    both_teams_not_found: "Neither team found",
-    no_common_league: "No common league",
-    fixture_not_in_league: "Teams don't play in this league",
-    no_league_detected: "No league detected",
-    ambiguous_league: "Ambiguous league",
-    no_event_found: "No event found",
-    no_event_card_match: "No event card match",
-    no_racing_match: "No racing match",
-    no_tennis_match: "No tennis match",
-    tennis_tournament_mismatch: "Different tournament",
-    tennis_matchup_unknown: "Tennis matchup not known",
-    no_epg_program_match: "No guide programme matched",
-    date_mismatch: "Date mismatch",
-    candidates_gated: "No candidate in window",
-    unmatched: "Unmatched",
-    "filtered:not_event": "Not an event",
-    "filtered:league_not_included": "League not enabled",
-    "filtered:include_regex": "Excluded by include pattern",
-    "filtered:exclude_regex": "Excluded by exclude pattern",
-    "filtered:stale": "Stale stream",
-    "skipped:unclassifiable": "Linear channel (no matchup)",
-    "skipped:name_match_disabled": "Stream Name matching off",
-    "skipped:team_streams_disabled": "Team matching off",
-  }
-  return labels[reason] || reason
 }
 
 function getMatchMethodBadge(method: string | null) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -79,3 +79,40 @@ export function getLeagueDisplayName(
   return league.name || league.slug || "Unknown"
 }
 
+/**
+ * Human label for a failure taxonomy code (#661/#662) as stored on
+ * `epg_failed_matches.reason`: a FailedReason value, or a `filtered:` /
+ * `skipped:` prefixed verdict. Shared by the run-history Failed drill-down and
+ * the source preview modal so one stream reads the same in both.
+ */
+export function getFailedReasonLabel(reason: string): string {
+  const labels: Record<string, string> = {
+    teams_not_parsed: "Could not parse teams",
+    team1_not_found: "Team 1 not found",
+    team2_not_found: "Team 2 not found",
+    both_teams_not_found: "Neither team found",
+    no_common_league: "No common league",
+    fixture_not_in_league: "Teams don't play in this league",
+    no_league_detected: "No league detected",
+    ambiguous_league: "Ambiguous league",
+    no_event_found: "No event found",
+    no_event_card_match: "No event card match",
+    no_racing_match: "No racing match",
+    no_tennis_match: "No tennis match",
+    tennis_tournament_mismatch: "Different tournament",
+    tennis_matchup_unknown: "Tennis matchup not known",
+    no_epg_program_match: "No guide programme matched",
+    date_mismatch: "Date mismatch",
+    candidates_gated: "No candidate in window",
+    unmatched: "Unmatched",
+    "filtered:not_event": "Not an event",
+    "filtered:league_not_included": "League not enabled",
+    "filtered:include_regex": "Excluded by include pattern",
+    "filtered:exclude_regex": "Excluded by exclude pattern",
+    "filtered:stale": "Stale stream",
+    "skipped:unclassifiable": "Linear channel (no matchup)",
+    "skipped:name_match_disabled": "Stream Name matching off",
+    "skipped:team_streams_disabled": "Team matching off",
+  }
+  return labels[reason] || reason
+}

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -952,7 +952,7 @@ export function EventGroups() {
 
       {/* Stream Preview Modal */}
       <Dialog open={showPreviewModal} onOpenChange={setShowPreviewModal}>
-        <DialogContent onClose={() => setShowPreviewModal(false)} className="max-w-4xl max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogContent onClose={() => setShowPreviewModal(false)} className="max-w-5xl max-h-[80vh] overflow-hidden flex flex-col">
           <DialogHeader>
             <DialogTitle>
               Stream Preview: {previewData?.group_name}
@@ -1024,11 +1024,66 @@ export function EventGroups() {
                           )}
                         </TableCell>
                         <TableCell className="font-mono text-xs">
-                          {stream.stream_name}
+                          <div className="break-all">{stream.stream_name}</div>
+                          {(stream.parsed_team1 ||
+                            stream.parsed_team2 ||
+                            stream.extracted_date ||
+                            stream.extracted_time ||
+                            stream.detected_league) && (
+                            <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-sans font-normal text-muted-foreground mt-1.5">
+                              <span className="text-muted-foreground/70 font-medium">Extracted:</span>
+                              {stream.parsed_team1 && (
+                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                  <span className="text-muted-foreground/60 font-medium">T1:</span>{" "}
+                                  <span className="text-foreground/90 font-mono text-[10.5px]">
+                                    {stream.parsed_team1}
+                                  </span>
+                                </span>
+                              )}
+                              {stream.parsed_team2 && (
+                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                  <span className="text-muted-foreground/60 font-medium">T2:</span>{" "}
+                                  <span className="text-foreground/90 font-mono text-[10.5px]">
+                                    {stream.parsed_team2}
+                                  </span>
+                                </span>
+                              )}
+                              {(stream.extracted_date || stream.extracted_time) && (
+                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                  <span className="text-muted-foreground/60 font-medium">When:</span>{" "}
+                                  <span className="text-foreground/90">
+                                    {[
+                                      stream.extracted_date,
+                                      stream.extracted_time,
+                                      stream.extracted_tz ? `(${stream.extracted_tz})` : null,
+                                    ]
+                                      .filter(Boolean)
+                                      .join(" ")}
+                                  </span>
+                                </span>
+                              )}
+                              {stream.detected_league && (
+                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                  <span className="text-muted-foreground/60 font-medium">Hint:</span>{" "}
+                                  <span className="text-foreground/90">
+                                    {getLeagueDisplay(stream.detected_league)}
+                                  </span>
+                                </span>
+                              )}
+                            </div>
+                          )}
                         </TableCell>
                         <TableCell>
                           {stream.league ? (
                             <Badge variant="secondary">{getLeagueDisplay(stream.league)}</Badge>
+                          ) : stream.detected_league ? (
+                            <Badge
+                              variant="outline"
+                              className="border-dashed text-muted-foreground text-xs"
+                              title="Detected league hint"
+                            >
+                              {getLeagueDisplay(stream.detected_league)}
+                            </Badge>
                           ) : (
                             <span className="text-muted-foreground">—</span>
                           )}

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -67,7 +67,7 @@ import {
 import { useDateFormat } from "@/hooks/useDateFormat"
 import { getLeagues } from "@/api/teams"
 import { BulkEditDialog } from "./event-groups/BulkEditDialog"
-import { getLeagueDisplayName } from "@/lib/utils"
+import { getFailedReasonLabel, getLeagueDisplayName } from "@/lib/utils"
 
 // Helper to get display name (prefer display_name over name)
 const getDisplayName = (group: EventGroup) => group.display_name || group.name
@@ -192,6 +192,19 @@ export function EventGroups() {
       return map.get(slug) ?? slug.toUpperCase()
     }
   }, [cachedLeagues])
+
+  // A detected league hint can name several leagues ("nba, wnba"), which is one
+  // string to the map and so would fall through to the raw slug. Resolve each.
+  const getLeagueHintDisplay = useMemo(
+    () => (hint: string | null | undefined) =>
+      !hint
+        ? "-"
+        : hint
+            .split(",")
+            .map((slug) => getLeagueDisplay(slug.trim()))
+            .join(", "),
+    [getLeagueDisplay]
+  )
 
   const handleDelete = async () => {
     if (!deleteConfirm) return
@@ -1025,53 +1038,45 @@ export function EventGroups() {
                         </TableCell>
                         <TableCell className="font-mono text-xs">
                           <div className="break-all">{stream.stream_name}</div>
-                          {(stream.parsed_team1 ||
-                            stream.parsed_team2 ||
-                            stream.extracted_date ||
-                            stream.extracted_time ||
-                            stream.detected_league) && (
-                            <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-sans font-normal text-muted-foreground mt-1.5">
-                              <span className="text-muted-foreground/70 font-medium">Extracted:</span>
-                              {stream.parsed_team1 && (
-                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
-                                  <span className="text-muted-foreground/60 font-medium">T1:</span>{" "}
-                                  <span className="text-foreground/90 font-mono text-[10.5px]">
-                                    {stream.parsed_team1}
+                          {!stream.matched &&
+                            (stream.parsed_team1 ||
+                              stream.parsed_team2 ||
+                              stream.extracted_date ||
+                              stream.extracted_time) && (
+                              <div className="flex flex-wrap items-center gap-1.5 text-[11px] font-sans font-normal text-muted-foreground mt-1.5">
+                                <span className="text-muted-foreground/70 font-medium">Extracted:</span>
+                                {stream.parsed_team1 && (
+                                  <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                    <span className="text-muted-foreground/60 font-medium">T1:</span>{" "}
+                                    <span className="text-foreground/90 font-mono text-[10.5px]">
+                                      {stream.parsed_team1}
+                                    </span>
                                   </span>
-                                </span>
-                              )}
-                              {stream.parsed_team2 && (
-                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
-                                  <span className="text-muted-foreground/60 font-medium">T2:</span>{" "}
-                                  <span className="text-foreground/90 font-mono text-[10.5px]">
-                                    {stream.parsed_team2}
+                                )}
+                                {stream.parsed_team2 && (
+                                  <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                    <span className="text-muted-foreground/60 font-medium">T2:</span>{" "}
+                                    <span className="text-foreground/90 font-mono text-[10.5px]">
+                                      {stream.parsed_team2}
+                                    </span>
                                   </span>
-                                </span>
-                              )}
-                              {(stream.extracted_date || stream.extracted_time) && (
-                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
-                                  <span className="text-muted-foreground/60 font-medium">When:</span>{" "}
-                                  <span className="text-foreground/90">
-                                    {[
-                                      stream.extracted_date,
-                                      stream.extracted_time,
-                                      stream.extracted_tz ? `(${stream.extracted_tz})` : null,
-                                    ]
-                                      .filter(Boolean)
-                                      .join(" ")}
+                                )}
+                                {(stream.extracted_date || stream.extracted_time) && (
+                                  <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
+                                    <span className="text-muted-foreground/60 font-medium">When:</span>{" "}
+                                    <span className="text-foreground/90">
+                                      {[
+                                        stream.extracted_date,
+                                        stream.extracted_time,
+                                        stream.extracted_tz ? `(${stream.extracted_tz})` : null,
+                                      ]
+                                        .filter(Boolean)
+                                        .join(" ")}
+                                    </span>
                                   </span>
-                                </span>
-                              )}
-                              {stream.detected_league && (
-                                <span className="bg-muted/70 px-1.5 py-0.5 rounded border border-border/40">
-                                  <span className="text-muted-foreground/60 font-medium">Hint:</span>{" "}
-                                  <span className="text-foreground/90">
-                                    {getLeagueDisplay(stream.detected_league)}
-                                  </span>
-                                </span>
-                              )}
-                            </div>
-                          )}
+                                )}
+                              </div>
+                            )}
                         </TableCell>
                         <TableCell>
                           {stream.league ? (
@@ -1082,7 +1087,7 @@ export function EventGroups() {
                               className="border-dashed text-muted-foreground text-xs"
                               title="Detected league hint"
                             >
-                              {getLeagueDisplay(stream.detected_league)}
+                              {getLeagueHintDisplay(stream.detected_league)}
                             </Badge>
                           ) : (
                             <span className="text-muted-foreground">—</span>
@@ -1098,12 +1103,19 @@ export function EventGroups() {
                                 </div>
                               )}
                             </div>
-                          ) : stream.exclusion_reason ? (
-                            <span className="text-muted-foreground text-xs">
-                              {stream.exclusion_reason}
-                            </span>
                           ) : (
-                            <span className="text-muted-foreground">No match</span>
+                            <div className="text-xs text-muted-foreground">
+                              <div>
+                                {getFailedReasonLabel(
+                                  stream.failed_reason || stream.exclusion_reason || "unmatched"
+                                )}
+                              </div>
+                              {stream.detail && (
+                                <div className="text-muted-foreground/70 mt-0.5 break-words">
+                                  {stream.detail}
+                                </div>
+                              )}
+                            </div>
                           )}
                         </TableCell>
                       </TableRow>

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -1907,6 +1907,12 @@ class PreviewStreamModel(BaseModel):
     start_time: str | None = None
     from_cache: bool = False
     exclusion_reason: str | None = None
+    parsed_team1: str | None = None
+    parsed_team2: str | None = None
+    detected_league: str | None = None
+    extracted_date: str | None = None
+    extracted_time: str | None = None
+    extracted_tz: str | None = None
 
 
 class PreviewGroupResponse(BaseModel):
@@ -1980,6 +1986,12 @@ def preview_group(group_id: int):
                 start_time=s.start_time,
                 from_cache=s.from_cache,
                 exclusion_reason=s.exclusion_reason,
+                parsed_team1=s.parsed_team1,
+                parsed_team2=s.parsed_team2,
+                detected_league=s.detected_league,
+                extracted_date=s.extracted_date,
+                extracted_time=s.extracted_time,
+                extracted_tz=s.extracted_tz,
             )
             for s in result.streams
         ],

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -1907,6 +1907,8 @@ class PreviewStreamModel(BaseModel):
     start_time: str | None = None
     from_cache: bool = False
     exclusion_reason: str | None = None
+    failed_reason: str | None = None
+    detail: str | None = None
     parsed_team1: str | None = None
     parsed_team2: str | None = None
     detected_league: str | None = None
@@ -1986,6 +1988,8 @@ def preview_group(group_id: int):
                 start_time=s.start_time,
                 from_cache=s.from_cache,
                 exclusion_reason=s.exclusion_reason,
+                failed_reason=s.failed_reason,
+                detail=s.detail,
                 parsed_team1=s.parsed_team1,
                 parsed_team2=s.parsed_team2,
                 detected_league=s.detected_league,

--- a/teamarr/consumers/event_group_processor/persistence.py
+++ b/teamarr/consumers/event_group_processor/persistence.py
@@ -3,7 +3,7 @@
 import logging
 from sqlite3 import Connection
 
-from teamarr.consumers.matching import BatchMatchResult
+from teamarr.consumers.matching import BatchMatchResult, MatchedStreamResult
 from teamarr.database.stats import (
     FailedMatch,
     MatchedStream,
@@ -17,6 +17,29 @@ logger = logging.getLogger(__name__)
 # Per-source skips that are not match failures (#662): the matcher never ran
 # for these, so they carry no FailedReason. Persisted under a "skipped:" prefix.
 _SKIP_REASONS = frozenset({"unclassifiable", "name_match_disabled", "team_streams_disabled"})
+
+
+def failure_reason_code(result: MatchedStreamResult) -> str:
+    """Name an unmatched stream's outcome honestly (#662).
+
+    Most rows that used to land here as the bare string "unmatched" were never
+    match failures: they were filter verdicts (not an event, league not
+    enabled, regex) or per-source skips (linear channel names, a matching type
+    switched off) that only reached the catch-all because it is the catch-all.
+    38% of one install's "failures" were these. They stay reported — an EPG-only
+    group still wants its linear channels listed — but under a prefix that says
+    what they are, so the failure taxonomy is only real failures.
+
+    Shared by run-history persistence and the preview modal so a stream reads
+    the same in both places.
+    """
+    if result.failed_reason:
+        return result.failed_reason.value
+    if result.filtered_reason:
+        return f"filtered:{result.filtered_reason.value}"
+    if result.exclusion_reason in _SKIP_REASONS:
+        return f"skipped:{result.exclusion_reason}"
+    return "unmatched"
 
 
 class MatchPersistence:
@@ -152,23 +175,7 @@ class MatchPersistence:
                 parsed_team2 = getattr(result, "parsed_team2", None)
                 detected_league = getattr(result, "detected_league", None)
 
-                # Name the outcome honestly (#662). Most rows that used to land
-                # here as the bare string "unmatched" were never match failures:
-                # they were filter verdicts (not an event, league not enabled,
-                # regex) or per-source skips (linear channel names, a matching
-                # type switched off) that only reached this branch because it
-                # is the catch-all. 38% of one install's "failures" were these.
-                # They stay persisted — an EPG-only group still wants its
-                # linear channels listed — but under a prefix that says what
-                # they are, so the failure taxonomy is only real failures.
-                if result.failed_reason:
-                    failed_reason = result.failed_reason.value
-                elif result.filtered_reason:
-                    failed_reason = f"filtered:{result.filtered_reason.value}"
-                elif result.exclusion_reason in _SKIP_REASONS:
-                    failed_reason = f"skipped:{result.exclusion_reason}"
-                else:
-                    failed_reason = "unmatched"
+                failed_reason = failure_reason_code(result)
 
                 failed_list.append(
                     FailedMatch(

--- a/teamarr/consumers/event_group_processor/preview.py
+++ b/teamarr/consumers/event_group_processor/preview.py
@@ -161,6 +161,12 @@ class PreviewBuilder:
                     ),
                     from_cache=getattr(r, "from_cache", False),
                     exclusion_reason=r.exclusion_reason,
+                    parsed_team1=getattr(r, "parsed_team1", None),
+                    parsed_team2=getattr(r, "parsed_team2", None),
+                    detected_league=getattr(r, "detected_league", None),
+                    extracted_date=getattr(r, "extracted_date", None),
+                    extracted_time=getattr(r, "extracted_time", None),
+                    extracted_tz=getattr(r, "extracted_tz", None),
                 )
                 result.streams.append(preview_stream)
 

--- a/teamarr/consumers/event_group_processor/preview.py
+++ b/teamarr/consumers/event_group_processor/preview.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from teamarr.database.groups import get_group
 from teamarr.utilities.sorting import natural_sort_key
 
+from .persistence import failure_reason_code
 from .results import PreviewResult, PreviewStream
 
 logger = logging.getLogger(__name__)
@@ -159,14 +160,16 @@ class PreviewBuilder:
                         if r.event and r.event.start_time
                         else None
                     ),
-                    from_cache=getattr(r, "from_cache", False),
+                    from_cache=r.from_cache,
                     exclusion_reason=r.exclusion_reason,
-                    parsed_team1=getattr(r, "parsed_team1", None),
-                    parsed_team2=getattr(r, "parsed_team2", None),
-                    detected_league=getattr(r, "detected_league", None),
-                    extracted_date=getattr(r, "extracted_date", None),
-                    extracted_time=getattr(r, "extracted_time", None),
-                    extracted_tz=getattr(r, "extracted_tz", None),
+                    failed_reason=None if r.matched else failure_reason_code(r),
+                    detail=r.detail,
+                    parsed_team1=r.parsed_team1,
+                    parsed_team2=r.parsed_team2,
+                    detected_league=r.detected_league,
+                    extracted_date=r.extracted_date,
+                    extracted_time=r.extracted_time,
+                    extracted_tz=r.extracted_tz,
                 )
                 result.streams.append(preview_stream)
 

--- a/teamarr/consumers/event_group_processor/results.py
+++ b/teamarr/consumers/event_group_processor/results.py
@@ -248,6 +248,10 @@ class PreviewStream:
     start_time: str | None = None
     from_cache: bool = False
     exclusion_reason: str | None = None
+    # The taxonomy code (#661/#662) and the evidence behind it, so preview
+    # reads the same as the run-history Failed drill-down.
+    failed_reason: str | None = None
+    detail: str | None = None
     parsed_team1: str | None = None
     parsed_team2: str | None = None
     detected_league: str | None = None
@@ -268,6 +272,8 @@ class PreviewStream:
             "start_time": self.start_time,
             "from_cache": self.from_cache,
             "exclusion_reason": self.exclusion_reason,
+            "failed_reason": self.failed_reason,
+            "detail": self.detail,
             "parsed_team1": self.parsed_team1,
             "parsed_team2": self.parsed_team2,
             "detected_league": self.detected_league,

--- a/teamarr/consumers/event_group_processor/results.py
+++ b/teamarr/consumers/event_group_processor/results.py
@@ -248,6 +248,12 @@ class PreviewStream:
     start_time: str | None = None
     from_cache: bool = False
     exclusion_reason: str | None = None
+    parsed_team1: str | None = None
+    parsed_team2: str | None = None
+    detected_league: str | None = None
+    extracted_date: str | None = None
+    extracted_time: str | None = None
+    extracted_tz: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -262,6 +268,12 @@ class PreviewStream:
             "start_time": self.start_time,
             "from_cache": self.from_cache,
             "exclusion_reason": self.exclusion_reason,
+            "parsed_team1": self.parsed_team1,
+            "parsed_team2": self.parsed_team2,
+            "detected_league": self.detected_league,
+            "extracted_date": self.extracted_date,
+            "extracted_time": self.extracted_time,
+            "extracted_tz": self.extracted_tz,
         }
 
 

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -27,6 +27,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from typing import TypedDict
 from zoneinfo import ZoneInfo
 
 from teamarr.config import get_user_timezone
@@ -100,7 +101,19 @@ class _PrefetchSlot:
     failed: bool = False
 
 
-def _extraction_fields(classified: ClassifiedStream) -> dict[str, str | None]:
+class _ExtractionFields(TypedDict):
+    """The fields _extraction_fields fills. A TypedDict, not a plain dict, so
+    pyright still checks the ** spread at each MatchedStreamResult call site."""
+
+    parsed_team1: str | None
+    parsed_team2: str | None
+    detected_league: str | None
+    extracted_date: str | None
+    extracted_time: str | None
+    extracted_tz: str | None
+
+
+def _extraction_fields(classified: ClassifiedStream) -> _ExtractionFields:
     """Classification metadata carried on every result for the preview modal.
 
     Built once here rather than at each construction site: the matcher has four

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -139,6 +139,9 @@ class MatchedStreamResult:
     parsed_team2: str | None = None
     detected_league: str | None = None
     card_segment: str | None = None  # For UFC: "early_prelims", "prelims", "main_card"
+    extracted_date: str | None = None
+    extracted_time: str | None = None
+    extracted_tz: str | None = None
 
     # Exception handling
     exception_keyword: str | None = None
@@ -746,6 +749,21 @@ class StreamMatcher:
             event_league_sport=event_league_sport,
         )
 
+        extracted_date_str = (
+            classified.normalized.extracted_date.isoformat()
+            if classified.normalized.extracted_date
+            else None
+        )
+        extracted_time_str = (
+            classified.normalized.extracted_time.strftime("%H:%M:%S")
+            if classified.normalized.extracted_time
+            else None
+        )
+        league_hint = classified.league_hint
+        detected_league_str = (
+            ", ".join(league_hint) if isinstance(league_hint, list) else league_hint
+        )
+
         # Step 2: Handle placeholders (streams that couldn't be classified)
         # Note: Placeholder pattern detection and unsupported sports filtering
         # is now handled by StreamFilter before streams reach the matcher.
@@ -769,6 +787,12 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="unclassifiable",
+                parsed_team1=classified.team1,
+                parsed_team2=classified.team2,
+                detected_league=detected_league_str,
+                extracted_date=extracted_date_str,
+                extracted_time=extracted_time_str,
+                extracted_tz=classified.normalized.extracted_tz,
             )]
 
         # Step 3: Gate TEAM_ONLY when disabled, then route by category.
@@ -788,6 +812,12 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="team_streams_disabled",
+                parsed_team1=classified.team1,
+                parsed_team2=classified.team2,
+                detected_league=detected_league_str,
+                extracted_date=extracted_date_str,
+                extracted_time=extracted_time_str,
+                extracted_tz=classified.normalized.extracted_tz,
             )]
 
         # Gate the name-identifies-event categories when Stream Name matching is
@@ -808,6 +838,12 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="name_match_disabled",
+                parsed_team1=classified.team1,
+                parsed_team2=classified.team2,
+                detected_league=detected_league_str,
+                extracted_date=extracted_date_str,
+                extracted_time=extracted_time_str,
+                extracted_tz=classified.normalized.extracted_tz,
             )]
 
         outcomes = self._route_to_outcomes(classified, stream_id, target_date)
@@ -1824,6 +1860,16 @@ class StreamMatcher:
         detected_league_str = (
             ", ".join(league_hint) if isinstance(league_hint, list) else league_hint
         )
+        extracted_date_str = (
+            classified.normalized.extracted_date.isoformat()
+            if classified.normalized.extracted_date
+            else None
+        )
+        extracted_time_str = (
+            classified.normalized.extracted_time.strftime("%H:%M:%S")
+            if classified.normalized.extracted_time
+            else None
+        )
 
         return MatchedStreamResult(
             stream_name=stream_name,
@@ -1842,6 +1888,9 @@ class StreamMatcher:
             parsed_team2=classified.team2,
             detected_league=detected_league_str,
             card_segment=classified.card_segment,  # UFC segment from stream name
+            extracted_date=extracted_date_str,
+            extracted_time=extracted_time_str,
+            extracted_tz=classified.normalized.extracted_tz,
             # Preserve detailed reason enums from MatchOutcome
             failed_reason=outcome.failed_reason,
             filtered_reason=outcome.filtered_reason,

--- a/teamarr/consumers/matching/matcher.py
+++ b/teamarr/consumers/matching/matcher.py
@@ -100,6 +100,32 @@ class _PrefetchSlot:
     failed: bool = False
 
 
+def _extraction_fields(classified: ClassifiedStream) -> dict[str, str | None]:
+    """Classification metadata carried on every result for the preview modal.
+
+    Built once here rather than at each construction site: the matcher has four
+    of them (three early-return gates plus _outcome_to_result), and #660 is the
+    standing lesson that near-identical copies in this file drift apart.
+    """
+    league_hint = classified.league_hint
+    normalized = classified.normalized
+    return {
+        "parsed_team1": classified.team1,
+        "parsed_team2": classified.team2,
+        # Multi-league hints are stored comma-separated.
+        "detected_league": (
+            ", ".join(league_hint) if isinstance(league_hint, list) else league_hint
+        ),
+        "extracted_date": (
+            normalized.extracted_date.isoformat() if normalized.extracted_date else None
+        ),
+        "extracted_time": (
+            normalized.extracted_time.strftime("%H:%M:%S") if normalized.extracted_time else None
+        ),
+        "extracted_tz": normalized.extracted_tz,
+    }
+
+
 @dataclass
 class MatchedStreamResult:
     """Result of matching a single stream.
@@ -749,21 +775,6 @@ class StreamMatcher:
             event_league_sport=event_league_sport,
         )
 
-        extracted_date_str = (
-            classified.normalized.extracted_date.isoformat()
-            if classified.normalized.extracted_date
-            else None
-        )
-        extracted_time_str = (
-            classified.normalized.extracted_time.strftime("%H:%M:%S")
-            if classified.normalized.extracted_time
-            else None
-        )
-        league_hint = classified.league_hint
-        detected_league_str = (
-            ", ".join(league_hint) if isinstance(league_hint, list) else league_hint
-        )
-
         # Step 2: Handle placeholders (streams that couldn't be classified)
         # Note: Placeholder pattern detection and unsupported sports filtering
         # is now handled by StreamFilter before streams reach the matcher.
@@ -787,12 +798,7 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="unclassifiable",
-                parsed_team1=classified.team1,
-                parsed_team2=classified.team2,
-                detected_league=detected_league_str,
-                extracted_date=extracted_date_str,
-                extracted_time=extracted_time_str,
-                extracted_tz=classified.normalized.extracted_tz,
+                **_extraction_fields(classified),
             )]
 
         # Step 3: Gate TEAM_ONLY when disabled, then route by category.
@@ -812,12 +818,7 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="team_streams_disabled",
-                parsed_team1=classified.team1,
-                parsed_team2=classified.team2,
-                detected_league=detected_league_str,
-                extracted_date=extracted_date_str,
-                extracted_time=extracted_time_str,
-                extracted_tz=classified.normalized.extracted_tz,
+                **_extraction_fields(classified),
             )]
 
         # Gate the name-identifies-event categories when Stream Name matching is
@@ -838,12 +839,7 @@ class StreamMatcher:
                 included=False,
                 category=StreamCategory.PLACEHOLDER,
                 exclusion_reason="name_match_disabled",
-                parsed_team1=classified.team1,
-                parsed_team2=classified.team2,
-                detected_league=detected_league_str,
-                extracted_date=extracted_date_str,
-                extracted_time=extracted_time_str,
-                extracted_tz=classified.normalized.extracted_tz,
+                **_extraction_fields(classified),
             )]
 
         outcomes = self._route_to_outcomes(classified, stream_id, target_date)
@@ -1855,22 +1851,6 @@ class StreamMatcher:
             reason = outcome.failed_reason.value if outcome.failed_reason else "failed"
             exclusion_reason = reason
 
-        # Convert list hint to comma-separated string for storage
-        league_hint = classified.league_hint
-        detected_league_str = (
-            ", ".join(league_hint) if isinstance(league_hint, list) else league_hint
-        )
-        extracted_date_str = (
-            classified.normalized.extracted_date.isoformat()
-            if classified.normalized.extracted_date
-            else None
-        )
-        extracted_time_str = (
-            classified.normalized.extracted_time.strftime("%H:%M:%S")
-            if classified.normalized.extracted_time
-            else None
-        )
-
         return MatchedStreamResult(
             stream_name=stream_name,
             stream_id=stream_id,
@@ -1884,13 +1864,8 @@ class StreamMatcher:
             from_cache=outcome.match_method == MatchMethod.CACHE if outcome.match_method else False,
             origin_match_method=outcome.origin_match_method,  # For cache hits
             category=classified.category,
-            parsed_team1=classified.team1,
-            parsed_team2=classified.team2,
-            detected_league=detected_league_str,
             card_segment=classified.card_segment,  # UFC segment from stream name
-            extracted_date=extracted_date_str,
-            extracted_time=extracted_time_str,
-            extracted_tz=classified.normalized.extracted_tz,
+            **_extraction_fields(classified),
             # Preserve detailed reason enums from MatchOutcome
             failed_reason=outcome.failed_reason,
             filtered_reason=outcome.filtered_reason,

--- a/tests/matching/test_preview_extracted_metadata.py
+++ b/tests/matching/test_preview_extracted_metadata.py
@@ -3,8 +3,10 @@
 from datetime import date
 from unittest.mock import MagicMock
 
+from teamarr.consumers.event_group_processor.persistence import failure_reason_code
 from teamarr.consumers.event_group_processor.results import PreviewStream
-from teamarr.consumers.matching.matcher import StreamMatcher
+from teamarr.consumers.matching.matcher import MatchedStreamResult, StreamMatcher
+from teamarr.consumers.matching.result import FailedReason, FilteredReason
 
 
 def test_preview_stream_carries_and_serializes_extracted_metadata():
@@ -60,9 +62,61 @@ def test_matcher_outcome_populates_extracted_metadata():
     assert len(results) >= 1
     r = results[0]
 
-    assert r.parsed_team1 == "US - NCAAF 17 : KENTUCKY CHRISTIAN"
+    # Pin what carries meaning, not the extraction noise: team1 still includes
+    # the provider prefix, and cleaning that up must not break a plumbing test.
+    assert "KENTUCKY CHRISTIAN" in (r.parsed_team1 or "")
     assert "MOREHEAD STATE" in (r.parsed_team2 or "")
     assert r.detected_league == "college-football"
     assert r.extracted_date == "2026-09-03"
     assert r.extracted_time == "18:00:00"
     assert r.extracted_tz == "America/New_York"
+
+
+def test_gated_streams_still_carry_extracted_metadata():
+    """A stream turned away by a matching-type gate is exactly the one a user
+    inspects in preview, so the early returns must carry metadata too."""
+    mock_db = MagicMock()
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchone.return_value = None
+    mock_conn.execute.return_value.fetchall.return_value = []
+    mock_db.return_value.__enter__.return_value = mock_conn
+
+    mock_service = MagicMock()
+    mock_service.get_provider_name.return_value = "espn"
+    mock_service.get_events.return_value = []
+
+    matcher = StreamMatcher(
+        service=mock_service,
+        db_factory=mock_db,
+        group_id=1,
+        search_leagues=["college-football"],
+        include_leagues=["college-football"],
+        name_match_enabled=False,
+    )
+
+    results = matcher._match_single(
+        stream_id=17,
+        stream_name="US - NCAAF 17 : KENTUCKY CHRISTIAN @ MOREHEAD STATE - SEP 3 - 6:00 PM ET",
+        target_date=date(2026, 9, 3),
+    )
+    r = results[0]
+
+    assert r.exclusion_reason == "name_match_disabled"
+    assert "MOREHEAD STATE" in (r.parsed_team2 or "")
+    assert r.detected_league == "college-football"
+    assert r.extracted_date == "2026-09-03"
+    assert r.extracted_time == "18:00:00"
+
+
+def test_failure_reason_code_matches_run_history_taxonomy():
+    """Preview and the run-history drill-down share one reason vocabulary."""
+
+    def code(**kwargs):
+        return failure_reason_code(
+            MatchedStreamResult(stream_name="s", stream_id=1, matched=False, **kwargs)
+        )
+
+    assert code(failed_reason=FailedReason.NO_EVENT_FOUND) == "no_event_found"
+    assert code(filtered_reason=FilteredReason.NOT_EVENT) == "filtered:not_event"
+    assert code(exclusion_reason="name_match_disabled") == "skipped:name_match_disabled"
+    assert code() == "unmatched"

--- a/tests/matching/test_preview_extracted_metadata.py
+++ b/tests/matching/test_preview_extracted_metadata.py
@@ -1,0 +1,68 @@
+"""Test that stream matcher and preview expose extracted classification metadata."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from teamarr.consumers.event_group_processor.results import PreviewStream
+from teamarr.consumers.matching.matcher import StreamMatcher
+
+
+def test_preview_stream_carries_and_serializes_extracted_metadata():
+    ps = PreviewStream(
+        stream_id=1,
+        stream_name="US - NCAAF 17 : KENTUCKY CHRISTIAN @ MOREHEAD STATE - SEP 3 - 6:00 PM ET",
+        matched=False,
+        exclusion_reason="no_event_found",
+        parsed_team1="US - NCAAF 17 : KENTUCKY CHRISTIAN",
+        parsed_team2="MOREHEAD STATE",
+        detected_league="college-football",
+        extracted_date="2026-09-03",
+        extracted_time="18:00:00",
+        extracted_tz="America/New_York",
+    )
+    d = ps.to_dict()
+    assert d["parsed_team1"] == "US - NCAAF 17 : KENTUCKY CHRISTIAN"
+    assert d["parsed_team2"] == "MOREHEAD STATE"
+    assert d["detected_league"] == "college-football"
+    assert d["extracted_date"] == "2026-09-03"
+    assert d["extracted_time"] == "18:00:00"
+    assert d["extracted_tz"] == "America/New_York"
+
+
+def test_matcher_outcome_populates_extracted_metadata():
+    stream_name = (
+        "US - NCAAF 17 : KENTUCKY CHRISTIAN @ MOREHEAD STATE - SEP 3 - 6:00 PM ET / 11:00 PM UK"
+    )
+
+    mock_db = MagicMock()
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchone.return_value = None
+    mock_conn.execute.return_value.fetchall.return_value = []
+    mock_db.return_value.__enter__.return_value = mock_conn
+
+    mock_service = MagicMock()
+    mock_service.get_provider_name.return_value = "espn"
+    mock_service.get_events.return_value = []
+
+    matcher = StreamMatcher(
+        service=mock_service,
+        db_factory=mock_db,
+        group_id=1,
+        search_leagues=["college-football"],
+        include_leagues=["college-football"],
+    )
+
+    results = matcher._match_single(
+        stream_id=17,
+        stream_name=stream_name,
+        target_date=date(2026, 9, 3),
+    )
+    assert len(results) >= 1
+    r = results[0]
+
+    assert r.parsed_team1 == "US - NCAAF 17 : KENTUCKY CHRISTIAN"
+    assert "MOREHEAD STATE" in (r.parsed_team2 or "")
+    assert r.detected_league == "college-football"
+    assert r.extracted_date == "2026-09-03"
+    assert r.extracted_time == "18:00:00"
+    assert r.extracted_tz == "America/New_York"


### PR DESCRIPTION
## Description

Resolves **teamarrv2-m2za**.

When inspecting streams in the **Stream Sources** table via the **Preview Stream Matches** modal (the magnifying glass view), unmatched streams only reported a bare `no_event_found` (or other exclusion code) and a dash `—` for the league. This left users guessing whether the failure was caused by team name extraction, date/time parsing, or league hints.

This PR exposes extracted stream metadata directly in the Preview pipeline and UI:
- **`MatchedStreamResult` & `PreviewStream`**: Carries `parsed_team1`, `parsed_team2`, `detected_league`, `extracted_date`, `extracted_time`, and `extracted_tz`.
- **Preview Modal UI**:
  - Displays structured extraction pills beneath each stream name (`T1`, `T2`, `When`, `Hint`).
  - Displays detected league hints as dashed badges in the League column when a stream is unmatched.
  - Widens modal to `max-w-5xl` for readable layout.

## Testing
- `npm run build` and `npm run lint` passed with 0 errors.
- `ruff check teamarr/ tests/` and `pyright teamarr/` passed with 0 errors.
- Full pytest suite: 2,770 passed.
- Added tests in `tests/matching/test_preview_extracted_metadata.py`.