### PR TITLE
feat(channels): {division} group wildcard for NCAA (FBS/FCS) (#717)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -898,3 +898,4 @@
 {"id":"int-99988cebba87b0315377641ade523df7","kind":"field_change","created_at":"2026-09-04T16:32:41.771333587Z","actor":"Luke Pukatch","issue_id":"teamarrv2-crvt","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-4175cd55eb44fbbab793007bb6cd15ee","kind":"field_change","created_at":"2026-09-04T21:33:31.304465788Z","actor":"luke","issue_id":"teamarrv2-dsz0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-e34fcc620413ad067c31d6bdf0020677","kind":"field_change","created_at":"2026-09-04T21:45:39.092743772Z","actor":"luke","issue_id":"teamarrv2-dsz0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-ad7a489d239f450d0f1df34944bd45c9","kind":"field_change","created_at":"2026-09-05T19:56:54.629068772Z","actor":"luke","issue_id":"teamarrv2-yuo7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/guide/channels/output.md
+++ b/docs/guide/channels/output.md
@@ -39,11 +39,14 @@ Pick a static group from the dropdown. By default the list hides M3U-sourced gro
 | **Static** | All channels go to the selected group above |
 | **Dynamic by Sport** | Auto-creates and assigns groups named by sport |
 | **Dynamic by League** | Auto-creates and assigns groups named by league |
-| **Custom pattern** | Define a pattern using `{sport}`, `{league}`, and `{conference}` placeholders |
+| **Custom pattern** | Define a pattern using `{sport}`, `{league}`, `{conference}`, and `{division}` placeholders |
 
 When **Custom pattern** is selected, a pattern field appears. For example, `{sport} | {league}` creates groups like "Hockey | NHL". Teamarr creates these dynamic groups in Dispatcharr automatically.
 
-In group patterns, `{sport}` resolves to the sport's display name ("Hockey"), and `{league}` to the league's **short alias** — "EPL", not "English Premier League". `{conference}` resolves to the home team's conference name for NCAA football/basketball events ("Southeastern Conference"); events without conference data fall back to the static group.
+In group patterns, `{sport}` resolves to the sport's display name ("Hockey"), and `{league}` to the league's **short alias** — "EPL", not "English Premier League". `{conference}` resolves to the home team's conference name for NCAA football/basketball events ("Southeastern Conference"), and `{division}` to that conference's division — **FBS** or **FCS** for college football, **Division I** for college basketball. Events without conference data fall back to the static group.
+
+{: .note }
+`{division}` is the light-touch way to tame a college football Saturday: `{league} | {division}` splits ~80 games into "NCAAF | FBS" and "NCAAF | FCS" without the 25 groups `{conference}` produces. Both wildcards bucket on the **home** team, so an FBS-vs-FCS game lands in FBS — which is where you want it, since the FCS side is the visitor in those matchups. `{division}` needs a conference-tree refresh (Settings → Cache → Refresh) before it resolves; until then those events fall back to the static group.
 
 A few failure modes are handled gracefully: a pattern whose wildcard can't resolve for an event falls back to the static group; and if a configured static group has been deleted in Dispatcharr, the channels are created **ungrouped** with a log warning telling you to re-select a group.
 

--- a/docs/guide/dispatcharr-integration.md
+++ b/docs/guide/dispatcharr-integration.md
@@ -37,7 +37,7 @@ Go to **Channels → Dispatcharr Output** to configure where Teamarr channels la
 
 - **Default Channel Profiles** — which Dispatcharr profiles Teamarr channels appear in
 - **Default Stream Profile** — which stream profile to assign to streams
-- **Default Channel Group** — a static group, or a dynamic pattern like `{sport} | {league}` that auto-creates groups (`{conference}` also available for NCAA leagues)
+- **Default Channel Group** — a static group, or a dynamic pattern like `{sport} | {league}` that auto-creates groups (`{conference}` and `{division}` also available for NCAA leagues)
 
 ![Channels → Dispatcharr Output configuration cards](../assets/images/channels-output.png)
 
@@ -56,7 +56,7 @@ Once connected, each generation run manages the full channel lifecycle in Dispat
 
 ### Profile & Group Sync
 
-Teamarr enforces profile and group assignments on every generation run. If someone manually changes a channel's profiles in Dispatcharr, Teamarr corrects it on the next run. Dynamic wildcards (`{sport}`, `{league}`, and `{conference}` for groups) automatically create profiles and groups in Dispatcharr if they don't exist.
+Teamarr enforces profile and group assignments on every generation run. If someone manually changes a channel's profiles in Dispatcharr, Teamarr corrects it on the next run. Dynamic wildcards (`{sport}`, `{league}`, `{conference}`, and `{division}` for groups) automatically create profiles and groups in Dispatcharr if they don't exist.
 
 ### Reconciliation
 

--- a/frontend/src/components/DispatcharrOutputSettings.tsx
+++ b/frontend/src/components/DispatcharrOutputSettings.tsx
@@ -263,8 +263,8 @@ export function DispatcharrOutputSettings() {
             </Select>
             <p className="text-xs text-muted-foreground">
               Static uses the group above. Dynamic modes auto-create groups named by sport or league.
-              Custom lets you define a pattern with {"{sport}"}, {"{league}"}, and {"{conference}"}{" "}
-              (NCAA) placeholders.
+              Custom lets you define a pattern with {"{sport}"}, {"{league}"}, {"{conference}"}, and{" "}
+              {"{division}"} (NCAA) placeholders.
             </p>
           </div>
 
@@ -281,8 +281,10 @@ export function DispatcharrOutputSettings() {
                 className="w-64"
               />
               <p className="text-xs text-muted-foreground">
-                Use {"{sport}"}, {"{league}"}, and {"{conference}"} (NCAA leagues) as placeholders.
-                Example: "{"{sport}"} | {"{league}"}" creates groups like "Hockey | NHL".
+                Use {"{sport}"}, {"{league}"}, {"{conference}"}, and {"{division}"} (the last two
+                NCAA only) as placeholders. Example: "{"{sport}"} | {"{league}"}" creates groups like
+                "Hockey | NHL"; "{"{league}"} | {"{division}"}" splits college football into
+                "NCAAF | FBS" and "NCAAF | FCS".
               </p>
             </div>
           )}

--- a/frontend/src/components/PerLeagueChannelConfig.tsx
+++ b/frontend/src/components/PerLeagueChannelConfig.tsx
@@ -255,12 +255,19 @@ function LeagueConfigRow({
                   <option value="custom">Custom pattern</option>
                 </Select>
                 {localGroupMode && !["static", "sport", "league"].includes(localGroupMode) && (
-                  <Input
-                    value={localGroupMode}
-                    onChange={(e) => setLocalGroupMode(e.target.value)}
-                    placeholder="{sport} | {league}"
-                    className="w-64 mt-2"
-                  />
+                  <>
+                    <Input
+                      value={localGroupMode}
+                      onChange={(e) => setLocalGroupMode(e.target.value)}
+                      placeholder="{sport} | {league}"
+                      className="w-64 mt-2"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {"{sport}"}, {"{league}"}, plus {"{conference}"} and {"{division}"} for NCAA
+                      leagues — "{"{league}"} | {"{division}"}" splits college football into
+                      "NCAAF | FBS" and "NCAAF | FCS".
+                    </p>
+                  </>
                 )}
               </div>
 

--- a/teamarr/consumers/cache/refresh.py
+++ b/teamarr/consumers/cache/refresh.py
@@ -276,6 +276,11 @@ class CacheRefresher:
         Children and teams arrive as $ref links; group ids and team ids are
         parsed from the ref URLs (teams need no follow-up fetch — ids join
         against team_cache.provider_team_id).
+
+        Each conference is tagged with its root group, which IS the division
+        ESPN names 'FBS'/'FCS' (football) or 'NCAA Division I' (basketball) —
+        one extra fetch per root, and the source of the {division} wildcard
+        (#717).
         """
 
         def _ref_tail_id(ref: str, segment: str) -> str | None:
@@ -287,6 +292,10 @@ class CacheRefresher:
 
         groups: list[dict] = []
         for root_id in root_group_ids:
+            root_meta = client.get_season_group(sport, espn_league, season, root_id) or {}
+            # shortName is the compact division label ('Division I' vs the
+            # full 'NCAA Division I'); football names both the same.
+            root_name = root_meta.get("shortName") or root_meta.get("name")
             children = client.get_season_group_children(sport, espn_league, season, root_id)
             for item in (children or {}).get("items", []):
                 group_id = _ref_tail_id(item.get("$ref", ""), "groups")
@@ -310,6 +319,8 @@ class CacheRefresher:
                         # shortName is the display abbrev ('SEC'); the
                         # 'abbreviation' field is lowercase ('sec')
                         "abbrev": meta.get("shortName") or meta.get("abbreviation"),
+                        "parent_key": root_id,
+                        "parent_name": root_name,
                         "team_ids": team_ids,
                     }
                 )

--- a/teamarr/consumers/lifecycle/dynamic_resolver.py
+++ b/teamarr/consumers/lifecycle/dynamic_resolver.py
@@ -1,6 +1,7 @@
 """Dynamic channel group and profile resolver.
 
-Resolves {sport} and {league} wildcards to actual Dispatcharr group/profile IDs.
+Resolves {sport}, {league}, {conference} and {division} wildcards to actual
+Dispatcharr group/profile IDs.
 Auto-creates groups/profiles in Dispatcharr if they don't exist.
 """
 
@@ -32,8 +33,8 @@ class DynamicResolver:
     _groups_by_name: dict[str, int] = field(default_factory=dict)
     _profiles_by_name: dict[str, int] = field(default_factory=dict)
     _sport_display_names: dict[str, str] = field(default_factory=dict)
-    # (provider, league, team_id) -> conference name or None (#91)
-    _conference_by_team: dict = field(default_factory=dict)
+    # (provider, league, team_id) -> provider group dict or None (#91)
+    _group_by_team: dict = field(default_factory=dict)
     _league_display_names: dict[str, str] = field(default_factory=dict)
     _league_aliases: dict[str, str] = field(default_factory=dict)
     # Resolutions already announced at INFO. Group resolution is answered from
@@ -49,6 +50,10 @@ class DynamicResolver:
     _known_group_ids: set[int] = field(default_factory=set)
     _groups_loaded: bool = False
     _initialized: bool = False
+    # Warn once when {division} is used against a conference tree cached
+    # before #717 (parent_name NULL) — otherwise every event silently falls
+    # back to the static group with no hint that a cache refresh fixes it.
+    _warned_missing_division: bool = False
 
     def initialize(
         self,
@@ -175,13 +180,15 @@ class DynamicResolver:
         self._ensure_initialized()
         return self._league_aliases.get(league_code, league_code.upper())
 
-    def get_event_conference(self, event: Any) -> str | None:
-        """Conference name for an event's home team, from provider_group_cache (#91).
+    def _get_event_group(self, event: Any) -> dict | None:
+        """The home team's cached provider group (conference), or None.
 
         NCAA-only today (the cache holds only leagues with ESPN conference
-        trees). The HOME team's conference buckets the event — deterministic,
-        and correct for conference games; non-conference games land in the
-        host's conference, which is how venues bucket them too.
+        trees). The HOME team buckets the event — deterministic, and correct
+        for conference games; non-conference games land in the host's
+        conference, which is how venues bucket them too. Cross-division games
+        follow the same rule, and land where you'd want them: in an
+        FBS-vs-FCS game the FCS side is the visitor.
         """
         home_team = getattr(event, "home_team", None)
         league = getattr(event, "league", None)
@@ -190,18 +197,44 @@ class DynamicResolver:
             return None
         provider = getattr(event, "provider", "espn")
         key = (provider, league, team_id)
-        if key not in self._conference_by_team:
-            name = None
+        if key not in self._group_by_team:
+            group = None
             if self._db_conn is not None:
                 try:
                     from teamarr.database.provider_groups import get_team_group
 
                     group = get_team_group(self._db_conn, provider, league, team_id)
-                    name = group["name"] if group else None
                 except Exception as e:
                     logger.debug("[RESOLVER] Conference lookup failed for %s: %s", key, e)
-            self._conference_by_team[key] = name
-        return self._conference_by_team[key]
+            self._group_by_team[key] = group
+        return self._group_by_team[key]
+
+    def get_event_conference(self, event: Any) -> str | None:
+        """Conference name for an event's home team (#91)."""
+        group = self._get_event_group(event)
+        return group["name"] if group else None
+
+    def get_event_division(self, event: Any) -> str | None:
+        """Division for an event's home team — the conference's parent (#717).
+
+        'FBS'/'FCS' for college football, 'Division I' for college basketball.
+        None until the conference tree has been re-cached with parent data
+        (pre-#717 rows), so the pattern falls back to the static group rather
+        than inventing a bucket.
+        """
+        group = self._get_event_group(event)
+        if not group:
+            return None
+        division = group.get("division")
+        if not division and not self._warned_missing_division:
+            self._warned_missing_division = True
+            logger.warning(
+                "[RESOLVER] {division} pattern used but the cached conference tree "
+                "has no division data (cached before this feature existed) — "
+                "channels fall back to the static group. Refresh the team cache "
+                "to populate it."
+            )
+        return division or None
 
     def resolve_pattern(
         self,
@@ -209,6 +242,7 @@ class DynamicResolver:
         event_sport: str | None,
         event_league: str | None,
         conference: str | None = None,
+        division: str | None = None,
     ) -> str:
         """Interpolate pattern with event data.
 
@@ -217,6 +251,7 @@ class DynamicResolver:
             event_sport: Event's sport code (e.g., 'soccer', 'mma')
             event_league: Event's league code (e.g., 'eng.1', 'nfl')
             conference: Conference name for the {conference} wildcard (#91)
+            division: Division name for the {division} wildcard (#717)
 
         Returns:
             Resolved string with wildcards replaced by display names
@@ -233,6 +268,9 @@ class DynamicResolver:
 
         if conference and "{conference}" in result:
             result = result.replace("{conference}", conference)
+
+        if division and "{division}" in result:
+            result = result.replace("{division}", division)
 
         return result
 
@@ -353,12 +391,14 @@ class DynamicResolver:
         """Resolve channel group ID based on mode.
 
         Args:
-            mode: 'static' or pattern string containing {sport}/{league}/{conference}
+            mode: 'static' or pattern string containing
+                {sport}/{league}/{conference}/{division}
             static_group_id: Group ID to use for 'static' mode
             event_sport: Event's sport code
             event_league: Event's league code
-            event: The event itself — needed only for the {conference}
-                wildcard (#91), which resolves from the home team
+            event: The event itself — needed only for the {conference} (#91)
+                and {division} (#717) wildcards, which resolve from the
+                home team
 
         Returns:
             Resolved group ID or None
@@ -395,19 +435,23 @@ class DynamicResolver:
             )
             return group_id
 
-        # Pattern mode: resolve {sport}/{league}/{conference} wildcards
+        # Pattern mode: resolve {sport}/{league}/{conference}/{division} wildcards
         if "{" in mode:
             conference = (
                 self.get_event_conference(event) if "{conference}" in mode else None
             )
-            resolved_name = self.resolve_pattern(mode, event_sport, event_league, conference)
+            division = self.get_event_division(event) if "{division}" in mode else None
+            resolved_name = self.resolve_pattern(
+                mode, event_sport, event_league, conference, division
+            )
 
             # Check if any wildcards remain unresolved (a non-NCAA event under
-            # a {conference} pattern falls back to the static group)
+            # a {conference}/{division} pattern falls back to the static group)
             if (
                 "{sport}" in resolved_name
                 or "{league}" in resolved_name
                 or "{conference}" in resolved_name
+                or "{division}" in resolved_name
             ):
                 logger.warning(
                     "[RESOLVER] Pattern has unresolved wildcards: %s -> %s (sport=%s, league=%s)",

--- a/teamarr/database/provider_groups.py
+++ b/teamarr/database/provider_groups.py
@@ -23,7 +23,9 @@ def save_provider_groups(
     """Replace a league's cached groups with a fresh tree snapshot.
 
     Args:
-        groups: [{"key", "name", "abbrev", "team_ids": [...]}, ...]
+        groups: [{"key", "name", "abbrev", "parent_key", "parent_name",
+            "team_ids": [...]}, ...] — parent_* is the division the conference
+            sits under and may be absent (#717).
 
     Returns:
         Number of groups saved.
@@ -40,9 +42,19 @@ def save_provider_groups(
     for group in groups:
         cursor = conn.execute(
             """INSERT INTO provider_group_cache
-               (provider, league, group_key, group_name, group_abbrev, season)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (provider, league, group["key"], group["name"], group.get("abbrev"), season),
+               (provider, league, group_key, group_name, group_abbrev,
+                parent_key, parent_name, season)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                provider,
+                league,
+                group["key"],
+                group["name"],
+                group.get("abbrev"),
+                group.get("parent_key"),
+                group.get("parent_name"),
+                season,
+            ),
         )
         group_cache_id = cursor.lastrowid
         conn.executemany(
@@ -60,7 +72,8 @@ def get_league_groups(conn: Connection, league: str) -> list[dict]:
     Returns [] for leagues with no cached tree (the UI hides the filter).
     """
     rows = conn.execute(
-        """SELECT g.id, g.group_key, g.group_name, g.group_abbrev, g.season
+        """SELECT g.id, g.group_key, g.group_name, g.group_abbrev,
+                  g.parent_name, g.season
            FROM provider_group_cache g
            WHERE g.league = ?
            ORDER BY g.group_name""",
@@ -77,6 +90,7 @@ def get_league_groups(conn: Connection, league: str) -> list[dict]:
                 "key": row["group_key"],
                 "name": row["group_name"],
                 "abbrev": row["group_abbrev"],
+                "division": row["parent_name"],
                 "season": row["season"],
                 "team_ids": [m["provider_team_id"] for m in member_rows],
                 "team_count": len(member_rows),
@@ -88,9 +102,13 @@ def get_league_groups(conn: Connection, league: str) -> list[dict]:
 def get_team_group(
     conn: Connection, provider: str, league: str, provider_team_id: str
 ) -> dict | None:
-    """The group (conference) a team belongs to in a league, or None."""
+    """The group (conference) a team belongs to in a league, or None.
+
+    ``division`` is the parent group's name ('FBS', 'FCS', 'NCAA Division I')
+    and is None for trees cached before #717 — callers fall back.
+    """
     row = conn.execute(
-        """SELECT g.group_name, g.group_abbrev
+        """SELECT g.group_name, g.group_abbrev, g.parent_name
            FROM provider_group_cache g
            JOIN provider_group_members m ON m.group_cache_id = g.id
            WHERE g.provider = ? AND g.league = ? AND m.provider_team_id = ?""",
@@ -98,4 +116,8 @@ def get_team_group(
     ).fetchone()
     if row is None:
         return None
-    return {"name": row["group_name"], "abbrev": row["group_abbrev"]}
+    return {
+        "name": row["group_name"],
+        "abbrev": row["group_abbrev"],
+        "division": row["parent_name"],
+    }

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -1496,6 +1496,11 @@ CREATE TABLE IF NOT EXISTS provider_group_cache (
     group_key TEXT NOT NULL,              -- provider's stable group id (SEC=8, Big Ten=5, ...)
     group_name TEXT NOT NULL,             -- 'Southeastern Conference'
     group_abbrev TEXT,                    -- 'SEC' (core tree shortName)
+    -- Parent group in the provider's season tree: the division the conference
+    -- sits under (football 80/81 = FBS/FCS, basketball 50 = NCAA Division I).
+    -- Powers the {division} channel-group wildcard (#717).
+    parent_key TEXT,                      -- '80'
+    parent_name TEXT,                     -- 'FBS'
     season INTEGER,                       -- season year the tree was read from
     last_refreshed TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 

--- a/tests/test_provider_groups.py
+++ b/tests/test_provider_groups.py
@@ -1,7 +1,8 @@
 """Provider group (conference) cache — #91, epic y5l8.
 
 Covers the DB round-trip, the core-tree walk with $ref parsing, the
-conferences API endpoint, and the dynamic-resolver {conference} wildcard.
+conferences API endpoint, and the dynamic-resolver {conference} and
+{division} (#717) wildcards.
 """
 
 from unittest.mock import MagicMock
@@ -16,8 +17,24 @@ from teamarr.database.provider_groups import (
 
 CFB = "college-football"
 
-SEC = {"key": "8", "name": "Southeastern Conference", "abbrev": "SEC", "team_ids": ["2", "57"]}
-B1G = {"key": "5", "name": "Big Ten Conference", "abbrev": "Big Ten", "team_ids": ["130"]}
+SEC = {
+    "key": "8",
+    "name": "Southeastern Conference",
+    "abbrev": "SEC",
+    "parent_key": "80",
+    "parent_name": "FBS",
+    "team_ids": ["2", "57"],
+}
+B1G = {
+    "key": "5",
+    "name": "Big Ten Conference",
+    "abbrev": "Big Ten",
+    "parent_key": "80",
+    "parent_name": "FBS",
+    "team_ids": ["130"],
+}
+# A tree cached before #717 carries no parent — {division} must stay silent
+MVFC = {"key": "21", "name": "Missouri Valley Football Conference", "team_ids": ["2"]}
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +71,7 @@ def test_team_group_lookup(db_conn):
     assert get_team_group(db_conn, "espn", CFB, "2") == {
         "name": "Southeastern Conference",
         "abbrev": "SEC",
+        "division": "FBS",
     }
     assert get_team_group(db_conn, "espn", CFB, "9999") is None
     assert get_team_group(db_conn, "espn", "mens-college-basketball", "2") is None
@@ -80,6 +98,8 @@ def _fake_client():
     }
 
     def group_meta(sport, league, season, group_id):
+        if group_id == "80":
+            return {"id": "80", "name": "FBS", "shortName": "FBS", "isConference": False}
         if group_id == "8":
             return {
                 "id": "8",
@@ -108,6 +128,9 @@ def test_fetch_tree_parses_refs_and_skips_non_conferences():
     assert groups[0]["key"] == "8"
     assert groups[0]["abbrev"] == "SEC"  # shortName preferred over lowercase abbreviation
     assert groups[0]["team_ids"] == ["2", "57"]
+    # Root group tagged onto every child — the {division} source (#717)
+    assert groups[0]["parent_key"] == "80"
+    assert groups[0]["parent_name"] == "FBS"
 
 
 def test_fetch_tree_empty_children_yields_no_groups():
@@ -176,3 +199,114 @@ def test_event_conference_from_home_team(db_conn):
     # Unknown team / non-NCAA league resolves to None (pattern falls back)
     assert resolver.get_event_conference(_cfb_event("9999")) is None
     assert resolver.get_event_conference(None) is None
+
+
+def test_save_and_read_division(db_conn):
+    save_provider_groups(db_conn, "espn", CFB, 2026, [SEC])
+    assert get_league_groups(db_conn, CFB)[0]["division"] == "FBS"
+
+
+def test_division_absent_for_pre_717_rows(db_conn):
+    save_provider_groups(db_conn, "espn", CFB, 2026, [MVFC])
+    assert get_team_group(db_conn, "espn", CFB, "2")["division"] is None
+
+
+def test_fetch_tree_survives_missing_root_meta():
+    """A root fetch that fails leaves parent_name unset, not the walk broken."""
+    client = _fake_client()
+
+    def group_meta(sport, league, season, group_id):
+        if group_id == "80":
+            return None
+        if group_id == "8":
+            return {
+                "id": "8",
+                "name": "Southeastern Conference",
+                "shortName": "SEC",
+                "isConference": True,
+            }
+        return {"id": "99", "isConference": False}
+
+    client.get_season_group.side_effect = group_meta
+    groups = CacheRefresher._fetch_conference_tree(
+        client, "football", "college-football", 2026, ("80",)
+    )
+    assert len(groups) == 1
+    assert groups[0]["parent_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# {division} wildcard (#717)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_pattern_replaces_division():
+    resolver = DynamicResolver()
+    resolver._initialized = True
+    resolver._league_aliases = {CFB: "NCAAF"}
+    assert (
+        resolver.resolve_pattern("{league} | {division}", "football", CFB, None, "FBS")
+        == "NCAAF | FBS"
+    )
+
+
+def test_event_division_from_home_team(db_conn):
+    resolver = _resolver_with_cache(db_conn)
+    assert resolver.get_event_division(_cfb_event("2")) == "FBS"
+    assert resolver.get_event_division(_cfb_event("9999")) is None
+    assert resolver.get_event_division(None) is None
+
+
+def test_event_division_none_without_parent_data(db_conn):
+    """Pre-#717 cache rows defer to the static group rather than invent one."""
+    save_provider_groups(db_conn, "espn", CFB, 2026, [MVFC])
+    resolver = DynamicResolver()
+    resolver._db_conn = db_conn
+    event = _cfb_event("2")
+    assert resolver.get_event_conference(event) == "Missouri Valley Football Conference"
+    assert resolver.get_event_division(event) is None
+
+
+def test_home_team_group_cached_once(db_conn):
+    """Conference and division share one lookup per team."""
+    resolver = _resolver_with_cache(db_conn)
+    event = _cfb_event("2")
+    resolver.get_event_conference(event)
+    resolver.get_event_division(event)
+    assert len(resolver._group_by_team) == 1
+
+
+def test_resolve_channel_group_falls_back_when_division_unknown(db_conn):
+    """An NFL event under a {division} pattern lands in the static group."""
+    resolver = _resolver_with_cache(db_conn)
+    resolver._initialized = True
+    resolver._groups_loaded = True
+    resolver._known_group_ids = {7}
+    resolver._league_aliases = {CFB: "NCAAF", "nfl": "NFL"}
+    resolver._get_or_create_group = MagicMock(return_value=42)
+
+    nfl_event = _cfb_event("2")
+    nfl_event.league = "nfl"
+    assert (
+        resolver.resolve_channel_group(
+            mode="{league} | {division}",
+            static_group_id=7,
+            event_sport="football",
+            event_league="nfl",
+            event=nfl_event,
+        )
+        == 7
+    )
+
+    cfb_event = _cfb_event("2")
+    assert (
+        resolver.resolve_channel_group(
+            mode="{league} | {division}",
+            static_group_id=7,
+            event_sport="football",
+            event_league=CFB,
+            event=cfb_event,
+        )
+        == 42
+    )
+    resolver._get_or_create_group.assert_called_once_with("NCAAF | FBS")


### PR DESCRIPTION
Closes #717.

## What

Adds a `{division}` wildcard to dynamic channel-group patterns. It resolves the home team's conference to its ESPN **parent** group:

| League | `{division}` |
|---|---|
| `college-football` | FBS / FCS |
| `mens-` / `womens-college-basketball` | Division I |

`{league} | {division}` turns a ~80-game college football Saturday into "NCAAF | FBS" and "NCAAF | FCS" — two legible groups instead of one bucket, without the 25 groups `{conference}` produces.

## How

`_fetch_conference_tree` already iterated roots `("80", "81")` and threw the parent away. It now reads each root's meta once per root and tags every child conference with it; `provider_group_cache` gains `parent_key` / `parent_name` (column addition — schema reconciliation handles the upgrade, verified against a copy of a real DB). `DynamicResolver` grows `get_event_division`, and conference + division now share one cached lookup per team.

No maintained mapping — ESPN names the root groups "FBS"/"FCS" itself. Power 4 / Group of 5 was considered and dropped: ESPN exposes no tier flag for football (checked the group payloads at both the conference and root levels), so it would need a hand-maintained list that realignment churns every year.

## Behavior notes

- Bucketing is on the **home** team, same as `{conference}`. In FBS-vs-FCS games the FCS side is the paid visitor, so those land in FBS.
- Trees cached before this change have `parent_name` NULL, so `{division}` defers to the static group (same fallback as an unresolvable `{conference}`) and logs one warning pointing at a cache refresh. Self-heals on the next weekly team-cache refresh.

## Testing

`tests/test_provider_groups.py` — parent persisted and read back, root tagging in the tree walk, a failed root fetch leaving the walk intact, pre-#717 rows resolving to None, the shared per-team cache, and pattern resolution incl. the NFL-falls-back-to-static case.

- `ruff check teamarr/ tests/` clean
- `pytest tests/ -v` — 2776 passed
- `cd frontend && npm run build` clean