### PR TITLE
fix(patterns): allow digits in builder-generated team names (#708)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -904,3 +904,4 @@
 {"id":"int-77043f00e9bb80077a91c0d97f0208cc","kind":"field_change","created_at":"2026-09-05T20:14:59.146843448Z","actor":"luke","issue_id":"teamarrv2-f7kp","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-6420abac42d1ad4dd2151e65c953ffa3","kind":"field_change","created_at":"2026-09-05T20:17:48.347748071Z","actor":"luke","issue_id":"teamarrv2-jtwo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-b8ac704cb610621f77b82ac07ff896c1","kind":"field_change","created_at":"2026-09-05T20:22:15.497534879Z","actor":"luke","issue_id":"teamarrv2-jtwo","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-00c5b6314bea8af3b87549e10c3fc8c5","kind":"field_change","created_at":"2026-09-05T20:29:56.358380161Z","actor":"luke","issue_id":"teamarrv2-v0sz","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/frontend/src/lib/pattern-generator.ts
+++ b/frontend/src/lib/pattern-generator.ts
@@ -37,8 +37,28 @@ export function escapeRegex(str: string): string {
 // accented team names — Atlético, Bayern München, Plzeň, São Paulo — are
 // captured, not just ASCII. Ranges: ASCII, Latin-1 letters (À-ÿ minus the ×/÷
 // math symbols), and Latin Extended-A (Ā-ž) for Czech/Polish/etc.
-const TEAM_CHARS = "A-Za-zÀ-ÖØ-öø-ÿĀ-ž"
-const TEAM_BODY = `[${TEAM_CHARS}][${TEAM_CHARS} .'-]+[${TEAM_CHARS}.]`
+const TEAM_LETTERS = "A-Za-zÀ-ÖØ-öø-ÿĀ-ž"
+
+// Team names also carry digits — "1. FC Köln", "Schalke 04", "1899 Hoffenheim"
+// (#708). Digits used to be excluded outright to keep a neighbouring date out of
+// the capture; instead the guards below fence off date-shaped tokens, so a
+// number that belongs to the club name is kept and one that belongs to a date
+// is not.
+const TEAM_CHARS = `0-9${TEAM_LETTERS}`
+
+// The head of a date-shaped token: 04-09-2026, 04/09, 2026-09-04, 09.04.2026.
+// Two components are enough to recognise one — the year, if any, follows.
+const DATE_TOKEN = "\\d{1,4}[-/.]\\d{1,2}"
+
+// A digit may open a team name only when it isn't already inside a date: the
+// lookbehind rejects a start in the middle of "04-09-2026" and the lookahead
+// rejects its leading digit. Letters open a name unconditionally, as before.
+const TEAM_START = `(?:[${TEAM_LETTERS}]|(?<![\\d/.-])(?!${DATE_TOKEN})\\d)`
+
+// The body stops before a whitespace-separated date token, so "Bayern 04-09-2026"
+// captures "Bayern" while "Schalke 04" stays whole.
+const TEAM_BODY =
+  `${TEAM_START}(?:(?!\\s+${DATE_TOKEN})[${TEAM_CHARS} .'-])+[${TEAM_CHARS}.]`
 
 /**
  * Attempt to generalize a literal selection into a broader pattern.
@@ -56,8 +76,8 @@ function generalizeForField(
     case "team2":
     case "fighter1":
     case "fighter2":
-      // Team / fighter names: letters (accent-inclusive), spaces, dots, hyphens,
-      // apostrophes (no digits — avoids grabbing dates)
+      // Team / fighter names: letters (accent-inclusive), digits, spaces, dots,
+      // hyphens, apostrophes — date-shaped runs are fenced out by TEAM_BODY
       return `(${TEAM_BODY})`
 
     case "event_name":


### PR DESCRIPTION
Closes #708.

## Problem

The interactive pattern builder generated a letters-only class for team and fighter names, so a source formatted `Next | Stuttgart vs. 1. FC Köln | all | 04-09-2026` produced a pattern that **did not match at all** — not merely a short capture. The generated separator is anchored (`\s*vs\.\s*`), so `team2` has to start exactly where the `1` is, and a digit was not a legal opening character.

Digits were originally excluded on purpose, to stop a greedy capture from swallowing a neighbouring date.

## Fix

Digits are allowed in the team body, with two guards that fence off date-shaped tokens instead of banning digits outright:

- **Opening a name:** a digit may start a capture only when it isn't already inside a date — a lookbehind rejects a start in the middle of `04-09-2026` and a lookahead rejects its leading digit. Letters open a name unconditionally, exactly as before.
- **Ending a name:** the body stops before a whitespace-separated date token.

## Verified

Generator run against a corpus, checking captures in both JS (browser highlighting) and Python `re` via `normalize_regex_syntax` (the real matcher path):

| Stream | team1 / team2 |
|---|---|
| `Next \| Stuttgart vs. 1. FC Köln \| all \| 04-09-2026` | `Stuttgart` / `1. FC Köln` |
| `Bayern München vs. Schalke 04` | `Bayern München` / `Schalke 04` |
| `1899 Hoffenheim vs. Bayer 04 Leverkusen` | `1899 Hoffenheim` / `Bayer 04 Leverkusen` |
| `Stuttgart vs. Bayern 04-09-2026` | `Stuttgart` / `Bayern` |
| `04-09-2026 Stuttgart vs. Bayern` | `Stuttgart` / `Bayern` |
| `Fulham 15:00 Burnley` | `Fulham` / `Burnley` |
| `NFL: Kansas City Chiefs @ Denver Broncos` | `Kansas City Chiefs` / `Denver Broncos` |

A pattern built from the reporter's sample also generalizes across sibling streams in that source (`1. FC Union Berlin`, `1. FSV Mainz 05`, `Werder Bremen`).

Gates: `ruff` clean, `pytest` 2779 passed, `npm run lint` clean, `npm run build` green.