### PR TITLE
fix(numbering): resolve pinned-block league sport from league_cache too (#720)

### DIFF
--- a/teamarr/api/routes/numbering_exceptions.py
+++ b/teamarr/api/routes/numbering_exceptions.py
@@ -97,10 +97,20 @@ def _display_name(conn, exc) -> str:
     if exc.scope == "team":
         return exc.team_name or "?"
     if exc.scope == "league":
+        # Configured first, then discovered (#720) — a league_cache-only pin
+        # would otherwise render as its raw code ("arg.2").
         row = conn.execute(
-            "SELECT display_name FROM leagues WHERE league_code = ?", (exc.league_code,)
+            """
+            SELECT display_name FROM leagues
+            WHERE league_code = ? AND display_name IS NOT NULL
+            UNION ALL
+            SELECT league_name FROM league_cache
+            WHERE league_slug = ? AND league_name IS NOT NULL
+            LIMIT 1
+            """,
+            (exc.league_code, exc.league_code),
         ).fetchone()
-        return (row["display_name"] if row and row["display_name"] else exc.league_code) or "?"
+        return (row["display_name"] if row else exc.league_code) or "?"
     from teamarr.core.sports import get_sport_display_names_from_db
 
     names = get_sport_display_names_from_db(conn)

--- a/teamarr/database/numbering_exceptions.py
+++ b/teamarr/database/numbering_exceptions.py
@@ -229,7 +229,7 @@ def add_numbering_exception(
       entry); name + sport are resolved from ``team_cache`` so the match key
       stays canonical. ``team_league`` narrows the cache lookup.
     - ``scope='league'``: pass ``league_code`` (+ ``sport`` if known; resolved
-      from ``leagues`` otherwise).
+      from ``leagues``, then ``league_cache``, otherwise).
     - ``scope='sport'``: pass ``sport``.
 
     Returns the stored row, or ``None`` on validation / lookup failure.
@@ -271,8 +271,18 @@ def add_numbering_exception(
             return None
         league_code = league_code.lower()
         if not sport:
+            # The league dropdown offers configured leagues UNION discovered
+            # ones from league_cache (#720), so resolve the sport across both
+            # — gating on the leagues table alone rejected every discovered
+            # league with "Unknown league (no sport)".
             row = conn.execute(
-                "SELECT sport FROM leagues WHERE league_code = ?", (league_code,)
+                """
+                SELECT sport FROM leagues WHERE league_code = ?
+                UNION ALL
+                SELECT sport FROM league_cache WHERE league_slug = ?
+                LIMIT 1
+                """,
+                (league_code, league_code),
             ).fetchone()
             sport = row["sport"] if row else None
         if not sport:

--- a/tests/lifecycle/test_numbering_lanes.py
+++ b/tests/lifecycle/test_numbering_lanes.py
@@ -46,6 +46,9 @@ CREATE TABLE channel_sort_priorities (
   created_at TEXT, updated_at TEXT);
 CREATE TABLE channel_priority_teams (id INTEGER PRIMARY KEY, sport TEXT, team_name TEXT);
 CREATE TABLE leagues (league_code TEXT PRIMARY KEY, sport TEXT, display_name TEXT);
+CREATE TABLE league_cache (
+  league_slug TEXT, provider TEXT, league_name TEXT, sport TEXT NOT NULL,
+  PRIMARY KEY (league_slug, provider));
 CREATE TABLE team_cache (
   id INTEGER PRIMARY KEY, provider TEXT, provider_team_id TEXT, team_name TEXT,
   sport TEXT, league TEXT);
@@ -61,6 +64,8 @@ INSERT INTO settings (id) VALUES (1);
 INSERT INTO leagues VALUES ('nfl','football','NFL'),('nba','basketball','NBA'),
   ('nhl','hockey','NHL'),('mlb','baseball','MLB'),('ncaaf','football','NCAA Football'),
   ('fifa.world','soccer','FIFA World Cup');
+-- Discovered-only league (#720): offered by the picker, absent from `leagues`
+INSERT INTO league_cache VALUES ('arg.2','espn','Argentine Nacional B','soccer');
 INSERT INTO team_cache (provider, provider_team_id, team_name, sport, league) VALUES
   ('espn','8','Detroit Lions','football','nfl'),
   ('espn','9','Green Bay Packers','football','nfl'),
@@ -467,6 +472,27 @@ def test_add_league_pin_resolves_sport():
     exc = pin(c, "league", 500, league_code="NFL")
     assert (exc.league_code, exc.sport) == ("nfl", "football")
     assert ne.add_numbering_exception(c, scope="league", start=510, league_code="zzz") is None
+
+
+def test_add_league_pin_resolves_discovered_league_sport():
+    """#720: the dropdown offers configured ∪ discovered leagues, so a
+    league_cache-only league must pin too — it used to be rejected with
+    "Unknown league (no sport)"."""
+    c = build()
+    exc = pin(c, "league", 520, league_code="ARG.2")
+    assert (exc.league_code, exc.sport, exc.scope) == ("arg.2", "soccer", "league")
+
+
+def test_league_pin_display_name_spans_both_tables():
+    """The block list labels a pin by league name, configured or discovered
+    (#720) — a league_cache-only pin used to render as its raw code."""
+    from teamarr.api.routes.numbering_exceptions import _display_name
+
+    c = build()
+    assert _display_name(c, pin(c, "league", 500, league_code="nfl")) == "NFL"
+    assert _display_name(c, pin(c, "league", 520, league_code="arg.2")) == (
+        "Argentine Nacional B"
+    )
 
 
 @pytest.mark.parametrize("kw", [


### PR DESCRIPTION
Fixes #720. Sibling of #709 (PR #719) — same union gap, different feature.

## Cause

The Pinned Blocks **League** dropdown is fed by `getLeagues()` → `GET /cache/leagues`, the **UNION** of configured leagues (`leagues`) and discovered ones (`league_cache`). `PinnedBlocks.tsx` sends `sport: null` for league-scope pins, and `add_numbering_exception` resolved that sport with:

```sql
SELECT sport FROM leagues WHERE league_code = ?
```

A discovered league missed, so the pin was rejected:

```
[NUMBERING_EXC] Unknown league 'arg.2' (no sport)
```

Same 169 leagues #709 unblocked for Gracenote overrides — all ESPN soccer competitions (`arg.2`, `eng.5`, `afc.champions`, …).

## Fix

Two spots, both widened to span the tables the picker already unions:

- `add_numbering_exception` — sport resolution falls back to `league_cache.sport` (NOT NULL there, so a hit is always usable).
- `_display_name` in the route — a discovered pin rendered as its raw code (`arg.2`); it now shows `Argentine Nacional B`.

## Tests

`test_add_league_pin_resolves_discovered_league_sport` and `test_league_pin_display_name_spans_both_tables`; the lanes fixture gains a `league_cache` table with one discovered row. Verified red before the fix / green after.

Gates: `ruff` clean · `pytest` 2779 passed · `npm run build` clean.