### PR TITLE
fix(jellyfin): use Authorization: MediaBrowser Token= header for Jellyfin 12 (#749)

### DIFF
--- a/docs/guide/settings/media-servers.md
+++ b/docs/guide/settings/media-servers.md
@@ -21,6 +21,8 @@ Each server entry takes a URL and either an API key (recommended — generate in
 
 The refresh triggers the server's own **Refresh Guide** scheduled task and waits for it to complete (with live progress, up to 5 minutes) — that's why a generation run can sit near the end while a slow server churns.
 
+Jellyfin 10.x and 12+ are both supported: Teamarr authenticates to Jellyfin with the standard `Authorization: MediaBrowser …` header rather than the legacy `X-Emby-Token` header that Jellyfin 12 removed.
+
 Saved secrets display as `********` — leave them as-is to keep the stored value, or type over them to replace.
 
 A failed refresh never fails the generation — but it is recorded. Each run stores every server's outcome (success, duration, error) with its run stats, and once a server has failed three consecutive runs the Dashboard status strip shows a **Media servers … not refreshing** warning (hover for the error) and the support bundle raises a `media_server_refresh_failing` signal. If you see it, check the URL first: a server that moved hosts fails instantly on every run and is otherwise invisible.

--- a/teamarr/emby/client.py
+++ b/teamarr/emby/client.py
@@ -4,8 +4,9 @@ Lightweight HTTP client using httpx to authenticate with Emby
 and trigger a Live TV guide refresh after EPG generation.
 
 Jellyfin (which forked from Emby) is API-compatible. JellyfinClient
-subclasses this and only overrides the URL path prefix — Emby uses
-``/emby/...`` while Jellyfin omits the prefix.
+subclasses this and overrides the URL path prefix — Emby uses
+``/emby/...`` while Jellyfin omits the prefix — and the auth headers,
+because Jellyfin 12 dropped the legacy ``X-Emby-*`` header family (#749).
 """
 
 import logging
@@ -16,8 +17,10 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Auth header required for all Emby API calls
-_EMBY_AUTH_HEADER = (
+# MediaBrowser client identification, shared by Emby and Jellyfin. Emby
+# sends it in ``X-Emby-Authorization``; Jellyfin sends it in the standard
+# ``Authorization`` header (see JellyfinClient, #749).
+MEDIABROWSER_AUTH_HEADER = (
     'MediaBrowser Client="Teamarr", Device="Server",'
     ' DeviceId="teamarr", Version="1.0"'
 )
@@ -55,9 +58,14 @@ class EmbyClient:
         return f"{self.base_url}{self.PATH_PREFIX}{path}"
 
     def _auth_headers(self) -> dict[str, str]:
-        """Build headers for unauthenticated requests."""
+        """Build headers for unauthenticated requests.
+
+        Every request that carries credentials goes through this or
+        :meth:`_token_headers`; subclasses override BOTH to change the
+        auth scheme.
+        """
         return {
-            "X-Emby-Authorization": _EMBY_AUTH_HEADER,
+            "X-Emby-Authorization": MEDIABROWSER_AUTH_HEADER,
             "Content-Type": "application/json",
         }
 

--- a/teamarr/jellyfin/client.py
+++ b/teamarr/jellyfin/client.py
@@ -1,15 +1,21 @@
 """Jellyfin server client for Live TV guide refresh.
 
 Jellyfin forked from Emby in 2018 and inherited a near-identical API
-surface. The only structural difference Teamarr cares about is the URL
-prefix: Emby mounts under ``/emby/...`` while Jellyfin serves the same
-endpoints at the server root. ``X-Emby-Token`` (the API-key header)
-still works on Jellyfin for back-compat.
+surface. Two things differ for Teamarr:
 
-This client therefore subclasses EmbyClient and only swaps the prefix.
+* URL prefix — Emby mounts under ``/emby/...``, Jellyfin serves the same
+  endpoints at the server root.
+* Auth headers — Jellyfin 12 removed the legacy ``X-Emby-Authorization`` /
+  ``X-Emby-Token`` headers (#749). Jellyfin's own scheme is the standard
+  ``Authorization`` header with the ``MediaBrowser`` value, and the access
+  token or API key rides inside it as ``Token="..."``. Older Jellyfin
+  (10.x) accepts that form too, so there is no version switch. Emby keeps
+  its ``X-Emby-*`` headers — they are not deprecated there.
+
+This client therefore subclasses EmbyClient and overrides only those two.
 """
 
-from teamarr.emby.client import EmbyClient
+from teamarr.emby.client import MEDIABROWSER_AUTH_HEADER, EmbyClient
 
 
 class JellyfinClient(EmbyClient):
@@ -17,3 +23,19 @@ class JellyfinClient(EmbyClient):
 
     PATH_PREFIX = ""
     SERVER_LABEL = "JELLYFIN"
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Headers for unauthenticated requests (``AuthenticateByName``)."""
+        return {
+            "Authorization": MEDIABROWSER_AUTH_HEADER,
+            "Content-Type": "application/json",
+        }
+
+    def _token_headers(self) -> dict[str, str]:
+        """Headers for authenticated requests: API key or session token."""
+        if not self._access_token:
+            raise RuntimeError("Not authenticated — call authenticate() first")
+        # Quotes cannot appear in a Jellyfin API key or session token; strip
+        # any anyway so a pasted value can never break the header grammar.
+        token = self._access_token.replace('"', "")
+        return {"Authorization": f'{MEDIABROWSER_AUTH_HEADER}, Token="{token}"'}

--- a/tests/integrations/test_jellyfin_client.py
+++ b/tests/integrations/test_jellyfin_client.py
@@ -1,11 +1,15 @@
 """Smoke tests for JellyfinClient.
 
-JellyfinClient subclasses EmbyClient and only differs in URL prefix:
-Emby uses /emby/..., Jellyfin uses the server root. These tests pin
-that contract so nobody collapses the two paths by accident.
+JellyfinClient subclasses EmbyClient and differs in two ways: the URL
+prefix (Emby uses /emby/..., Jellyfin the server root) and the auth
+headers (Jellyfin 12 dropped the legacy X-Emby-* family, #749). These
+tests pin both contracts so nobody collapses the two paths by accident.
 """
 
-from teamarr.emby.client import EmbyClient
+import httpx
+import pytest
+
+from teamarr.emby.client import MEDIABROWSER_AUTH_HEADER, EmbyClient
 from teamarr.jellyfin.client import JellyfinClient
 
 
@@ -22,7 +26,72 @@ class TestUrlPrefix:
         client = JellyfinClient(base_url="http://jellyfin:8096/")
         assert client._url("/System/Info/Public") == "http://jellyfin:8096/System/Info/Public"
 
-    def test_jellyfin_inherits_emby_token_header(self):
-        # Jellyfin accepts X-Emby-Token for back-compat — same auth path as Emby.
-        client = JellyfinClient(base_url="http://jellyfin:8096", api_key="abc")
+
+class TestAuthHeaders:
+    """Jellyfin speaks ``Authorization: MediaBrowser …``; Emby keeps X-Emby-*."""
+
+    def test_emby_keeps_legacy_token_header(self):
+        client = EmbyClient(base_url="http://emby:8096", api_key="abc")
         assert client._token_headers() == {"X-Emby-Token": "abc"}
+        assert "X-Emby-Authorization" in client._auth_headers()
+
+    def test_jellyfin_api_key_rides_in_authorization_header(self):
+        client = JellyfinClient(base_url="http://jellyfin:8096", api_key="abc")
+        headers = client._token_headers()
+        assert "X-Emby-Token" not in headers
+        assert headers["Authorization"] == (
+            'MediaBrowser Client="Teamarr", Device="Server",'
+            ' DeviceId="teamarr", Version="1.0", Token="abc"'
+        )
+
+    def test_jellyfin_unauthenticated_header_has_no_token(self):
+        client = JellyfinClient(base_url="http://jellyfin:8096")
+        headers = client._auth_headers()
+        assert "X-Emby-Authorization" not in headers
+        assert headers["Authorization"] == MEDIABROWSER_AUTH_HEADER
+        assert "Token=" not in headers["Authorization"]
+
+    def test_jellyfin_token_headers_require_auth(self):
+        client = JellyfinClient(base_url="http://jellyfin:8096")
+        with pytest.raises(RuntimeError):
+            client._token_headers()
+
+    def test_jellyfin_strips_quotes_from_token(self):
+        client = JellyfinClient(base_url="http://jellyfin:8096", api_key='a"b')
+        assert client._token_headers()["Authorization"].endswith('Token="ab"')
+
+
+class TestAuthenticateWireFormat:
+    """The header actually leaves the process on every authenticated call."""
+
+    def test_api_key_validation_sends_mediabrowser_header(self, monkeypatch):
+        seen: dict = {}
+
+        def fake_get(url, headers=None, timeout=None, **_):
+            seen["url"] = url
+            seen["headers"] = headers
+            return httpx.Response(200, json=[], request=httpx.Request("GET", url))
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        client = JellyfinClient(base_url="http://jellyfin:8096", api_key="k3y")
+        assert client.authenticate() is True
+        assert seen["url"] == "http://jellyfin:8096/ScheduledTasks"
+        assert seen["headers"]["Authorization"].endswith('Token="k3y"')
+        assert "X-Emby-Token" not in seen["headers"]
+
+    def test_password_login_uses_authorization_then_session_token(self, monkeypatch):
+        posted: dict = {}
+
+        def fake_post(url, json=None, headers=None, timeout=None, **_):
+            posted["headers"] = headers
+            return httpx.Response(
+                200,
+                json={"AccessToken": "sess", "User": {"Id": "u1"}},
+                request=httpx.Request("POST", url),
+            )
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+        client = JellyfinClient(base_url="http://jellyfin:8096", username="u", password="p")
+        assert client.authenticate() is True
+        assert posted["headers"]["Authorization"] == MEDIABROWSER_AUTH_HEADER
+        assert client._token_headers()["Authorization"].endswith('Token="sess"')


### PR DESCRIPTION
Refs #749 (closes at release per the on-dev workflow).

Jellyfin 12.0 removed legacy `X-Emby-Authorization` / `X-Emby-Token` authentication. `JellyfinClient` inherited both from `EmbyClient`, so API-key validation (`GET /ScheduledTasks`) returned 401 and the integration test failed.

**Change**
- `JellyfinClient` overrides `_auth_headers` and `_token_headers` to send the standard `Authorization: MediaBrowser Client="Teamarr", Device="Server", DeviceId="teamarr", Version="1.0"[, Token="<key>"]` header. Jellyfin 10.x accepts this form too, so there is no version switch.
- Emby is untouched and keeps `X-Emby-Token` (not deprecated there). The shared client-identification string is now `MEDIABROWSER_AUTH_HEADER`.
- Tests pin both contracts, including the wire format on the API-key validation call and on password login → session token.
- Docs: one sentence in `docs/guide/settings/media-servers.md`.

**Verification**
- `ruff check` clean · full `pytest` green (2,913 tests) · not tested against a live Jellyfin 12 here — reporter confirmation requested on the `:dev` image before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg