### PR TITLE
fix(hockeytech): an empty broadcasters list no longer drops the whole game (#752)

### DIFF
--- a/teamarr/providers/hockeytech/provider.py
+++ b/teamarr/providers/hockeytech/provider.py
@@ -190,8 +190,20 @@ class HockeyTechProvider(SportsProvider):
             )
 
         except Exception as e:
+            # Name the exception TYPE, not just its message: this handler drops
+            # the entire game, and "'list' object has no attribute 'get'" (#752)
+            # took a reproduction to trace back to a field. Debug carries the
+            # traceback for the next one.
             logger.warning(
-                "[HOCKEYTECH] Failed to parse game %s: %s", game.get("game_id", "unknown"), e
+                "[HOCKEYTECH] Failed to parse game %s: %s: %s",
+                game.get("game_id", "unknown"),
+                type(e).__name__,
+                e,
+            )
+            logger.debug(
+                "[HOCKEYTECH] Parse failure detail for game %s",
+                game.get("game_id", "unknown"),
+                exc_info=True,
             )
             return None
 
@@ -388,9 +400,21 @@ class HockeyTechProvider(SportsProvider):
         )
 
     def _parse_broadcasts(self, game: dict) -> list[str]:
-        """Parse broadcast info from HockeyTech data."""
-        broadcasts = []
-        broadcasters = game.get("broadcasters", {})
+        """Parse broadcast info from HockeyTech data.
+
+        HockeyTech sends ``broadcasters`` as a mapping of home/away/national
+        when a game has any, and as an empty LIST when it has none — the usual
+        JSON idiom, and the shape this used to crash on (#752). The crash cost
+        far more than the field: the exception reached ``_parse_event``'s
+        handler, which drops the whole game, so a fixture with no listed
+        broadcaster never became an Event at all and no stream could match it
+        (17 distinct games a day on one install). Broadcast names are cosmetic,
+        so any shape that is not a mapping simply yields none.
+        """
+        broadcasts: list[str] = []
+        broadcasters = game.get("broadcasters")
+        if not isinstance(broadcasters, dict):
+            return broadcasts
 
         # Handle different broadcaster types
         for key in ["home", "away", "national"]:

--- a/tests/providers/test_hockeytech.py
+++ b/tests/providers/test_hockeytech.py
@@ -2,7 +2,10 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from teamarr.providers.hockeytech.client import HockeyTechClient
+from teamarr.providers.hockeytech.provider import HockeyTechProvider
 
 
 class _MappingSource:
@@ -63,3 +66,103 @@ def test_schema_seeds_gohl_hockeytech_mapping(db_conn):
         "team_vs_team",
         1,
     )
