### PR TITLE
fix(epg): split ASCII-dash inline matchup titles

### DIFF
--- a/teamarr/consumers/matching/epg_matcher.py
+++ b/teamarr/consumers/matching/epg_matcher.py
@@ -35,10 +35,10 @@ _EPG_DECORATION = re.compile(
 )
 
 # Inline matchup separators used by feeds that put the whole matchup in the
-# title with no sub_title ("MLB Baseball : Mets at Mariners", "… — …", "… – …").
+# title with no sub_title ("MLB Baseball : Mets at Mariners", "… - …", "… — …").
 # Converting the FIRST one to the pipe boundary lets classify_stream treat the
 # leading league/category as a strippable hint, same as a real sub_title split.
-_INLINE_SEP = re.compile(r"\s+[:–—]\s+")
+_INLINE_SEP = re.compile(r"\s+[-:–—]\s+")
 
 # Category tokens (lowercased) that classify a program.
 _CLASSIC = "classic sport event"

--- a/tests/epg/test_epg_matcher_logic.py
+++ b/tests/epg/test_epg_matcher_logic.py
@@ -115,6 +115,17 @@ def test_build_input_dash_separator_inline():
     assert build_match_input(p) == "Premier League | Arsenal vs Chelsea"
 
 
+def test_build_input_ascii_dash_separator_inline():
+    p = _prog("College Football - Missouri State at Texas A&M", None)
+    match_input = build_match_input(p)
+    assert match_input == "College Football | Missouri State at Texas A&M"
+
+    classified = classify_stream(match_input, "team", None, None, None)
+    assert classified.category is StreamCategory.TEAM_VS_TEAM
+    assert classified.team1 == "Missouri State"
+    assert classified.team2 == "Texas A&M"
+
+
 def test_build_input_no_split_when_subtitle_present():
     # A real title|sub_title split is authoritative; an in-title colon stays put.
     p = _prog("MLB Baseball: Special", "Cubs at Cardinals")


### PR DESCRIPTION
## Summary

- Split subtitle-free EPG titles on spaced ASCII hyphens, alongside the existing colon and Unicode dash separators.
- Preserve the existing `title | matchup` matching path for `College Football - Missouri State at Texas A&M`.
- Add end-to-end input and classification regression coverage.

Closes #727