### PR TITLE
fix(resolver): normalize group/profile name lookups so trailing whitespace resolves (#745)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -914,3 +914,4 @@
 {"id":"int-892c018b3b620679672936e76d0b8691","kind":"field_change","created_at":"2026-09-07T01:48:09.890972544Z","actor":"luke","issue_id":"teamarrv2-m6z4.1","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-f8d27ef6feb45c97fa2e45d5d0870e07","kind":"field_change","created_at":"2026-09-07T01:48:10.824423957Z","actor":"luke","issue_id":"teamarrv2-m6z4.3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-72164c3620c5fbdc89105ab091aec375","kind":"field_change","created_at":"2026-09-07T02:40:57.259755303Z","actor":"luke","issue_id":"teamarrv2-m6z4.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-9e3efd61f83ec085d16639a2391dd1e1","kind":"field_change","created_at":"2026-09-07T11:08:23.937702085Z","actor":"luke","issue_id":"teamarrv2-vkak","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 **Dynamic Groups** (`teamarr/consumers/lifecycle/dynamic_resolver.py`):
 - `{sport}`, `{league}`, and `{conference}` wildcards (`{conference}` = home team's NCAA conference from `provider_group_cache`, #91)
 - Auto-creates in Dispatcharr
+- **Group/profile names are keyed through `_group_key` — trim + lowercase, never collapse internal whitespace (#745).** Both `create_channel_group` and `create_profile` post `name.strip()`, so a name differing only at the ends can never create what it was looking for: the cache lookup misses, Dispatcharr refuses the create as a duplicate of the group that was already there, the channel gets a null `channel_group_id`, and it repeats every run because nothing about that state changes. Collapsing *internal* runs looks like the same idea and is not safe — on a live install's 3,097 groups, trimming collided 0 keys while collapsing collided 18, all real distinct groups separated only by `\xa0` vs a regular space. Any new name→id cache against Dispatcharr must go through `_group_key` on both populate and lookup.
 
 **Per-Source Matching Types** (epic `teamarrv2-ahow`):
 - Each source declares which matching pipeline(s) it runs — three independent booleans on `event_epg_groups`: `name_match_enabled` (Stream Name → TEAM_VS_TEAM/EVENT_CARD/RACING categories), `team_streams_enabled` (Team → TEAM_ONLY), `epg_match_enabled` (EPG). Multi-select; ≥1 required (enforced in `api/routes/groups.py::require_matching_type`).

--- a/teamarr/consumers/lifecycle/dynamic_resolver.py
+++ b/teamarr/consumers/lifecycle/dynamic_resolver.py
@@ -16,6 +16,28 @@ from teamarr.dispatcharr.factory import get_dispatcharr_connection
 logger = logging.getLogger(__name__)
 
 
+def _group_key(name: str) -> str:
+    """Cache key for a Dispatcharr channel-group or profile name (#745).
+
+    Trims and lowercases — and deliberately does NOT collapse internal
+    whitespace runs.
+
+    Both managers post ``name.strip()`` when creating, so a name that differs
+    from Dispatcharr's only at the ends can never resolve: the lookup misses,
+    the create is refused as a duplicate of the group that was already there,
+    the channel is left with a null group id, and the cycle repeats on every
+    run because nothing about that state changes.
+
+    Collapsing internal runs looks like the same idea and is not safe. Measured
+    against a live install's 3,097 channel groups, trimming produced 0 colliding
+    keys while collapsing produced 18 — real, distinct groups separated only by
+    a non-breaking space where the other has a regular one ("UK| ULTIMATE POOL
+    PPV" vs "UK| ULTIMATE\xa0POOL\xa0PPV"). Merging those would file channels
+    under the wrong group, which is worse than the bug this fixes.
+    """
+    return name.strip().lower()
+
+
 @dataclass
 class DynamicResolver:
     """Resolves dynamic channel groups and profiles.
@@ -114,7 +136,7 @@ class DynamicResolver:
                 groups = dispatcharr.m3u.list_groups()
                 for g in groups:
                     if g.name and g.id:
-                        self._groups_by_name[g.name.lower()] = g.id
+                        self._groups_by_name[_group_key(g.name)] = g.id
                         self._known_group_ids.add(g.id)
                 self._groups_loaded = True
             except Exception as e:
@@ -124,7 +146,7 @@ class DynamicResolver:
                 profiles = dispatcharr.channels.list_profiles()
                 for p in profiles:
                     if p.name and p.id:
-                        self._profiles_by_name[p.name.lower()] = p.id
+                        self._profiles_by_name[_group_key(p.name)] = p.id
             except Exception as e:
                 logger.warning("[RESOLVER] Failed to fetch channel profiles: %s", e)
 
@@ -316,11 +338,25 @@ class DynamicResolver:
             Group ID or None if creation failed
         """
         self._ensure_initialized()
-        name_lower = name.lower()
+
+        # Match Dispatcharr's own trimming (#745). create_channel_group already
+        # posts name.strip(), so an untrimmed name could never create the group
+        # it was looking for — it looked up a key nothing holds, then asked
+        # Dispatcharr to create a name that already existed and got a duplicate
+        # 400 back. Every run, forever, because nothing about that state changes.
+        name = name.strip()
+        if not name:
+            logger.warning(
+                "[RESOLVER] Refusing to resolve an empty channel-group name "
+                "(pattern resolved to whitespace only) — channel left ungrouped"
+            )
+            return None
+
+        key = _group_key(name)
 
         # Check cache
-        if name_lower in self._groups_by_name:
-            return self._groups_by_name[name_lower]
+        if key in self._groups_by_name:
+            return self._groups_by_name[key]
 
         # Create new group
         dispatcharr = self._get_dispatcharr()
@@ -333,7 +369,7 @@ class DynamicResolver:
             if result.success and result.data:
                 gid = result.data.get("id")
                 if gid:
-                    self._groups_by_name[name_lower] = gid
+                    self._groups_by_name[key] = gid
                     logger.info("[RESOLVER] Created channel group '%s' (id=%d)", name, gid)
                     return gid
             else:
@@ -353,11 +389,20 @@ class DynamicResolver:
             Profile ID or None if creation failed
         """
         self._ensure_initialized()
-        name_lower = name.lower()
+
+        # Same trimming contract as _get_or_create_group (#745): create_profile
+        # posts name.strip(), so an untrimmed lookup can only ever miss and then
+        # ask Dispatcharr for a duplicate.
+        name = name.strip()
+        if not name:
+            logger.warning("[RESOLVER] Refusing to resolve an empty channel-profile name")
+            return None
+
+        key = _group_key(name)
 
         # Check cache
-        if name_lower in self._profiles_by_name:
-            return self._profiles_by_name[name_lower]
+        if key in self._profiles_by_name:
+            return self._profiles_by_name[key]
 
         # Create new profile
         dispatcharr = self._get_dispatcharr()
@@ -370,7 +415,7 @@ class DynamicResolver:
             if result.success and result.data:
                 pid = result.data.get("id")
                 if pid:
-                    self._profiles_by_name[name_lower] = pid
+                    self._profiles_by_name[key] = pid
                     logger.info("[RESOLVER] Created channel profile '%s' (id=%d)", name, pid)
                     return pid
             else:

--- a/tests/lifecycle/test_resolver_name_normalization.py
+++ b/tests/lifecycle/test_resolver_name_normalization.py
@@ -1,0 +1,129 @@
+"""A resolved group name that differs only in surrounding whitespace must still
+resolve to the group Dispatcharr already has (#745).
+
+Observed on a live install, 129 times in three hours:
+
+    [RESOLVER] Failed to create group 'Auto | Football | NCAAF | FBS ': Bad request
+    [LIFECYCLE] ... channel 59280: channel_group_id: This field may not be null.
+
+The group `Auto | Football | NCAAF | FBS` existed the whole time. The trailing
+space made the cache lookup miss, so the resolver tried to CREATE it; both
+managers post `name.strip()`, so Dispatcharr saw a duplicate and returned 400;
+the channel then got a null group id and its settings sync failed. Nothing
+about that state changes between runs, so it repeated forever.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from teamarr.consumers.lifecycle.dynamic_resolver import DynamicResolver, _group_key
+
+
+def _resolver(existing: dict[str, int], dispatcharr=None) -> DynamicResolver:
+    r = DynamicResolver()
+    r._initialized = True  # skip the Dispatcharr/DB load
+    r._groups_loaded = True
+    r._groups_by_name = {_group_key(n): i for n, i in existing.items()}
+    r._profiles_by_name = {_group_key(n): i for n, i in existing.items()}
+    r._known_group_ids = set(existing.values())
+    if dispatcharr is not None:
+        r._get_dispatcharr = lambda: dispatcharr
+    return r
+
+
+EXISTING = {"Auto | Football | NCAAF | FBS": 4004, "Auto | Football | NCAAF": 3914}
+
+
+class TestGroupKey:
+    def test_trims_and_lowercases(self):
+        assert _group_key("  Auto | X  ") == "auto | x"
+
+    def test_does_not_collapse_internal_runs(self):
+        """Live data: 18 real groups differ only by \\xa0 vs a regular space."""
+        assert _group_key("UK| ULTIMATE POOL PPV") != _group_key("UK| ULTIMATE\xa0POOL\xa0PPV")
+
+    def test_internal_double_space_is_preserved(self):
+        assert _group_key("DK: TV2 PLAY  [1080p]") != _group_key("DK: TV2 PLAY [1080p]")
+
+
+class TestGroupLookup:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Auto | Football | NCAAF | FBS",
+            "Auto | Football | NCAAF | FBS ",     # the reported failure
+            " Auto | Football | NCAAF | FBS",
+            "\tAuto | Football | NCAAF | FBS\n",
+            "auto | football | ncaaf | fbs ",
+        ],
+    )
+    def test_whitespace_variants_all_find_the_existing_group(self, name):
+        dispatcharr = MagicMock()
+        r = _resolver(EXISTING, dispatcharr)
+
+        assert r._get_or_create_group(name) == 4004
+        # The whole point: no create attempt, so no duplicate 400 from Dispatcharr.
+        dispatcharr.m3u.create_channel_group.assert_not_called()
+
+    def test_a_genuinely_new_name_is_still_created(self):
+        dispatcharr = MagicMock()
+        dispatcharr.m3u.create_channel_group.return_value = MagicMock(
+            success=True, data={"id": 9001}
+        )
+        r = _resolver(EXISTING, dispatcharr)
+
+        assert r._get_or_create_group("Auto | Football | NCAAF | FCS ") == 9001
+        # Created under the trimmed name, matching what the manager would post.
+        dispatcharr.m3u.create_channel_group.assert_called_once_with(
+            "Auto | Football | NCAAF | FCS"
+        )
+
+    def test_a_created_group_is_cached_under_the_normalized_key(self):
+        dispatcharr = MagicMock()
+        dispatcharr.m3u.create_channel_group.return_value = MagicMock(
+            success=True, data={"id": 9001}
+        )
+        r = _resolver(EXISTING, dispatcharr)
+
+        r._get_or_create_group("New Group ")
+        assert r._get_or_create_group("  New Group") == 9001
+        # Second lookup is a cache hit, not a second create.
+        assert dispatcharr.m3u.create_channel_group.call_count == 1
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+    def test_a_whitespace_only_name_is_refused_without_calling_dispatcharr(self, blank):
+        dispatcharr = MagicMock()
+        r = _resolver(EXISTING, dispatcharr)
+
+        assert r._get_or_create_group(blank) is None
+        dispatcharr.m3u.create_channel_group.assert_not_called()
+
+    def test_distinct_groups_are_not_merged_by_normalization(self):
+        """The collapsing bug this deliberately avoids."""
+        dispatcharr = MagicMock()
+        dispatcharr.m3u.create_channel_group.return_value = MagicMock(
+            success=True, data={"id": 777}
+        )
+        r = _resolver({"UK| ULTIMATE POOL PPV": 100}, dispatcharr)
+
+        # The nbsp variant is a DIFFERENT group and must not resolve to 100.
+        assert r._get_or_create_group("UK| ULTIMATE\xa0POOL\xa0PPV") == 777
+
+
+class TestProfileLookup:
+    """Same contract — create_profile also posts name.strip()."""
+
+    def test_whitespace_variant_finds_the_existing_profile(self):
+        dispatcharr = MagicMock()
+        r = _resolver({"Sports": 42}, dispatcharr)
+
+        assert r._get_or_create_profile("Sports ") == 42
+        dispatcharr.channels.create_profile.assert_not_called()
+
+    def test_whitespace_only_profile_name_is_refused(self):
+        dispatcharr = MagicMock()
+        r = _resolver({"Sports": 42}, dispatcharr)
+
+        assert r._get_or_create_profile("   ") is None
+        dispatcharr.channels.create_profile.assert_not_called()


### PR DESCRIPTION
Fixes #745.

## What was happening

A dynamic group name with a trailing space could never resolve, and the failure was self-perpetuating:

1. The pattern resolves to `Auto | Football | NCAAF | FBS ` (trailing space).
2. `_groups_by_name` is keyed on the name **as Dispatcharr reports it**, so the lookup for `auto | football | ncaaf | fbs ` misses the entry for `auto | football | ncaaf | fbs`.
3. So the resolver tries to **create** the group. `create_channel_group` posts `name.strip()`, so Dispatcharr sees a name that already exists — confirmed on the reporting install as `id=4004 Auto | Football | NCAAF | FBS` — and returns 400.
4. Resolver returns `None` → `_sync_channel_settings` pushes `channel_group_id: null` → Dispatcharr rejects that too.
5. Nothing about that state changes between runs, so it repeats **forever** — 129 times in a three-hour window, for a group that existed the whole time.

Worth noting this is **not** a name-validity problem, which is what the issue originally guessed. `create_channel_group` was already stripping. It is a lookup-normalization problem, and the fix is on our side of the cache.

## The fix

`_group_key` (trim + lowercase) applied on **both** populate and lookup, for channel groups and channel profiles alike — `create_profile` strips too, so it carried the same latent bug. A name that is whitespace-only is now refused without calling Dispatcharr at all.

## What I deliberately did not do

Collapse internal whitespace runs. That was my first instinct and the data says it is wrong. Measured against the reporting install's **3,097** channel groups:

| normalization | colliding keys |
|---|---|
| `strip().lower()` | **0** |
| `" ".join(name.lower().split())` | **18** |

Every collision is a pair of real, distinct groups separated only by a non-breaking space where the other has a regular one — `UK| ULTIMATE POOL PPV` vs `UK| ULTIMATE\xa0POOL\xa0PPV`, and similar. Merging those would file channels under the wrong group, which is worse than the bug being fixed. There is a test pinning that they stay distinct.

## Verification

- `ruff` clean · `pytest tests/ -v` **2881 passed** · `npm run build` clean
- The old code reproduces the production log line exactly:
  ```
  [RESOLVER] Failed to create group 'Auto | Football | NCAAF | FBS ': Bad request
  OLD CODE  -> None    (attempted create: call('Auto | Football | NCAAF | FBS '))
  ```
  The same call on this branch returns `4004` with **no create attempted**.
- 16 new tests in `tests/lifecycle/test_resolver_name_normalization.py`: five whitespace variants of the real failing name all resolving to the existing group with no create call; a genuinely new name still created (under the trimmed form); a created group cached under the normalized key so the second lookup is a hit; whitespace-only names refused without touching Dispatcharr; the nbsp pair staying distinct; and the same contract for profiles.

## Note on scope

This clears the warning, but if your channel overrides were producing that trailing space, the name Dispatcharr ends up with is now the trimmed one — which is the group that already existed, so those channels should simply start landing in `Auto | Football | NCAAF | FBS` on the next run rather than staying ungrouped.