### PR TITLE
fix(leagues): allow Gracenote overrides for discovered leagues (#709)

### DIFF
--- a/teamarr/services/league_overrides.py
+++ b/teamarr/services/league_overrides.py
@@ -96,9 +96,24 @@ def set_gracenote_override(league_code: str, value: str | None) -> dict:
 
 
 def _require_league(league_code: str) -> None:
+    """Accept any league the league picker can offer (#709).
+
+    The picker lists the UNION of configured leagues and discovered ones
+    (``league_cache``), so gating on the ``leagues`` table alone rejected
+    every discovered league — e.g. ``eng.5`` (English National League) —
+    with "Unknown league". The override read path already resolves those:
+    ``get_default_gracenote_category`` falls back to the league_cache name
+    and sport, so an override on a discovered league renders correctly.
+    """
     with get_db() as conn:
         row = conn.execute(
-            "SELECT 1 FROM leagues WHERE league_code = ?", (league_code,)
+            """
+            SELECT 1 FROM leagues WHERE league_code = ?
+            UNION ALL
+            SELECT 1 FROM league_cache WHERE league_slug = ?
+            LIMIT 1
+            """,
+            (league_code, league_code),
         ).fetchone()
     if row is None:
         raise LeagueNotFoundError(f"Unknown league: {league_code}")

--- a/tests/test_league_overrides.py
+++ b/tests/test_league_overrides.py
@@ -86,3 +86,30 @@ def test_list_overrides():
 def test_unknown_league_rejected():
     with pytest.raises(LeagueNotFoundError):
         set_gracenote_override("not-a-league", "X")
+
+
+def test_discovered_league_accepted(db_conn):
+    """#709: the league picker offers configured ∪ discovered leagues, so a
+    league_cache-only league (eng.5) must be overridable too — it used to
+    fail with "Unknown league"."""
+    db_conn.execute(
+        """
+        INSERT INTO league_cache (league_slug, provider, league_name, sport)
+        VALUES ('eng.5', 'espn', 'English National League', 'soccer')
+        """
+    )
+    db_conn.commit()
+    lm.get_league_mapping_service().reload()
+
+    # Derived default comes from the league_cache name + sport
+    state = get_gracenote_override_state("eng.5")
+    assert state["override"] is None
+    assert state["default"] == "English National League Soccer"
+
+    state = set_gracenote_override("eng.5", "National League Soccer")
+    assert state["override"] == "National League Soccer"
+    assert state["effective"] == "National League Soccer"
+    assert (
+        lm.get_league_mapping_service().get_gracenote_category("eng.5")
+        == "National League Soccer"
+    )


### PR DESCRIPTION
Fixes #709.

## Cause

Settings → Advanced → Gracenote Category Overrides uses `LeaguePicker`, which lists `GET /cache/leagues` — the **UNION** of configured leagues (`leagues` table) and discovered ones (`league_cache`). The write path's `_require_league` guard only checked the `leagues` table, so every discovered league was rejected with `Unknown league: <code>`.

On a seeded database that is **169 leagues** (all ESPN soccer competitions): `eng.5` (English National League, the reported one), `arg.2`, `afc.champions`, `caf.nations`, …

## Fix

`_require_league` now accepts a league present in either table. Nothing else had to change — the read path already resolved discovered leagues: `get_default_gracenote_category` falls back to the `league_cache` name and sport, so `eng.5` derives **"English National League Soccer"**, matching the curated shape for configured soccer leagues (`uefa.champions` → "UEFA Champions League Soccer").

## Tests

`test_discovered_league_accepted` seeds an `eng.5` row into `league_cache` and asserts both the derived default and a round-tripped override. Verified red before the fix / green after.

Gates: `ruff` clean · `pytest` 2777 passed · `npm run build` clean.

## Note — sibling bug, not in this PR

The same shape exists in **Pinned Blocks** (`PinnedBlocks.tsx` feeds the same union into the league dropdown, but `add_numbering_exception` resolves the pin's sport with `SELECT sport FROM leagues WHERE league_code = ?`). A league-scope pin on a discovered league logs `Unknown league 'arg.2' (no sport)` and returns `None`. Confirmed by direct repro; filed separately.