### PR TITLE
fix(matching): reject fuzzy matchup false positives

### DIFF
--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -322,6 +322,24 @@ def _best_name_score(stream_norm: str, event_team) -> float:
     )
 
 
+def _has_shared_name_token(stream_norm: str, event_team) -> bool:
+    """Whether a fuzzy side match has a meaningful token in common.
+
+    Low fuzzy scores can result from coincidental character overlap alone,
+    such as ``Barrie Colts`` and ``Erie Otters``. A partial team name should
+    still contain at least one meaningful word from its full or short name.
+    """
+    stream_tokens = {token for token in stream_norm.split() if len(token) > 2}
+    if not stream_tokens:
+        return False
+
+    names = [event_team.name, getattr(event_team, "short_name", None) or ""]
+    return any(
+        stream_tokens & {token for token in normalize_text(name).split() if len(token) > 2}
+        for name in names
+    )
+
+
 @lru_cache(maxsize=65536)
 def _best_name_score_cached(
     stream_norm: str, team_name: str, team_short: str, team_abbrev: str
@@ -1765,7 +1783,14 @@ class TeamMatcher:
                     )
                 else:
                     base = _best_name_score(stream_norm, event_team)
-                return max(base, alias_score)
+                score = max(base, alias_score)
+                if (
+                    not canonical
+                    and BOTH_TEAMS_THRESHOLD <= score < HIGH_CONFIDENCE_THRESHOLD
+                    and not _has_shared_name_token(stream_norm, event_team)
+                ):
+                    return 0.0
+                return score
 
             t1_vs_home = _side_score(t1_norm, event.home_team, home_normalized)
             t1_vs_away = _side_score(t1_norm, event.away_team, away_normalized)

--- a/tests/matching/test_stream_matching.py
+++ b/tests/matching/test_stream_matching.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from teamarr.consumers.matching.classifier import classify_stream
 from teamarr.consumers.matching.result import MatchMethod
 from teamarr.core.types import Event, EventStatus, Team
 
@@ -316,6 +317,20 @@ class TestMatchTeamsToEventAbbreviationIntegration:
         result = matcher._match_teams_to_event("DEN", "PHI", event)
         assert result is None
 
+    def test_rejects_low_score_side_with_no_shared_team_token(self, matcher):
+        """Barrie Colts must not bind to Erie Otters on character similarity alone."""
+        classified = classify_stream(
+            "OHL  01 : 6:00 PM Kitchener Rangers @ Barrie Colts [1080p]"
+        )
+        event = _make_event(
+            _make_team("Kitchener Rangers", "KIT"),
+            _make_team("Erie Otters", "ER"),
+        )
+
+        assert classified.team1 == "OHL 01 :  Kitchener Rangers"
+        assert classified.team2 == "Barrie Colts"
+        assert matcher._match_teams_to_event(classified.team1, classified.team2, event) is None
+
     def test_brockport_the_stopword_does_not_match_random_streams(self, matcher):
         """ESPN abbreviation 'THE' for Brockport Golden Eagles must not match random streams (#705).
         """
@@ -336,4 +351,3 @@ class TestMatchTeamsToEventAbbreviationIntegration:
 
         # Two-team streams with a stop word in a phrase
         assert matcher._match_teams_to_event("BUF", "THE MOVIES", event) is None
-


### PR DESCRIPTION
## Summary

Reject low-confidence two-team fuzzy matches when a side has no meaningful token in common with the candidate team's full or short name.

This prevents `Kitchener Rangers @ Barrie Colts` from incorrectly matching `Erie Otters at Kitchener Rangers` based on character similarity alone.

Explicit aliases, abbreviation matches, and high-confidence fuzzy matches remain unchanged.

## Testing

- `pytest tests/matching` (572 passed)

Closes: #730