### PR TITLE
perf(frontend): code-split routes and pin a vendor chunk (#737)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ When changing support-bundle schemas, archive layout, collection limits, redacti
 
 **Stack**: Python 3.11+, FastAPI, SQLite | Frontend: React + TypeScript + Vite + Tailwind
 
+**Frontend routes are code-split (#737).** Pages are `React.lazy`'d in `App.tsx` from their own modules; Dashboard alone stays eager because it is the landing route. When adding a page, import the **module** (`@/pages/Thing`), never the `@/pages` barrel — a barrel import pulls every page back into one chunk and the only symptom is the entry bundle quietly growing (it was 1.03 MB before this). `vite.config.ts` also pins React/Router/Query into a `vendor` chunk so a release invalidates app code only.
+
 ## Start of Session
 
 1. Re-read this file and follow it exactly

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,29 +1,94 @@
+import { lazy, Suspense } from "react"
 import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from "react-router"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { LoaderCircle } from "lucide-react"
 import { MainLayout } from "@/layouts/MainLayout"
 import { EpgLayout } from "@/components/EpgLayout"
 import { ChannelsLayout } from "@/components/ChannelsLayout"
-import { ChannelLifecycle } from "@/pages/channels/ChannelLifecycle"
-import { ChannelConsolidation } from "@/pages/channels/ChannelConsolidation"
-import { ChannelNumbering } from "@/pages/channels/ChannelNumbering"
-import { ChannelStreamPriority } from "@/pages/channels/ChannelStreamPriority"
-import { ChannelDispatcharrOutput } from "@/pages/channels/ChannelDispatcharrOutput"
 import { GenerationProvider } from "@/contexts/GenerationContext"
 import { StartupOverlay } from "@/components/StartupOverlay"
-import {
-  Dashboard,
-  Subscriptions,
-  DetectionLibrary,
-  Templates,
-  TemplateForm,
-  EpgOutput,
-  Teams,
-  TeamImport,
-  EventGroups,
-  EventGroupForm,
-  EventGroupImport,
-  Settings,
-} from "@/pages"
+import { Dashboard } from "@/pages/Dashboard"
+
+/**
+ * Every page below the landing route is code-split (#737).
+ *
+ * All 19 pages used to be imported statically through the `@/pages` barrel, so
+ * the build emitted one 1.03 MB bundle and every visitor downloaded, parsed and
+ * compiled the whole app to look at the dashboard.
+ *
+ * Two rules keep it that way:
+ *   - Import the page MODULE, never the `@/pages` barrel. Going through the
+ *     barrel pulls every page into the same chunk and quietly undoes this.
+ *   - Dashboard stays eager. It is the landing route, so lazy-loading it just
+ *     adds a round trip to the most common entry point.
+ *
+ * The pages use named exports, hence the `.then` unwrap.
+ */
+const Subscriptions = lazy(() =>
+  import("@/pages/Subscriptions").then((m) => ({ default: m.Subscriptions })),
+)
+const DetectionLibrary = lazy(() =>
+  import("@/pages/DetectionLibrary").then((m) => ({ default: m.DetectionLibrary })),
+)
+const Templates = lazy(() =>
+  import("@/pages/Templates").then((m) => ({ default: m.Templates })),
+)
+const TemplateForm = lazy(() =>
+  import("@/pages/TemplateForm").then((m) => ({ default: m.TemplateForm })),
+)
+const EpgOutput = lazy(() =>
+  import("@/pages/EpgOutput").then((m) => ({ default: m.EpgOutput })),
+)
+const Teams = lazy(() => import("@/pages/Teams").then((m) => ({ default: m.Teams })))
+const TeamImport = lazy(() =>
+  import("@/pages/TeamImport").then((m) => ({ default: m.TeamImport })),
+)
+const EventGroups = lazy(() =>
+  import("@/pages/EventGroups").then((m) => ({ default: m.EventGroups })),
+)
+const EventGroupForm = lazy(() =>
+  import("@/pages/EventGroupForm").then((m) => ({ default: m.EventGroupForm })),
+)
+const EventGroupImport = lazy(() =>
+  import("@/pages/EventGroupImport").then((m) => ({ default: m.EventGroupImport })),
+)
+const Settings = lazy(() => import("@/pages/Settings").then((m) => ({ default: m.Settings })))
+const ChannelLifecycle = lazy(() =>
+  import("@/pages/channels/ChannelLifecycle").then((m) => ({ default: m.ChannelLifecycle })),
+)
+const ChannelConsolidation = lazy(() =>
+  import("@/pages/channels/ChannelConsolidation").then((m) => ({
+    default: m.ChannelConsolidation,
+  })),
+)
+const ChannelNumbering = lazy(() =>
+  import("@/pages/channels/ChannelNumbering").then((m) => ({ default: m.ChannelNumbering })),
+)
+const ChannelStreamPriority = lazy(() =>
+  import("@/pages/channels/ChannelStreamPriority").then((m) => ({
+    default: m.ChannelStreamPriority,
+  })),
+)
+const ChannelDispatcharrOutput = lazy(() =>
+  import("@/pages/channels/ChannelDispatcharrOutput").then((m) => ({
+    default: m.ChannelDispatcharrOutput,
+  })),
+)
+
+/**
+ * Shown while a route chunk downloads.
+ *
+ * Deliberately plain: chunks are served from the same origin and are small, so
+ * on anything but a cold first visit this is a flash. A skeleton that mimicked
+ * page structure would be more distracting than a spinner, not less.
+ */
+function RouteFallback() {
+  return (
+    <div className="flex items-center justify-center py-24" role="status" aria-label="Loading">
+      <LoaderCircle className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -54,6 +119,7 @@ function AppContent() {
     <>
       <StartupOverlay />
       <BrowserRouter>
+        <Suspense fallback={<RouteFallback />}>
         <Routes>
           <Route path="/" element={<MainLayout />}>
             <Route index element={<Dashboard />} />
@@ -112,6 +178,7 @@ function AppContent() {
             <Route path="templates/:templateId" element={<Redirect to="/epg/templates/:templateId" />} />
           </Route>
         </Routes>
+        </Suspense>
       </BrowserRouter>
     </>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,27 @@ export default defineConfig({
         entryFileNames: 'assets/[name]-[hash].js',
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
+        // Keep the framework in its own chunk (#737). Teamarr ships often and
+        // its own code changes every release; React/Router/Query do not, so
+        // splitting them means an upgrade re-downloads the app chunks and
+        // leaves the largest single dependency in the browser cache.
+        manualChunks(id: string) {
+          if (!id.includes('node_modules')) return
+          // Matched on the package directory, not a bare substring, so
+          // 'react-router' can't sweep in every package with 'react' in its
+          // name. Rolldown wants the function form; the object map that older
+          // Vite accepted is a type error here.
+          const framework = [
+            '/react/',
+            '/react-dom/',
+            '/react-router/',
+            '/scheduler/',
+            '/@tanstack/react-query/',
+          ]
+          if (framework.some((pkg) => id.includes(`node_modules${pkg}`))) {
+            return 'vendor'
+          }
+        },
       },
     },
   },


### PR DESCRIPTION
Last item of the performance pass epic (`teamarrv2-m6z4`).

## Problem

`lazy(` appeared **0 times** anywhere in `frontend/src`. All 19 pages were imported statically through the `@/pages` barrel in `App.tsx`, so the build emitted a single `index-*.js` of **1,030,063 bytes** and every visitor downloaded, parsed and compiled the entire app to render the dashboard. Vite has been warning about it on every build.

## Change

- Pages are `React.lazy`d from their **own modules** behind a `Suspense` fallback. Importing through the barrel would pull every page into one chunk and silently undo this, so there is a comment on the block saying so — the failure mode is invisible (the build still succeeds, the bundle just grows again).
- **Dashboard stays eager.** It is the landing route; lazy-loading it only adds a round trip to the most common entry point.
- `vite.config.ts` pins React/Router/Query into a `vendor` chunk. Vite 8 uses rolldown, which wants `manualChunks` as a **function** — the object map older Vite accepted is a type error — and it matches on the package directory rather than a bare substring so `react-router` cannot sweep in every package with "react" in its name.

## Result

| | before | after |
|---|---|---|
| entry chunk | 1030 kB | **237 kB** |
| vendor chunk | — | 260 kB (cached across releases) |
| **initial JS, gzipped** | **273 kB** | **162 kB** |
| per-page chunks | — | 11–94 kB, fetched on navigation |

Because Teamarr ships often and its own code changes every release while React does not, the vendor split means an upgrade re-downloads roughly 80 kB gzipped instead of the whole bundle.

## Verification

- `tsc -b` clean · `eslint` clean · `pytest tests/ -v` **2825 passed** (backend untouched)
- Driven in a real browser against the **production** build served by the backend: all **12** lazy routes (`/matching`, `/epg/templates`, `/epg/teams`, `/epg/output`, all five `/channels/*`, `/subscriptions`, `/sources/new`, `/epg/templates/new`) render their expected heading with the Suspense fallback cleared, plus `/sources` (full 154-group list) and `/settings` on direct navigation.
- **Zero console errors.** The only console entry across the whole sweep is the pre-existing "Password field is not contained in a form" DOM advisory on Settings, which is unrelated and present on dev today.