+
+
+# ---------------------------------------------------------------------------
+# Broadcaster parsing (#752)
+#
+# HockeyTech sends `broadcasters` as a home/away/national mapping when a game
+# has any, and as an empty LIST when it has none. `_parse_broadcasts` defaulted
+# it to {} and called .get() on it, so the list shape raised AttributeError —
+# which reached `_parse_event`'s handler and dropped the ENTIRE GAME. A fixture
+# with no listed broadcaster never became an Event, so no stream could match it:
+# 17 distinct games a day on one production install, re-dropped every run.
+#
+# The load-bearing assertion is not that broadcasts parse — it is that the
+# EVENT survives a broadcaster field of any shape.
+# ---------------------------------------------------------------------------
+
+def _provider() -> HockeyTechProvider:
+    """Provider instance without touching __init__'s client wiring."""
+    return HockeyTechProvider.__new__(HockeyTechProvider)
+
+
+@pytest.mark.parametrize(
+    "shape,expected",
+    [
+        ({}, []),                                              # no broadcasters, dict form
+        ([], []),                                              # no broadcasters, LIST form (#752)
+        (None, []),                                            # key present but null
+        ("Sportsnet", []),                                     # scalar — not a mapping
+        ({"home": []}, []),                                    # mapping, empty side
+        ({"home": "CBC"}, []),                                 # side is a scalar, not a list
+        ({"home": [{"name": "TSN"}]}, ["TSN"]),
+        ({"national": ["Sportsnet"]}, ["Sportsnet"]),
+        ({"home": [{"short_name": "TSN2"}]}, ["TSN2"]),
+    ],
+)
+def test_broadcaster_shapes_never_raise(shape, expected):
+    assert _provider()._parse_broadcasts({"broadcasters": shape}) == expected
+
+
+def test_missing_broadcasters_key_is_empty():
+    assert _provider()._parse_broadcasts({}) == []
+
+
+def test_broadcast_names_are_deduplicated_across_sides():
+    got = _provider()._parse_broadcasts(
+        {"broadcasters": {"home": [{"name": "TSN"}], "away": [{"name": "TSN"}]}}
+    )
+    assert got == ["TSN"]
+
+
+class _StubClient:
+    def get_sport(self, league):
+        return "hockey"
+
+    def get_league_config(self, league):
+        return ("ahl", "key")
+
+    def get_teams(self, *a, **kw):
+        return []
+
+
+def _game(broadcasters):
+    return {
+        "game_id": "32635",
+        "GameDateISO8601": "2026-09-08T19:00:00-04:00",
+        "home_team": "1",
+        "home_team_city": "Hershey",
+        "home_team_nickname": "Bears",
+        "home_team_code": "HER",
+        "visiting_team": "2",
+        "visiting_team_city": "Wilkes-Barre",
+        "visiting_team_nickname": "Penguins",
+        "visiting_team_code": "WBS",
+        "game_status": "1",
+        "broadcasters": broadcasters,
+    }
+
+
+@pytest.mark.parametrize("broadcasters", [[], {}, None, "Sportsnet"])
+def test_a_game_survives_any_broadcaster_shape(broadcasters):
+    """The regression that mattered: the FIXTURE must not be dropped (#752)."""
+    provider = _provider()
+    provider._client = _StubClient()
+
+    event = provider._parse_event(_game(broadcasters), "ahl")
+
+    assert event is not None, "game was dropped over a cosmetic broadcaster field"
+    assert event.id == "32635"
+    assert event.home_team.name == "Hershey Bears"
+    assert event.away_team.name == "Wilkes-Barre Penguins"
+
+
+def test_a_game_with_real_broadcasters_still_carries_them():
+    provider = _provider()
+    provider._client = _StubClient()
+
+    event = provider._parse_event(_game({"national": [{"name": "TSN"}]}), "ahl")
+
+    assert event is not None
+    assert event.broadcasts == ["TSN"]


### PR DESCRIPTION
Fixes #752. Found reviewing a 36h production soak.

## What was happening

HockeyTech sends `broadcasters` as a home/away/national mapping when a game has any, and as an empty **list** when it has none — the usual JSON idiom. `_parse_broadcasts` defaulted it to a dict and called `.get()` on it:

```python
broadcasters = game.get("broadcasters", {})   # dict default...
bc = broadcasters.get(key, [])                # ...but the API sends []
```

The inner code was already defensive (`isinstance(bc, list)`, `isinstance(b, dict)`) — only the outer container was not.

## Why it mattered more than the field

The `AttributeError` propagated to `_parse_event`, whose handler returns `None` for the **entire game**. So a fixture with no listed broadcaster never became an `Event`, and no stream could ever match it.

On the install where this was found: **17 distinct games dropped per day** across CHL/AHL/PWHL/USHL, re-attempted and re-dropped every run, with nothing louder than a WARNING to show for it. Broadcast names are cosmetic metadata Teamarr uses only to populate `broadcasts`.

## Change

Any `broadcasters` shape that is not a mapping now yields no broadcasts instead of raising.

Also — and this is the part worth a second look — the parse-failure warning now names the exception **type** and logs the traceback at debug. This handler silently discards a fixture, and `'list' object has no attribute 'get'` took a reproduction to trace back to a field. I deliberately did **not** go further and make every optional-metadata parser non-fatal: that is the real defect class here, but it changes error semantics for unknown future failures, and I would rather raise it than do it unasked.

## Verification

- `ruff` clean · `pytest tests/ -v` **2929 passed** · `npm run build` clean
- 16 new tests. The load-bearing ones are not about broadcasts parsing — they assert the **event survives**:

```python
@pytest.mark.parametrize("broadcasters", [[], {}, None, "Sportsnet"])
def test_a_game_survives_any_broadcaster_shape(broadcasters):
    event = provider._parse_event(_game(broadcasters), "ahl")
    assert event is not None, "game was dropped over a cosmetic broadcaster field"
```

Checked against the old code: **6 of the new tests fail**, including the `[]` case that is the actual production shape, and the failure log reproduces the exact message seen in production. All pass on this branch. A game with real broadcasters still carries them, and names are still deduplicated across sides.