### PR TITLE
feat(channels): add scoped stream priority rulesets

### DIFF
--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -15,6 +15,30 @@ This is distinct from [channel ordering](numbering#channel-ordering), which cont
 
 With no rules configured, streams simply keep the order they were added in — generation performs no reordering.
 
+## Scoped rulesets
+
+The **Global** tab is the default for every channel. Add scoped tabs to use a
+different policy for selected sports, leagues, or both. Teamarr selects one tab
+for each channel, in this order:
+
+1. A tab that includes the channel's league.
+2. A tab that includes the channel's sport.
+3. Global.
+
+A sport or league can be assigned to only one scoped tab, so this selection is
+always unambiguous. A tab that includes several sports or leagues can therefore
+serve a shared policy, while a league tab can override a broader sport tab.
+
+Scoped tabs inherit both sections from Global initially. **Inherit Global** beside
+the **Scoring** and **Priority** headings controls each section independently.
+When enabled, Global rules are read-only but scope-specific rules can still be
+added alongside them; later Global changes continue to apply. The Priority
+setting includes the **Everything Else** baseline. Turn off inheritance to use
+only the local section, or use that section's **Clone from Global** button to
+replace its local rules with an editable snapshot of the current Global rules.
+A scoped tab can,
+for example, keep Global Priority bands while using sport-specific scoring.
+
 ## Two ways to rank: Scoring and Priority
 
 Every rule belongs to one of two classes, added with the separate **Add scoring rule** and **Add priority rule** buttons. Both use the same [rule types](#rule-types) — the difference is *how* a match affects ordering.

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -188,6 +188,7 @@ export interface ChannelStreamEntry {
   stream_stats: Record<string, unknown> | null
   stream_stats_updated_at: string | null
   matched_rules: StreamRuleMatch[]
+  sorting_scope: string
   matched_event: string | null
   matched_league: string | null
   cache_match_method: string | null

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -176,6 +176,25 @@ export interface StreamOrderingSettingsUpdate {
   rules: StreamOrderingRule[]
 }
 
+export interface StreamOrderingScope {
+  id: number
+  name: string
+  sports: string[]
+  leagues: string[]
+  rules: StreamOrderingRule[]
+  use_global_scoring: boolean
+  use_global_priority: boolean
+}
+
+export interface StreamOrderingScopeUpdate {
+  name: string
+  sports: string[]
+  leagues: string[]
+  rules: StreamOrderingRule[]
+  use_global_scoring: boolean
+  use_global_priority: boolean
+}
+
 export interface UpdateCheckSettings {
   enabled: boolean
   notify_stable: boolean
@@ -545,6 +564,31 @@ export async function updateStreamOrderingSettings(
   data: StreamOrderingSettingsUpdate
 ): Promise<StreamOrderingSettings> {
   return api.put("/settings/stream-ordering", data)
+}
+
+export async function getStreamOrderingScopes(): Promise<StreamOrderingScope[]> {
+  return api.get("/settings/stream-ordering/scopes")
+}
+
+export async function getStreamOrderingScope(id: number): Promise<StreamOrderingScope> {
+  return api.get(`/settings/stream-ordering/scopes/${id}`)
+}
+
+export async function createStreamOrderingScope(
+  data: StreamOrderingScopeUpdate,
+): Promise<StreamOrderingScope> {
+  return api.post("/settings/stream-ordering/scopes", data)
+}
+
+export async function updateStreamOrderingScope(
+  id: number,
+  data: StreamOrderingScopeUpdate,
+): Promise<StreamOrderingScope> {
+  return api.put(`/settings/stream-ordering/scopes/${id}`, data)
+}
+
+export async function deleteStreamOrderingScope(id: number): Promise<void> {
+  return api.delete(`/settings/stream-ordering/scopes/${id}`)
 }
 
 // Update Check Settings API

--- a/frontend/src/components/ManagedChannelsTable.tsx
+++ b/frontend/src/components/ManagedChannelsTable.tsx
@@ -189,8 +189,8 @@ const fmtSigned = (n: number) => (n > 0 ? `+${n}` : String(n))
 // number is decoded to band(+score); staleness compares stored vs the freshly
 // recomputed `expected` priority.
 function PriorityCell(
-  { priority, expected, rules, generating }:
-  { priority: number; expected: number; rules: StreamRuleMatch[]; generating: boolean },
+  { priority, expected, rules, sortingScope, generating }:
+  { priority: number; expected: number; rules: StreamRuleMatch[]; sortingScope: string; generating: boolean },
 ) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -250,6 +250,9 @@ function PriorityCell(
         <div className="absolute left-0 top-full z-50 mt-1 w-64 rounded-md border bg-popover p-1.5 shadow-lg">
           <div className="px-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
             Matched rules
+          </div>
+          <div className="px-1 pb-1 text-[10px] text-muted-foreground">
+            Sorting scope: <span className="font-medium text-foreground">{sortingScope}</span>
           </div>
           <div className="space-y-0.5">
             {priorityMatches.map((r, i) => (
@@ -637,7 +640,7 @@ const ChannelRow = React.memo(function ChannelRow({
                       <td className="py-1 pr-4 text-muted-foreground">{stream.m3u_account_name ?? "—"}</td>
                       <td className="py-1 pr-4"><MethodCell stream={stream} /></td>
                       <td className="py-1 pr-4"><FeedSideCell side={stream.feed_side} /></td>
-                      <td className="py-1 pr-4"><PriorityCell priority={stream.priority} expected={stream.expected_priority} rules={stream.matched_rules} generating={isGenerating} /></td>
+                      <td className="py-1 pr-4"><PriorityCell priority={stream.priority} expected={stream.expected_priority} rules={stream.matched_rules} sortingScope={stream.sorting_scope} generating={isGenerating} /></td>
                       <td className="py-1"><StreamStatsBadges stats={stream.stream_stats} /></td>
                     </tr>
                   ))}

--- a/frontend/src/components/StreamOrderingManager.tsx
+++ b/frontend/src/components/StreamOrderingManager.tsx
@@ -11,6 +11,8 @@ import {
   Info,
   Download,
   Upload,
+  Pencil,
+  Copy,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SaveButton } from "@/components/ui/save-button"
@@ -27,17 +29,28 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Select } from "@/components/ui/select"
 import { RichTooltip } from "@/components/ui/rich-tooltip"
+import { Label } from "@/components/ui/label"
+import { CheckboxListPicker } from "@/components/ui/checkbox-list-picker"
+import type { CheckboxListGroup } from "@/components/ui/checkbox-list-picker"
 import { cn } from "@/lib/utils"
 import {
   useStreamOrderingSettings,
   useUpdateStreamOrderingSettings,
+  useStreamOrderingScopes,
+  useCreateStreamOrderingScope,
+  useUpdateStreamOrderingScope,
+  useDeleteStreamOrderingScope,
   useTeamFilterSettings,
 } from "@/hooks/useSettings"
 import { useGroups } from "@/hooks/useGroups"
 import { useChannelGroupsWithChannels } from "@/hooks/useDispatcharr"
-import { getLeagueTeams, getTeamPickerLeagues } from "@/api/teams"
+import { useSubscription } from "@/hooks/useSubscription"
+import { getLeagueTeams, getTeamPickerLeagues, getLeagues } from "@/api/teams"
 import type { CachedTeam } from "@/api/teams"
 import { getSettings } from "@/api/settings"
+import type { StreamOrderingRule, StreamOrderingScope, StreamOrderingScopeUpdate } from "@/api/settings"
+import { useSports } from "@/hooks/useSports"
+import { getSportDisplayName } from "@/lib/utils"
 
 function TeamMultiSelect({
   selected,
@@ -435,6 +448,7 @@ function RuleRow({
   m3uAccounts,
   groupNames,
   dpGroupNames,
+  disabled = false,
 }: {
   rule: RuleFormData
   index: number
@@ -443,6 +457,7 @@ function RuleRow({
   m3uAccounts: string[]
   groupNames: string[]
   dpGroupNames: string[]
+  disabled?: boolean
 }) {
   const isCatchAll = rule.type === "catch_all"
 
@@ -457,7 +472,7 @@ function RuleRow({
 
   if (isCatchAll) {
     return (
-      <div className="flex items-center gap-2 p-2 rounded-md border bg-muted/30">
+      <fieldset disabled={disabled} className="flex items-center gap-2 rounded-md border bg-muted/30 p-2 disabled:opacity-60">
         <div className="flex-1 grid grid-cols-1 md:grid-cols-12 gap-2 md:items-center">
           <div className="col-span-12 md:col-span-2">
             <span className="text-sm font-medium px-3">Everything Else</span>
@@ -482,12 +497,12 @@ function RuleRow({
             </Button>
           </div>
         </div>
-      </div>
+      </fieldset>
     )
   }
 
   return (
-    <div className="flex items-center gap-2 p-2 rounded-md border bg-card">
+    <fieldset disabled={disabled} className="flex items-center gap-2 rounded-md border bg-card p-2 disabled:opacity-60">
       <div className="flex-1 grid grid-cols-1 md:grid-cols-12 gap-2 md:items-center">
         <div className="col-span-12 md:col-span-2">
           <Select
@@ -672,7 +687,7 @@ function RuleRow({
           </Button>
         </div>
       </div>
-    </div>
+    </fieldset>
   )
 }
 
@@ -808,16 +823,44 @@ function StatsMetricBuilder({ value, onChange }: { value: string; onChange: (v: 
 let nextRuleId = 0
 const allocateId = () => ++nextRuleId
 
+const isScoringRule = (rule: { mode: RuleFormData["mode"] }) => rule.mode === "score"
+const isPriorityRule = (rule: { mode: RuleFormData["mode"] }) => rule.mode === "priority"
+
+interface ScopeDraft {
+  id?: number
+  name: string
+  sports: string[]
+  leagues: string[]
+}
+
 export function StreamOrderingManager() {
   const { data: settings, isLoading, error } = useStreamOrderingSettings()
   const updateSettings = useUpdateStreamOrderingSettings()
+  const { data: scopes = [], isLoading: scopesLoading } = useStreamOrderingScopes()
+  const createScope = useCreateStreamOrderingScope()
+  const updateScope = useUpdateStreamOrderingScope()
+  const deleteScope = useDeleteStreamOrderingScope()
   const { data: groupsData } = useGroups(true) // Include disabled groups
+  const { data: subscription } = useSubscription()
 
+  const [activeTab, setActiveTab] = useState("global")
   const [rules, setRules] = useState<RuleFormData[]>([])
+  const [useGlobalScoring, setUseGlobalScoring] = useState(true)
+  const [useGlobalPriority, setUseGlobalPriority] = useState(true)
   const [hasChanges, setHasChanges] = useState(false)
+  const [scopeDraft, setScopeDraft] = useState<ScopeDraft | null>(null)
   const [isImporting, setIsImporting] = useState(false)
   const [exportWarning, setExportWarning] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const activeScope = activeTab === "global"
+    ? undefined
+    : scopes.find((scope) => scope.id === Number(activeTab.slice("scope-".length)))
+  const isScoped = !!activeScope
+
+  if (activeTab !== "global" && !activeScope && !scopesLoading) {
+    setActiveTab("global")
+  }
 
   // Extract unique M3U account names and group names from groups
   const { m3uAccounts, groupNames } = useMemo(() => {
@@ -856,15 +899,77 @@ export function StreamOrderingManager() {
     return dpChannelGroups.filter(g => selected.has(g.id)).map(g => g.name).sort()
   }, [appSettings, dpChannelGroups])
 
+  const { data: sportsData } = useSports()
+  const { data: leaguesData } = useQuery({ queryKey: ["leagues"], queryFn: () => getLeagues() })
+  const sportsMap = useMemo(() => sportsData?.sports ?? {}, [sportsData])
+  const configuredLeagues = subscription?.leagues
+  const subscribedLeagues = useMemo(() => configuredLeagues ?? [], [configuredLeagues])
+  const sportItems = useMemo(() =>
+    [...new Set(
+      (leaguesData?.leagues ?? [])
+        .filter((league) => subscribedLeagues.includes(league.slug))
+        .map((league) => league.sport),
+    )]
+      .map((sport) => ({ value: sport, label: getSportDisplayName(sport, sportsMap) }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [leaguesData, sportsMap, subscribedLeagues],
+  )
+  const leagueGroups: CheckboxListGroup[] = useMemo(() => {
+    const bySport: Record<string, { slug: string; name: string }[]> = {}
+    for (const league of leaguesData?.leagues ?? []) {
+      if (!subscribedLeagues.includes(league.slug)) continue
+      if (!bySport[league.sport]) bySport[league.sport] = []
+      bySport[league.sport].push({ slug: league.slug, name: league.name })
+    }
+    return Object.entries(bySport)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([sport, leagues]) => ({
+        key: sport,
+        label: getSportDisplayName(sport, sportsMap),
+        items: leagues
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((league) => ({ value: league.slug, label: league.name })),
+      }))
+  }, [leaguesData, sportsMap, subscribedLeagues])
+  const unavailableScopes = useMemo(() => {
+    const sports = new Set<string>()
+    const leagues = new Set<string>()
+    for (const scope of scopes) {
+      if (scope.id === scopeDraft?.id) continue
+      scope.sports.forEach((sport) => sports.add(sport))
+      scope.leagues.forEach((league) => leagues.add(league))
+    }
+    return { sports, leagues }
+  }, [scopes, scopeDraft?.id])
+  const selectableSportItems = useMemo(
+    () => sportItems.filter((item) => !unavailableScopes.sports.has(item.value)
+      || scopeDraft?.sports.includes(item.value)),
+    [sportItems, unavailableScopes, scopeDraft?.sports],
+  )
+  const selectableLeagueGroups = useMemo(
+    () => leagueGroups.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => !unavailableScopes.leagues.has(item.value)
+        || scopeDraft?.leagues.includes(item.value)),
+    })).filter((group) => group.items.length > 0),
+    [leagueGroups, unavailableScopes, scopeDraft?.leagues],
+  )
+
   // Initialize rules from settings. Legacy rows without mode default to
   // 'priority' (backend already coerces, but guard here for safety). The
   // catch_all baseline is optional — no longer auto-injected.
   // (render-time "adjust state when props change" pattern — see
   // DispatcharrOutputSettings.tsx).
-  const [syncedSettings, setSyncedSettings] = useState<typeof settings>(undefined)
-  if (settings?.rules && settings !== syncedSettings) {
-    setSyncedSettings(settings)
-    const loaded: RuleFormData[] = settings.rules.map(r => ({
+  const currentRules = activeScope?.rules ?? settings?.rules
+  const currentSource = activeScope ?? settings
+  const globalRuleForms = useMemo<RuleFormData[]>(() => (settings?.rules ?? []).map((rule) => ({
+    ...rule,
+    _id: allocateId(),
+  })), [settings])
+  const [syncedSource, setSyncedSource] = useState<typeof currentSource>(undefined)
+  if (currentRules && currentSource !== syncedSource) {
+    setSyncedSource(currentSource)
+    const loaded: RuleFormData[] = currentRules.map(r => ({
       _id: allocateId(),
       type: r.type,
       value: r.value,
@@ -873,6 +978,8 @@ export function StreamOrderingManager() {
       points: r.points ?? 0,
     }))
     setRules(loaded)
+    setUseGlobalScoring(activeScope?.use_global_scoring ?? false)
+    setUseGlobalPriority(activeScope?.use_global_priority ?? false)
     setHasChanges(false)
   }
 
@@ -889,7 +996,10 @@ export function StreamOrderingManager() {
   const handleAddPriorityRule = () => {
     // Find next available priority among priority-mode rules.
     const usedPriorities = new Set(
-      rules.filter(r => r.mode === "priority").map(r => r.priority)
+      [
+        ...rules,
+        ...(isScoped && useGlobalPriority ? globalRuleForms : []),
+      ].filter(r => r.mode === "priority").map(r => r.priority)
     )
     let nextPriority = 1
     while (usedPriorities.has(nextPriority) && nextPriority < 99) {
@@ -922,6 +1032,28 @@ export function StreamOrderingManager() {
     setHasChanges(true)
   }
 
+  const serializedRules = (source: RuleFormData[] = rules): StreamOrderingRule[] => source.map((r) => ({
+    type: r.type,
+    value: r.value.trim(),
+    priority: r.priority,
+    mode: r.mode,
+    points: r.mode === "score" ? r.points : 0,
+  }))
+
+  const saveScope = (scope: StreamOrderingScope, overrides: Partial<StreamOrderingScopeUpdate> = {}) =>
+    updateScope.mutateAsync({
+      id: scope.id,
+      data: {
+        name: scope.name,
+        sports: scope.sports,
+        leagues: scope.leagues,
+        rules: serializedRules(),
+        use_global_scoring: useGlobalScoring,
+        use_global_priority: useGlobalPriority,
+        ...overrides,
+      },
+    })
+
   const handleSave = async () => {
     // Validate rules — no-value types (team_feed, not_team_feed, catch_all) don't require a value
     const invalidRules = rules.filter(r => !NO_VALUE_TYPES.has(r.type) && !r.value.trim())
@@ -932,15 +1064,8 @@ export function StreamOrderingManager() {
     }
 
     try {
-      await updateSettings.mutateAsync({
-        rules: rules.map((r: RuleFormData) => ({
-          type: r.type,
-          value: r.value.trim(),
-          priority: r.priority,
-          mode: r.mode,
-          points: r.mode === "score" ? r.points : 0,
-        })),
-      })
+      if (activeScope) await saveScope(activeScope)
+      else await updateSettings.mutateAsync({ rules: serializedRules() })
       toast.success("Stream ordering rules saved")
       setHasChanges(false)
     } catch {
@@ -948,10 +1073,33 @@ export function StreamOrderingManager() {
     }
   }
 
+  const copyGlobalFamily = (family: "scoring" | "priority") => {
+    if (!confirm(`Replace this scope's ${family} rules with the Global rules?`)) return
+    const globalRules = settings?.rules ?? []
+    const copied = globalRules.filter((rule) =>
+      family === "scoring" ? isScoringRule(rule) : isPriorityRule(rule),
+    )
+    setRules((current) => [
+      ...current.filter((rule) => family === "scoring" ? !isScoringRule(rule) : !isPriorityRule(rule)),
+      ...copied.map((rule) => ({ ...rule, _id: allocateId() })),
+    ])
+    if (family === "scoring") setUseGlobalScoring(false)
+    else setUseGlobalPriority(false)
+    setHasChanges(true)
+  }
+
+  const clearLocalFamily = (family: "scoring" | "priority") => {
+    if (!confirm(`Clear all local ${family} rules for this scope?`)) return
+    setRules((current) => current.filter((rule) =>
+      family === "scoring" ? !isScoringRule(rule) : !isPriorityRule(rule),
+    ))
+    setHasChanges(true)
+  }
+
   // Always exports the last *saved* rules, never unsaved editor edits.
   const doExport = () => {
     const payload = {
-      rules: (settings?.rules ?? []).map((r) => ({
+      rules: (currentRules ?? []).map((r) => ({
         type: r.type,
         value: r.value,
         priority: r.priority,
@@ -1030,7 +1178,15 @@ export function StreamOrderingManager() {
       const skipped = importedRules.length - accepted
       // catch_all is optional now — do not force-inject one on import.
 
-      await updateSettings.mutateAsync({ rules: clean })
+      if (activeScope) {
+        await saveScope(activeScope, {
+          rules: clean,
+          use_global_scoring: false,
+          use_global_priority: false,
+        })
+      } else {
+        await updateSettings.mutateAsync({ rules: clean })
+      }
       const message = skipped > 0
         ? `Imported ${accepted} rules (${skipped} skipped - invalid)`
         : `Imported ${accepted} rules`
@@ -1043,6 +1199,48 @@ export function StreamOrderingManager() {
       if (fileInputRef.current) {
         fileInputRef.current.value = ""
       }
+    }
+  }
+
+  const handleScopeDraftSave = async () => {
+    if (!scopeDraft?.name.trim()) {
+      toast.error("Enter a name for this ruleset")
+      return
+    }
+    try {
+      if (scopeDraft.id && activeScope) {
+        await saveScope(activeScope, {
+          name: scopeDraft.name.trim(),
+          sports: scopeDraft.sports,
+          leagues: scopeDraft.leagues,
+        })
+        setHasChanges(false)
+      } else {
+        const created = await createScope.mutateAsync({
+          name: scopeDraft.name.trim(),
+          sports: scopeDraft.sports,
+          leagues: scopeDraft.leagues,
+          rules: [],
+          use_global_scoring: true,
+          use_global_priority: true,
+        })
+        setActiveTab(`scope-${created.id}`)
+      }
+      setScopeDraft(null)
+      toast.success(scopeDraft.id ? "Ruleset updated" : "Ruleset created")
+    } catch {
+      toast.error(scopeDraft.id ? "Failed to update ruleset" : "Failed to create ruleset")
+    }
+  }
+
+  const handleDeleteScope = async () => {
+    if (!activeScope || !confirm(`Delete the ${activeScope.name} ruleset?`)) return
+    try {
+      await deleteScope.mutateAsync(activeScope.id)
+      setActiveTab("global")
+      toast.success("Ruleset deleted")
+    } catch {
+      toast.error("Failed to delete ruleset")
     }
   }
 
@@ -1067,11 +1265,23 @@ export function StreamOrderingManager() {
     )
   }
 
+  // Inherited sections render the saved Global family first, followed by their
+  // local rules. The Global rows are read-only, while scope-specific rules stay
+  // editable and are evaluated alongside their inherited family.
+  const displayedRules = isScoped
+    ? [
+        ...(useGlobalScoring ? globalRuleForms.filter(isScoringRule) : []),
+        ...rules.filter(isScoringRule),
+        ...(useGlobalPriority ? globalRuleForms.filter(isPriorityRule) : []),
+        ...rules.filter(isPriorityRule),
+      ]
+    : rules
+
   // Split rules by class for the two sections. catch_all is the optional
-  // baseline, rendered at the end of the Priority section.
-  const priorityRules = rules.filter(r => r.mode === "priority" && r.type !== "catch_all")
-  const scoreRules = rules.filter(r => r.mode === "score")
-  const catchAll = rules.find(r => r.type === "catch_all")
+  // baseline and sorts among the other Priority rows by its band number.
+  const priorityRules = displayedRules.filter(r => r.mode === "priority")
+  const scoreRules = displayedRules.filter(r => r.mode === "score")
+  const catchAll = displayedRules.find(r => r.type === "catch_all")
 
   const renderRow = (rule: RuleFormData) => (
     <RuleRow
@@ -1083,12 +1293,72 @@ export function StreamOrderingManager() {
       m3uAccounts={m3uAccounts}
       groupNames={groupNames}
       dpGroupNames={dpGroupNames}
+      disabled={isScoped && globalRuleForms.includes(rule)}
     />
   )
 
   return (
     <>
-    <Card>
+    <div className="mb-0 flex flex-wrap items-end gap-2 border-b">
+      <div role="tablist" aria-label="Stream priority rulesets" className="-mb-px flex flex-wrap items-end gap-1">
+        {[
+          { key: "global", label: "Global" },
+          ...scopes.map((scope) => ({ key: `scope-${scope.id}`, label: scope.name })),
+        ].map((tab) => {
+          const isActive = activeTab === tab.key
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls="stream-priority-panel"
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                "rounded-t-md border border-b-0 px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? "border-border bg-card text-foreground"
+                  : "border-transparent text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+      <div className="ml-auto flex gap-2 pb-1">
+        {activeScope && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setScopeDraft({
+                id: activeScope.id,
+                name: activeScope.name,
+                sports: activeScope.sports,
+                leagues: activeScope.leagues,
+              })}
+            >
+              <Pencil className="h-4 w-4 mr-1" />
+              Edit scope
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleDeleteScope} disabled={deleteScope.isPending}>
+              <Trash2 className="h-4 w-4 mr-1" />
+              Delete
+            </Button>
+          </>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setScopeDraft({ name: "", sports: [], leagues: [] })}
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          Add scope
+        </Button>
+      </div>
+    </div>
+    <Card className="rounded-t-none border border-t-0">
       <CardHeader>
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="space-y-1.5">
@@ -1099,7 +1369,7 @@ export function StreamOrderingManager() {
             </CardDescription>
           </div>
           <div className="flex flex-wrap items-center gap-2 shrink-0">
-            <Button variant="outline" size="sm" onClick={handleExport} disabled={!settings?.rules?.length}>
+            <Button variant="outline" size="sm" onClick={handleExport} disabled={!currentRules?.length}>
               <Download className="h-4 w-4 mr-1" />
               Export
             </Button>
@@ -1121,17 +1391,46 @@ export function StreamOrderingManager() {
           </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent id="stream-priority-panel" role="tabpanel" className="space-y-6">
         {/* Scoring section (primary — new rules default here) */}
         <div className="space-y-2">
-          <div className="space-y-0.5">
-            <h3 className="text-sm font-semibold">Scoring</h3>
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="space-y-0.5">
+            <div className="flex items-center gap-3">
+              <h3 className="text-sm font-semibold">Scoring</h3>
+              {isScoped && (
+                <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                  <Checkbox
+                    checked={useGlobalScoring}
+                    onCheckedChange={(checked) => {
+                      setUseGlobalScoring(checked === true)
+                      setHasChanges(true)
+                    }}
+                  />
+                  Inherit Global
+                </label>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground">
               Every matching rule adds its points; streams sort by total (highest first) within
               their band. Use negative points to push streams down.
             </p>
+            </div>
+            {isScoped && !useGlobalScoring && (
+              <div className="flex gap-1">
+                <Button variant="ghost" size="sm" onClick={() => copyGlobalFamily("scoring")}>
+                  <Copy className="h-4 w-4 mr-1" />
+                  Clone from Global
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => clearLocalFamily("scoring")}>
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Clear rules
+                </Button>
+              </div>
+            )}
           </div>
 
+          <div className="space-y-2">
           {scoreRules.length > 0 && (
             <div className="space-y-2">
               <div className="hidden md:grid grid-cols-12 gap-2 px-2 text-xs font-medium text-muted-foreground">
@@ -1140,7 +1439,7 @@ export function StreamOrderingManager() {
                 <div className="col-span-2 text-center">Points</div>
                 <div className="col-span-1"></div>
               </div>
-              {scoreRules.map(renderRow)}
+              {scoreRules.slice().sort((a, b) => b.points - a.points).map(renderRow)}
             </div>
           )}
 
@@ -1148,20 +1447,50 @@ export function StreamOrderingManager() {
             <Plus className="h-4 w-4 mr-1" />
             Add scoring rule
           </Button>
+          </div>
         </div>
 
         {/* Priority section (hard-order escape hatch) */}
         <div className="space-y-2 border-t pt-4">
-          <div className="space-y-0.5">
-            <h3 className="text-sm font-semibold">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div className="space-y-0.5">
+            <div className="flex items-center gap-3">
+              <h3 className="text-sm font-semibold">
               Priority <span className="font-normal text-muted-foreground">— hard order</span>
-            </h3>
+              </h3>
+              {isScoped && (
+                <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                  <Checkbox
+                    checked={useGlobalPriority}
+                    onCheckedChange={(checked) => {
+                      setUseGlobalPriority(checked === true)
+                      setHasChanges(true)
+                    }}
+                  />
+                  Inherit Global
+                </label>
+              )}
+            </div>
             <p className="text-xs text-muted-foreground">
               The first rule a stream matches sets its band, and bands always outrank scoring — use
               these for “must always win/lose”. Lower number = higher. Optional.
             </p>
+            </div>
+            {isScoped && !useGlobalPriority && (
+              <div className="flex gap-1">
+                <Button variant="ghost" size="sm" onClick={() => copyGlobalFamily("priority")}>
+                  <Copy className="h-4 w-4 mr-1" />
+                  Clone from Global
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => clearLocalFamily("priority")}>
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Clear rules
+                </Button>
+              </div>
+            )}
           </div>
 
+          <div className="space-y-2">
           {(priorityRules.length > 0 || catchAll) && (
             <div className="space-y-2">
               <div className="hidden md:grid grid-cols-12 gap-2 px-2 text-xs font-medium text-muted-foreground">
@@ -1171,7 +1500,6 @@ export function StreamOrderingManager() {
                 <div className="col-span-1"></div>
               </div>
               {priorityRules.slice().sort((a, b) => a.priority - b.priority).map(renderRow)}
-              {catchAll && renderRow(catchAll)}
             </div>
           )}
 
@@ -1187,9 +1515,10 @@ export function StreamOrderingManager() {
               </Button>
             )}
           </div>
+          </div>
         </div>
 
-        {rules.length === 0 && (
+        {displayedRules.length === 0 && (
           <p className="text-center text-xs text-muted-foreground pt-1">
             No rules yet — streams keep their addition order.
           </p>
@@ -1198,7 +1527,7 @@ export function StreamOrderingManager() {
         <div className="flex items-center justify-end pt-2 border-t">
           <SaveButton
             onClick={handleSave}
-            pending={updateSettings.isPending}
+            pending={updateSettings.isPending || updateScope.isPending}
             disabled={!hasChanges}
           />
         </div>
@@ -1229,6 +1558,65 @@ export function StreamOrderingManager() {
             }}
           >
             Export saved rules
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <Dialog open={!!scopeDraft} onOpenChange={(open) => !open && setScopeDraft(null)}>
+      <DialogContent onClose={() => setScopeDraft(null)} className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{scopeDraft?.id ? "Edit stream ordering scope" : "Add stream ordering scope"}</DialogTitle>
+          <DialogDescription>
+            Apply this ruleset to any combination of sports and leagues. A matching league takes
+            precedence over a sport-only scope.
+          </DialogDescription>
+        </DialogHeader>
+        {scopeDraft && (
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="stream-ordering-scope-name">Name</Label>
+              <Input
+                id="stream-ordering-scope-name"
+                value={scopeDraft.name}
+                onChange={(event) => setScopeDraft({ ...scopeDraft, name: event.target.value })}
+                placeholder="e.g., Baseball"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Sports (optional)</Label>
+              <CheckboxListPicker
+                selected={scopeDraft.sports}
+                onChange={(sports) => setScopeDraft({ ...scopeDraft, sports })}
+                items={selectableSportItems}
+                searchPlaceholder="Search sports..."
+                maxHeight="max-h-36"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Leagues (optional)</Label>
+              <CheckboxListPicker
+                selected={scopeDraft.leagues}
+                onChange={(leagues) => setScopeDraft({ ...scopeDraft, leagues })}
+                groups={selectableLeagueGroups}
+                searchPlaceholder="Search leagues..."
+                maxHeight="max-h-48"
+              />
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setScopeDraft(null)}>Cancel</Button>
+          <Button
+            onClick={handleScopeDraftSave}
+            disabled={
+              createScope.isPending || updateScope.isPending || !scopeDraft?.name.trim()
+              || (!scopeDraft?.sports.length && !scopeDraft?.leagues.length)
+            }
+          >
+            {(createScope.isPending || updateScope.isPending) && <LoaderCircle className="h-4 w-4 mr-1 animate-spin" />}
+            {scopeDraft?.id ? "Update scope" : "Create scope"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -24,6 +24,11 @@ import {
   updateChannelNumberingSettings,
   getStreamOrderingSettings,
   updateStreamOrderingSettings,
+  getStreamOrderingScopes,
+  getStreamOrderingScope,
+  createStreamOrderingScope,
+  updateStreamOrderingScope,
+  deleteStreamOrderingScope,
   getUpdateCheckSettings,
   updateUpdateCheckSettings,
   checkForUpdates,
@@ -146,6 +151,40 @@ export const useStreamOrderingSettings = settingsQueryHook(
 export const useUpdateStreamOrderingSettings = settingsMutationHook(updateStreamOrderingSettings, [
   ["settings", "stream-ordering"],
 ])
+
+export const useStreamOrderingScopes = settingsQueryHook(
+  "stream-ordering-scopes",
+  getStreamOrderingScopes,
+)
+
+export function useStreamOrderingScope(id: number | null) {
+  return useQuery({
+    queryKey: ["settings", "stream-ordering-scopes", id],
+    queryFn: () => getStreamOrderingScope(id!),
+    enabled: id !== null,
+  })
+}
+
+function streamOrderingScopeMutationHook<TData, TVariables>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+) {
+  return function useStreamOrderingScopeMutation() {
+    const queryClient = useQueryClient()
+    return useMutation({
+      mutationFn,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["settings", "stream-ordering-scopes"] })
+      },
+    })
+  }
+}
+
+export const useCreateStreamOrderingScope = streamOrderingScopeMutationHook(createStreamOrderingScope)
+export const useUpdateStreamOrderingScope = streamOrderingScopeMutationHook(
+  ({ id, data }: { id: number; data: Parameters<typeof updateStreamOrderingScope>[1] }) =>
+    updateStreamOrderingScope(id, data),
+)
+export const useDeleteStreamOrderingScope = streamOrderingScopeMutationHook(deleteStreamOrderingScope)
 
 export const useUpdateCheckSettings = settingsQueryHook("update-check", getUpdateCheckSettings)
 export const useUpdateUpdateCheckSettings = settingsMutationHook(updateUpdateCheckSettings, [

--- a/teamarr/api/routes/channels.py
+++ b/teamarr/api/routes/channels.py
@@ -29,9 +29,10 @@ from teamarr.database.channels.streams import (
 )
 from teamarr.database.groups import get_group_names_by_ids
 from teamarr.database.settings import get_dispatcharr_settings
+from teamarr.database.stream_ordering_scopes import resolve_stream_ordering_rules
 from teamarr.dispatcharr import ChannelManager, get_dispatcharr_client
 from teamarr.services import create_channel_service, create_default_service
-from teamarr.services.stream_ordering import get_stream_ordering_service
+from teamarr.services.stream_ordering import StreamOrderingService
 from teamarr.utilities.tz import parse_db_timestamp
 
 logger = logging.getLogger(__name__)
@@ -208,6 +209,7 @@ class ChannelStreamEntry(BaseModel):
     stream_stats: dict | None = None
     stream_stats_updated_at: str | None = None
     matched_rules: list[StreamRuleMatch] = []
+    sorting_scope: str = "Global"
     # Cache-derived match detail (absent for EPG / dedicated matches)
     matched_event: str | None = None
     matched_league: str | None = None
@@ -374,7 +376,11 @@ def get_managed_channel_streams(channel_id: int):
         # plus the priority those current rules WOULD produce (for the staleness
         # flag — the stored priority is a collapsed band*stride-score int once
         # scoring is in play, so the UI can't recompute it from matched_rules alone).
-        ordering_service = get_stream_ordering_service(conn)
+        ordering_rules, ordering_scope = resolve_stream_ordering_rules(
+            conn, channel.sport, channel.league
+        )
+        ordering_service = StreamOrderingService(ordering_rules, conn)
+        sorting_scope = ordering_scope.name if ordering_scope else "Global"
         # With no rules configured, generation never reorders (streams keep their
         # sequential added order), so 'expected' must mirror the stored priority
         # rather than the service's no-match baseline — otherwise every stream
@@ -429,6 +435,7 @@ def get_managed_channel_streams(channel_id: int):
                 stream_stats=s.stream_stats,
                 stream_stats_updated_at=_safe_isoformat(s.stream_stats_updated_at),
                 matched_rules=matched_by_stream.get(s.dispatcharr_stream_id, []),
+                sorting_scope=sorting_scope,
                 matched_event=channel_event,
                 matched_league=channel.league,
                 cache_match_method=(d := match_details.get(

--- a/teamarr/api/routes/settings/models.py
+++ b/teamarr/api/routes/settings/models.py
@@ -95,6 +95,7 @@ class DispatcharrSettingsModel(BaseModel):
     @classmethod
     def _mask_password(cls, v: str | None) -> str | None:
         return MASKED_SECRET if v else None
+
     epg_id: int | None = None
     # None = all profiles, [] = no profiles, [1,2,...] = specific profiles
     # Supports int IDs and string wildcards like "{sport}", "{league}"
@@ -398,6 +399,29 @@ class StreamOrderingSettingsUpdate(BaseModel):
     )
 
 
+class StreamOrderingScopeModel(BaseModel):
+    """A scoped stream-ordering ruleset, independently persisted from global rules."""
+
+    id: int
+    name: str = Field(..., min_length=1)
+    sports: list[str] = Field(default_factory=list)
+    leagues: list[str] = Field(default_factory=list)
+    rules: list[StreamOrderingRuleModel] = Field(default_factory=list)
+    use_global_scoring: bool = True
+    use_global_priority: bool = True
+
+
+class StreamOrderingScopeUpdate(BaseModel):
+    """Create or fully replace a scoped stream-ordering ruleset."""
+
+    name: str = Field(..., min_length=1)
+    sports: list[str] = Field(default_factory=list)
+    leagues: list[str] = Field(default_factory=list)
+    rules: list[StreamOrderingRuleModel] = Field(default_factory=list)
+    use_global_scoring: bool = True
+    use_global_priority: bool = True
+
+
 # =============================================================================
 # UPDATE CHECK SETTINGS
 # =============================================================================
@@ -529,9 +553,7 @@ class EmbySettingsUpdate(BaseModel):
 class EmbyConnectionTestRequest(BaseModel):
     """Request to test Emby connection."""
 
-    url: str | None = Field(
-        None, description="Override URL (uses saved if not provided)"
-    )
+    url: str | None = Field(None, description="Override URL (uses saved if not provided)")
     username: str | None = Field(None, description="Override username")
     password: str | None = Field(None, description="Override password")
     api_key: str | None = Field(None, description="Override API key")
@@ -570,9 +592,7 @@ class JellyfinSettingsUpdate(BaseModel):
 class JellyfinConnectionTestRequest(BaseModel):
     """Request to test Jellyfin connection."""
 
-    url: str | None = Field(
-        None, description="Override URL (uses saved if not provided)"
-    )
+    url: str | None = Field(None, description="Override URL (uses saved if not provided)")
     username: str | None = Field(None, description="Override username")
     password: str | None = Field(None, description="Override password")
     api_key: str | None = Field(None, description="Override API key")
@@ -621,9 +641,7 @@ class ChannelsDVRSettingsUpdate(BaseModel):
 class ChannelsDVRConnectionTestRequest(BaseModel):
     """Request to test Channels DVR connection."""
 
-    url: str | None = Field(
-        None, description="Override URL (uses saved if not provided)"
-    )
+    url: str | None = Field(None, description="Override URL (uses saved if not provided)")
     source_name: str | None = Field(None, description="Override source name")
 
 

--- a/teamarr/api/routes/settings/stream_ordering.py
+++ b/teamarr/api/routes/settings/stream_ordering.py
@@ -1,17 +1,69 @@
 """Stream ordering settings endpoints."""
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Response, status
 
 from teamarr.database import get_db
 from teamarr.database.settings.types import NO_VALUE_RULE_TYPES, VALID_RULE_TYPES
+from teamarr.database.stream_ordering_scopes import ScopeAssignmentConflict
 
 from .models import (
+    StreamOrderingScopeModel,
+    StreamOrderingScopeUpdate,
     StreamOrderingSettingsModel,
     StreamOrderingSettingsUpdate,
     to_model,
 )
 
 router = APIRouter()
+
+
+def _validated_rules(rules) -> list[dict]:
+    """Validate and normalize rule payloads shared by global and scoped settings."""
+    for rule in rules:
+        if rule.type not in VALID_RULE_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid rule type '{rule.type}'. Valid: {VALID_RULE_TYPES}",
+            )
+        if rule.type not in NO_VALUE_RULE_TYPES and (not rule.value or not rule.value.strip()):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Rule value cannot be empty",
+            )
+        if rule.type == "stream_type":
+            base = rule.value.split("|")[0].strip()
+            if base not in {"event", "team"}:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="stream_type value must be 'event' or 'team'",
+                )
+    return [
+        {
+            "type": rule.type,
+            "value": rule.value.strip(),
+            "priority": rule.priority,
+            "mode": rule.mode,
+            "points": rule.points,
+        }
+        for rule in rules
+    ]
+
+
+def _scope_model(scope) -> StreamOrderingScopeModel:
+    return StreamOrderingScopeModel(**scope.__dict__)
+
+
+def _validate_scope_update(update: StreamOrderingScopeUpdate) -> list[dict]:
+    if not update.name.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Ruleset name cannot be empty"
+        )
+    if not update.sports and not update.leagues:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Select at least one sport or league for a scoped ruleset",
+        )
+    return _validated_rules(update.rules)
 
 
 @router.get("/settings/stream-ordering", response_model=StreamOrderingSettingsModel)
@@ -47,37 +99,7 @@ def update_stream_ordering_settings(update: StreamOrderingSettingsUpdate):
         update_stream_ordering_rules,
     )
 
-    # Validate rule types
-    for rule in update.rules:
-        if rule.type not in VALID_RULE_TYPES:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid rule type '{rule.type}'. Valid: {VALID_RULE_TYPES}",
-            )
-        if rule.type not in NO_VALUE_RULE_TYPES and (not rule.value or not rule.value.strip()):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Rule value cannot be empty",
-            )
-        if rule.type == "stream_type":
-            base = rule.value.split("|")[0].strip()
-            if base not in {"event", "team"}:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="stream_type value must be 'event' or 'team'",
-                )
-
-    # Convert to dict format for database function
-    rules_data = [
-        {
-            "type": rule.type,
-            "value": rule.value.strip(),
-            "priority": rule.priority,
-            "mode": rule.mode,
-            "points": rule.points,
-        }
-        for rule in update.rules
-    ]
+    rules_data = _validated_rules(update.rules)
 
     with get_db() as conn:
         update_stream_ordering_rules(conn, rules_data)
@@ -87,3 +109,93 @@ def update_stream_ordering_settings(update: StreamOrderingSettingsUpdate):
         settings = get_stream_ordering_settings(conn)
 
     return to_model(StreamOrderingSettingsModel, settings)
+
+
+@router.get("/settings/stream-ordering/scopes", response_model=list[StreamOrderingScopeModel])
+def get_stream_ordering_scopes():
+    """List persisted scoped stream-ordering rulesets."""
+    from teamarr.database.stream_ordering_scopes import get_stream_ordering_scopes
+
+    with get_db() as conn:
+        return [_scope_model(scope) for scope in get_stream_ordering_scopes(conn)]
+
+
+@router.post(
+    "/settings/stream-ordering/scopes",
+    response_model=StreamOrderingScopeModel,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_stream_ordering_scope(update: StreamOrderingScopeUpdate):
+    """Create a scoped stream-ordering ruleset."""
+    from teamarr.database.stream_ordering_scopes import create_stream_ordering_scope
+
+    rules = _validate_scope_update(update)
+    try:
+        with get_db() as conn:
+            scope = create_stream_ordering_scope(
+                conn,
+                name=update.name,
+                sports=update.sports,
+                leagues=update.leagues,
+                rules=rules,
+                use_global_scoring=update.use_global_scoring,
+                use_global_priority=update.use_global_priority,
+            )
+    except ScopeAssignmentConflict as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _scope_model(scope)
+
+
+@router.get(
+    "/settings/stream-ordering/scopes/{ruleset_id}", response_model=StreamOrderingScopeModel
+)
+def get_stream_ordering_scope(ruleset_id: int):
+    """Get one scoped stream-ordering ruleset."""
+    from teamarr.database.stream_ordering_scopes import get_stream_ordering_scope
+
+    with get_db() as conn:
+        scope = get_stream_ordering_scope(conn, ruleset_id)
+    if scope is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ruleset not found")
+    return _scope_model(scope)
+
+
+@router.put(
+    "/settings/stream-ordering/scopes/{ruleset_id}", response_model=StreamOrderingScopeModel
+)
+def update_stream_ordering_scope(ruleset_id: int, update: StreamOrderingScopeUpdate):
+    """Fully replace a scoped stream-ordering ruleset."""
+    from teamarr.database.stream_ordering_scopes import update_stream_ordering_scope
+
+    rules = _validate_scope_update(update)
+    try:
+        with get_db() as conn:
+            scope = update_stream_ordering_scope(
+                conn,
+                ruleset_id,
+                name=update.name,
+                sports=update.sports,
+                leagues=update.leagues,
+                rules=rules,
+                use_global_scoring=update.use_global_scoring,
+                use_global_priority=update.use_global_priority,
+            )
+    except ScopeAssignmentConflict as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    if scope is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ruleset not found")
+    return _scope_model(scope)
+
+
+@router.delete(
+    "/settings/stream-ordering/scopes/{ruleset_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_stream_ordering_scope(ruleset_id: int):
+    """Delete a scoped stream-ordering ruleset."""
+    from teamarr.database.stream_ordering_scopes import delete_stream_ordering_scope
+
+    with get_db() as conn:
+        deleted = delete_stream_ordering_scope(conn, ruleset_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ruleset not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -1202,12 +1202,8 @@ def _apply_stream_ordering(
             # streams still need their membership synced each run so they attach
             # when their window opens and detach when it closes (bead teamarr-uye).
             scoped_ordering = get_stream_ordering_scopes(conn)
-            all_ordering_rules = ordering_settings.rules + [
-                rule
-                for scope in scoped_ordering
-                for rule in scope.rules
-            ]
-            if all_ordering_rules:
+            has_scoped_rules = any(scope.rules for scope in scoped_ordering)
+            if ordering_settings.rules or has_scoped_rules:
                 logger.info("[ORDERING] Applying scoped stream ordering rules")
             else:
                 logger.debug(
@@ -1267,10 +1263,14 @@ def _apply_stream_ordering(
             #
             # Skipped outright when no rule reads stats: the fetch buys nothing
             # for a ruleset built from m3u/group/regex, and most are.
-            if any(
-                (rule.type if hasattr(rule, "type") else rule.get("type")) == "stats_metric"
-                for rule in all_ordering_rules
-            ):
+            has_stats_rule = any(
+                rule.type == "stats_metric" for rule in ordering_settings.rules
+            ) or any(
+                rule.get("type") == "stats_metric"
+                for scope in scoped_ordering
+                for rule in scope.rules
+            )
+            if has_stats_rule:
                 stat_stream_ids = get_active_dispatcharr_stream_ids(conn)
                 refreshed = refresh_stream_stats_bulk(conn, stat_stream_ids)
                 reorder_result["stats_refreshed"] = refreshed

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -21,7 +21,6 @@ from teamarr.emby.client import EmbyClient
 from teamarr.jellyfin.client import JellyfinClient
 from teamarr.services import create_default_service
 from teamarr.services.sports_data import flush_shared_cache
-from teamarr.services.stream_ordering import StreamOrderingService
 from teamarr.utilities import call_metrics
 from teamarr.utilities.xmltv import merge_xmltv_content
 
@@ -1185,6 +1184,8 @@ def _apply_stream_ordering(
         refresh_stream_stats_bulk,
     )
     from teamarr.database.settings import get_stream_ordering_settings
+    from teamarr.database.stream_ordering_scopes import get_stream_ordering_scopes
+    from teamarr.services.stream_ordering import get_stream_ordering_service
     from teamarr.utilities.tz import now_utc
 
     reorder_result: dict = {
@@ -1200,15 +1201,14 @@ def _apply_stream_ordering(
             # No early return when rules are absent: time-windowed (EPG-matched)
             # streams still need their membership synced each run so they attach
             # when their window opens and detach when it closes (bead teamarr-uye).
-            ordering_service = (
-                StreamOrderingService(rules=ordering_settings.rules, conn=conn)
-                if ordering_settings.rules
-                else None
-            )
-            if ordering_service:
-                logger.info(
-                    "[ORDERING] Applying %d ordering rule(s)", len(ordering_settings.rules)
-                )
+            scoped_ordering = get_stream_ordering_scopes(conn)
+            all_ordering_rules = ordering_settings.rules + [
+                rule
+                for scope in scoped_ordering
+                for rule in scope.rules
+            ]
+            if all_ordering_rules:
+                logger.info("[ORDERING] Applying scoped stream ordering rules")
             else:
                 logger.debug(
                     "[ORDERING] No ordering rules configured; running window sync only"
@@ -1267,8 +1267,9 @@ def _apply_stream_ordering(
             #
             # Skipped outright when no rule reads stats: the fetch buys nothing
             # for a ruleset built from m3u/group/regex, and most are.
-            if ordering_service and any(
-                rule.type == "stats_metric" for rule in ordering_settings.rules
+            if any(
+                (rule.type if hasattr(rule, "type") else rule.get("type")) == "stats_metric"
+                for rule in all_ordering_rules
             ):
                 stat_stream_ids = get_active_dispatcharr_stream_ids(conn)
                 refreshed = refresh_stream_stats_bulk(conn, stat_stream_ids)
@@ -1344,7 +1345,10 @@ def _apply_stream_ordering(
                             pinned_top = None
 
                 reordered_count = 0
-                if ordering_service:
+                ordering_service = get_stream_ordering_service(
+                    conn, channel.sport, channel.league
+                )
+                if ordering_service.rules:
                     for stream in streams:
                         new_priority = ordering_service.compute_priority(stream)
                         if stream.priority != new_priority:

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -599,6 +599,8 @@ class ChannelCreator(_LifecycleHost):
                     dispatcharr_channel_group=stream.get("dp_channel_group"),
                     feed_team_id=stream_feed_team_id,
                     feed_side=stream_feed_side,
+                    sport=event.sport,
+                    league=event.league,
                 )
                 if priority is None:
                     priority = get_next_stream_priority(conn, existing.id)

--- a/teamarr/database/channels/streams.py
+++ b/teamarr/database/channels/streams.py
@@ -187,6 +187,8 @@ def compute_stream_priority_from_rules(
     dispatcharr_channel_group: str | None = None,
     feed_team_id: str | None = None,
     feed_side: str | None = None,
+    sport: str | None = None,
+    league: str | None = None,
 ) -> int:
     """Compute priority for a stream based on ordering rules.
 
@@ -219,7 +221,7 @@ def compute_stream_priority_from_rules(
     from teamarr.database.channels.types import ManagedChannelStream
     from teamarr.services.stream_ordering import get_stream_ordering_service
 
-    ordering_service = get_stream_ordering_service(conn)
+    ordering_service = get_stream_ordering_service(conn, sport, league)
     if not ordering_service.rules:
         # No rules - use sequential ordering (will be assigned by get_next_stream_priority)
         return None  # type: ignore
@@ -535,8 +537,14 @@ def reorder_channel_streams(
     if not streams:
         return 0
 
-    # Get ordering service with rules
-    ordering_service = get_stream_ordering_service(conn)
+    channel = conn.execute(
+        "SELECT sport, league FROM managed_channels WHERE id = ?", (managed_channel_id,)
+    ).fetchone()
+    ordering_service = get_stream_ordering_service(
+        conn,
+        channel["sport"] if channel else None,
+        channel["league"] if channel else None,
+    )
     if not ordering_service.rules:
         # No rules defined - skip reordering
         return 0

--- a/teamarr/database/migrations/versioned.py
+++ b/teamarr/database/migrations/versioned.py
@@ -336,6 +336,10 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         )
         current_version = 93
 
+    if current_version < 94:
+        _advance_version(conn, 94, "scoped stream-ordering rulesets")
+        current_version = 94
+
 
 # =============================================================================
 # Migration helpers

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -483,7 +483,28 @@ CREATE TABLE IF NOT EXISTS settings (
     channelsdvr_servers JSON,
 
     -- Schema Version
-    schema_version INTEGER DEFAULT 93
+    schema_version INTEGER DEFAULT 94
+);
+
+-- Scoped stream-ordering rulesets. Runtime resolution intentionally remains
+-- separate; this table only owns the persisted configuration and assignments.
+CREATE TABLE IF NOT EXISTS stream_ordering_scopes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    rules JSON NOT NULL DEFAULT '[]',
+    use_global_scoring BOOLEAN NOT NULL DEFAULT 1,
+    use_global_priority BOOLEAN NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS stream_ordering_scope_assignments (
+    ruleset_id INTEGER NOT NULL,
+    scope_type TEXT NOT NULL CHECK(scope_type IN ('sport', 'league')),
+    scope_value TEXT NOT NULL,
+    PRIMARY KEY (ruleset_id, scope_type, scope_value),
+    UNIQUE (scope_type, scope_value),
+    FOREIGN KEY (ruleset_id) REFERENCES stream_ordering_scopes(id) ON DELETE CASCADE
 );
 
 -- Insert default settings

--- a/teamarr/database/stream_ordering_scopes.py
+++ b/teamarr/database/stream_ordering_scopes.py
@@ -1,0 +1,182 @@
+"""Persistence for scoped stream-ordering rulesets.
+
+These rulesets are stored independently from the global settings rule list.
+Runtime selection is deliberately outside this module.
+"""
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from sqlite3 import Connection
+
+from teamarr.database.settings.types import StreamOrderingRule
+
+
+@dataclass
+class StreamOrderingScope:
+    """A stream-ordering ruleset assigned to sports and/or leagues."""
+
+    id: int
+    name: str
+    sports: list[str] = field(default_factory=list)
+    leagues: list[str] = field(default_factory=list)
+    rules: list[dict] = field(default_factory=list)
+    use_global_scoring: bool = True
+    use_global_priority: bool = True
+
+
+class ScopeAssignmentConflict(ValueError):
+    """A sport or league is already assigned to another ruleset."""
+
+
+def _normalize_scope_values(values: list[str]) -> list[str]:
+    return sorted({value.strip().lower() for value in values if value.strip()})
+
+
+def _row_to_scope(conn: Connection, row: sqlite3.Row) -> StreamOrderingScope:
+    assignments = conn.execute(
+        "SELECT scope_type, scope_value FROM stream_ordering_scope_assignments "
+        "WHERE ruleset_id = ? ORDER BY scope_type, scope_value",
+        (row["id"],),
+    ).fetchall()
+    return StreamOrderingScope(
+        id=row["id"],
+        name=row["name"],
+        sports=[r["scope_value"] for r in assignments if r["scope_type"] == "sport"],
+        leagues=[r["scope_value"] for r in assignments if r["scope_type"] == "league"],
+        rules=json.loads(row["rules"] or "[]"),
+        use_global_scoring=bool(row["use_global_scoring"]),
+        use_global_priority=bool(row["use_global_priority"]),
+    )
+
+
+def get_stream_ordering_scopes(conn: Connection) -> list[StreamOrderingScope]:
+    """Return every scoped ruleset in creation order."""
+    rows = conn.execute(
+        "SELECT id, name, rules, use_global_scoring, use_global_priority "
+        "FROM stream_ordering_scopes ORDER BY id"
+    ).fetchall()
+    return [_row_to_scope(conn, row) for row in rows]
+
+
+def get_stream_ordering_scope(conn: Connection, ruleset_id: int) -> StreamOrderingScope | None:
+    """Return one scoped ruleset, if present."""
+    row = conn.execute(
+        "SELECT id, name, rules, use_global_scoring, use_global_priority "
+        "FROM stream_ordering_scopes WHERE id = ?",
+        (ruleset_id,),
+    ).fetchone()
+    return _row_to_scope(conn, row) if row else None
+
+
+def _replace_assignments(
+    conn: Connection, ruleset_id: int, sports: list[str], leagues: list[str]
+) -> None:
+    conn.execute(
+        "DELETE FROM stream_ordering_scope_assignments WHERE ruleset_id = ?", (ruleset_id,)
+    )
+    assignments = [(ruleset_id, "sport", value) for value in _normalize_scope_values(sports)]
+    assignments.extend((ruleset_id, "league", value) for value in _normalize_scope_values(leagues))
+    try:
+        conn.executemany(
+            "INSERT INTO stream_ordering_scope_assignments (ruleset_id, scope_type, scope_value) "
+            "VALUES (?, ?, ?)",
+            assignments,
+        )
+    except sqlite3.IntegrityError as exc:
+        raise ScopeAssignmentConflict(
+            "Each sport or league can only be assigned to one scoped ruleset"
+        ) from exc
+
+
+def create_stream_ordering_scope(
+    conn: Connection,
+    *,
+    name: str,
+    sports: list[str],
+    leagues: list[str],
+    rules: list[dict],
+    use_global_scoring: bool = True,
+    use_global_priority: bool = True,
+) -> StreamOrderingScope:
+    """Create a scoped ruleset and its exclusive sport/league assignments."""
+    cursor = conn.execute(
+        "INSERT INTO stream_ordering_scopes "
+        "(name, rules, use_global_scoring, use_global_priority) VALUES (?, ?, ?, ?)",
+        (name.strip(), json.dumps(rules), int(use_global_scoring), int(use_global_priority)),
+    )
+    assert cursor.lastrowid is not None
+    _replace_assignments(conn, cursor.lastrowid, sports, leagues)
+    scope = get_stream_ordering_scope(conn, cursor.lastrowid)
+    assert scope is not None
+    return scope
+
+
+def update_stream_ordering_scope(
+    conn: Connection,
+    ruleset_id: int,
+    *,
+    name: str,
+    sports: list[str],
+    leagues: list[str],
+    rules: list[dict],
+    use_global_scoring: bool = True,
+    use_global_priority: bool = True,
+) -> StreamOrderingScope | None:
+    """Replace a scoped ruleset and its assignments."""
+    cursor = conn.execute(
+        "UPDATE stream_ordering_scopes SET name = ?, rules = ?, use_global_scoring = ?, "
+        "use_global_priority = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+        (
+            name.strip(),
+            json.dumps(rules),
+            int(use_global_scoring),
+            int(use_global_priority),
+            ruleset_id,
+        ),
+    )
+    if cursor.rowcount == 0:
+        return None
+    _replace_assignments(conn, ruleset_id, sports, leagues)
+    return get_stream_ordering_scope(conn, ruleset_id)
+
+
+def delete_stream_ordering_scope(conn: Connection, ruleset_id: int) -> bool:
+    """Delete a scoped ruleset and its assignments."""
+    return (
+        conn.execute("DELETE FROM stream_ordering_scopes WHERE id = ?", (ruleset_id,)).rowcount > 0
+    )
+
+
+def resolve_stream_ordering_rules(
+    conn: Connection,
+    sport: str | None,
+    league: str | None,
+) -> tuple[list[StreamOrderingRule], StreamOrderingScope | None]:
+    """Return the effective rules for the most-specific matching scope.
+
+    A matching scoped ruleset may independently inherit the scoring and priority
+    families from Global. ``catch_all`` belongs to the priority family.
+    """
+    from teamarr.database.settings import get_stream_ordering_settings
+
+    global_rules = get_stream_ordering_settings(conn).rules
+    scopes = get_stream_ordering_scopes(conn)
+    league_key = league.strip().lower() if league else ""
+    sport_key = sport.strip().lower() if sport else ""
+    scope = next((item for item in scopes if league_key and league_key in item.leagues), None)
+    if scope is None:
+        scope = next((item for item in scopes if sport_key and sport_key in item.sports), None)
+    if scope is None:
+        return global_rules, None
+
+    local_rules = [StreamOrderingRule(**rule) for rule in scope.rules]
+    global_scoring = [rule for rule in global_rules if rule.mode == "score"]
+    global_priority = [rule for rule in global_rules if rule.mode != "score"]
+    local_scoring = [rule for rule in local_rules if rule.mode == "score"]
+    local_priority = [rule for rule in local_rules if rule.mode != "score"]
+    return (
+        (global_scoring + local_scoring if scope.use_global_scoring else local_scoring)
+        + (global_priority + local_priority if scope.use_global_priority else local_priority),
+        scope,
+    )

--- a/teamarr/services/stream_ordering.py
+++ b/teamarr/services/stream_ordering.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from sqlite3 import Connection
 
 from teamarr.database.channels.types import ManagedChannelStream
-from teamarr.database.settings import get_stream_ordering_settings
 from teamarr.database.settings.types import StreamOrderingRule
 
 logger = logging.getLogger(__name__)
@@ -882,7 +881,11 @@ class StreamOrderingService:
         return None
 
 
-def get_stream_ordering_service(conn: Connection) -> StreamOrderingService:
+def get_stream_ordering_service(
+    conn: Connection,
+    sport: str | None = None,
+    league: str | None = None,
+) -> StreamOrderingService:
     """Factory function to create a StreamOrderingService with rules from database.
 
     Args:
@@ -892,5 +895,7 @@ def get_stream_ordering_service(conn: Connection) -> StreamOrderingService:
         Configured StreamOrderingService
     """
 
-    settings = get_stream_ordering_settings(conn)
-    return StreamOrderingService(rules=settings.rules, conn=conn)
+    from teamarr.database.stream_ordering_scopes import resolve_stream_ordering_rules
+
+    rules, _ = resolve_stream_ordering_rules(conn, sport, league)
+    return StreamOrderingService(rules=rules, conn=conn)

--- a/teamarr/services/support_bundle.py
+++ b/teamarr/services/support_bundle.py
@@ -224,18 +224,25 @@ class SupportBundleService:
         groups = {
             row["id"]: row.get("name") for row in self._query(conn, "event_epg_groups", errors)
         }
-        ordering = self._safe_stream_ordering(conn, errors)
+        channel_context = {
+            channel["id"]: (channel.get("sport"), channel.get("league"))
+            for channel in channels
+            if isinstance(channel.get("id"), int)
+        }
         by_channel: dict[int, list[dict[str, Any]]] = {}
         for stream in stream_rows:
             model = ManagedChannelStream.from_row(stream)
             stream.pop("m3u_account_name", None)
             stream.pop("m3u_account_id", None)
             stream["source_group_name"] = groups.get(stream.get("source_group_id"))
-            stream["matched_rules"] = self._matched_rules(
-                ordering, model, stream.get("source_group_name")
-            )
             channel_id = stream.get("managed_channel_id")
             if isinstance(channel_id, int):
+                sport, league = channel_context.get(channel_id, (None, None))
+                stream["matched_rules"] = self._matched_rules(
+                    get_stream_ordering_service(conn, sport, league),
+                    model,
+                    stream.get("source_group_name"),
+                )
                 by_channel.setdefault(channel_id, []).append(stream)
 
         channel_entries = []

--- a/tests/migrations/test_checkpoint_v43.py
+++ b/tests/migrations/test_checkpoint_v43.py
@@ -626,7 +626,7 @@ class TestFullMigrationPath:
 
         # Should now be at the latest schema version.
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
 
 
 if __name__ == "__main__":

--- a/tests/migrations/test_reconciliation.py
+++ b/tests/migrations/test_reconciliation.py
@@ -374,7 +374,7 @@ class TestFullSchemaReconciliation:
             "SELECT schema_version, proxy_enabled, proxy_url, proxy_user_agent, "
             "proxy_excluded_providers, bullpen_api_key FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
         assert row["proxy_enabled"] == 0
         assert row["proxy_url"] is None
         assert row["proxy_user_agent"] is None

--- a/tests/migrations/test_subscription_migration.py
+++ b/tests/migrations/test_subscription_migration.py
@@ -381,4 +381,4 @@ class TestGroupNormalization:
         _run_v58_migration(db)
 
         row = db.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row[0] == 93  # v59-v93 migrations run after v58
+        assert row[0] == 94  # v59-v94 migrations run after v58

--- a/tests/migrations/test_versioned_migrations.py
+++ b/tests/migrations/test_versioned_migrations.py
@@ -218,7 +218,7 @@ class TestV73DeletesDuplicateLeagues:
         _run_migrations(conn)
 
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
 
 
 class TestV73CleansTeamCache:
@@ -412,7 +412,7 @@ class TestV73MissingTablesGraceful:
         _run_migrations(conn)
 
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ class TestFreshInstall:
         conn = sqlite3.connect(str(db_path))
         conn.row_factory = sqlite3.Row
         row = conn.execute("SELECT schema_version FROM settings WHERE id = 1").fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
 
 
 # ===========================================================================
@@ -1222,7 +1222,7 @@ class TestV82ChannelsDVRServersList:
         row = conn.execute(
             "SELECT schema_version, channelsdvr_servers FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
         servers = json.loads(row["channelsdvr_servers"])
         assert servers == [
             {
@@ -1241,7 +1241,7 @@ class TestV82ChannelsDVRServersList:
         row = conn.execute(
             "SELECT schema_version, channelsdvr_servers FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
         assert row["channelsdvr_servers"] is None
 
     def test_settings_roundtrip_servers_list(self, db_conn):

--- a/tests/test_media_server_settings.py
+++ b/tests/test_media_server_settings.py
@@ -62,7 +62,7 @@ class TestV83MediaServerLists:
             "SELECT schema_version, emby_servers, jellyfin_servers "
             "FROM settings WHERE id = 1"
         ).fetchone()
-        assert row["schema_version"] == 93
+        assert row["schema_version"] == 94
         emby = json.loads(row["emby_servers"])
         assert emby == [
             {

--- a/tests/test_stream_ordering.py
+++ b/tests/test_stream_ordering.py
@@ -9,7 +9,12 @@ import pytest
 
 from teamarr.database.channels.types import ManagedChannelStream
 from teamarr.database.connection import get_connection, get_db, init_db
+from teamarr.database.settings import update_stream_ordering_rules
 from teamarr.database.settings.types import StreamOrderingRule
+from teamarr.database.stream_ordering_scopes import (
+    create_stream_ordering_scope,
+    resolve_stream_ordering_rules,
+)
 from teamarr.services.stream_ordering import (
     BAND_STRIDE,
     NO_MATCH_PRIORITY,
@@ -88,6 +93,101 @@ class TestBasicRules:
         svc = StreamOrderingService(rules)
         # ESPN rule has lower number → evaluated first → wins
         assert svc.compute_priority(_stream("ESPN 1080p")) == 2
+
+
+class TestScopedRules:
+    def test_league_scope_beats_sport_and_inherits_scoring(self, seeded_db):
+        update_stream_ordering_rules(
+            seeded_db,
+            [
+                {"type": "regex", "value": "HD", "priority": 99, "mode": "score", "points": 10},
+                {"type": "m3u", "value": "Global", "priority": 1, "mode": "priority", "points": 0},
+            ],
+        )
+        create_stream_ordering_scope(
+            seeded_db,
+            name="Baseball",
+            sports=["baseball"],
+            leagues=[],
+            rules=[
+                {"type": "m3u", "value": "Sport", "priority": 2, "mode": "priority", "points": 0}
+            ],
+            use_global_scoring=True,
+            use_global_priority=False,
+        )
+        create_stream_ordering_scope(
+            seeded_db,
+            name="MLB",
+            sports=[],
+            leagues=["mlb"],
+            rules=[
+                {"type": "m3u", "value": "League", "priority": 3, "mode": "priority", "points": 0}
+            ],
+            use_global_scoring=True,
+            use_global_priority=False,
+        )
+
+        rules, scope = resolve_stream_ordering_rules(seeded_db, "baseball", "mlb")
+
+        assert scope is not None
+        assert scope.name == "MLB"
+        assert [(rule.mode, rule.value) for rule in rules] == [
+            ("score", "HD"),
+            ("priority", "League"),
+        ]
+
+    def test_scope_can_inherit_priority_and_use_local_scoring(self, seeded_db):
+        update_stream_ordering_rules(
+            seeded_db,
+            [
+                {"type": "regex", "value": "Global", "priority": 99, "mode": "score", "points": 10},
+                {"type": "catch_all", "value": "", "priority": 50, "mode": "priority", "points": 0},
+            ],
+        )
+        create_stream_ordering_scope(
+            seeded_db,
+            name="Football",
+            sports=["football"],
+            leagues=[],
+            rules=[
+                {"type": "regex", "value": "Local", "priority": 99, "mode": "score", "points": 20}
+            ],
+            use_global_scoring=False,
+            use_global_priority=True,
+        )
+
+        rules, _ = resolve_stream_ordering_rules(seeded_db, "football", "nfl")
+
+        assert [(rule.mode, rule.value) for rule in rules] == [
+            ("score", "Local"),
+            ("priority", ""),
+        ]
+
+    def test_scope_keeps_local_rules_alongside_inherited_family(self, seeded_db):
+        update_stream_ordering_rules(
+            seeded_db,
+            [
+                {"type": "regex", "value": "Global", "priority": 99, "mode": "score", "points": 10},
+            ],
+        )
+        create_stream_ordering_scope(
+            seeded_db,
+            name="Basketball",
+            sports=["basketball"],
+            leagues=[],
+            rules=[
+                {"type": "regex", "value": "Local", "priority": 99, "mode": "score", "points": 20}
+            ],
+            use_global_scoring=True,
+            use_global_priority=True,
+        )
+
+        rules, _ = resolve_stream_ordering_rules(seeded_db, "basketball", "nba")
+
+        assert [(rule.mode, rule.value) for rule in rules] == [
+            ("score", "Global"),
+            ("score", "Local"),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stream_ordering_api.py
+++ b/tests/test_stream_ordering_api.py
@@ -14,6 +14,7 @@ from teamarr.database import init_db
 client = TestClient(app)
 
 STREAM_ORDERING = "/api/v1/settings/stream-ordering"
+STREAM_ORDERING_SCOPES = f"{STREAM_ORDERING}/scopes"
 
 
 @pytest.fixture(autouse=True)
@@ -87,3 +88,38 @@ def test_combined_settings_carries_mode_and_points():
     rules = combined["stream_ordering"]["rules"]
     assert rules[0]["mode"] == "score"
     assert rules[0]["points"] == 10
+
+
+def test_scoped_ruleset_rejects_duplicate_league_assignments():
+    payload = {
+        "name": "Baseball",
+        "sports": ["baseball"],
+        "leagues": ["mlb"],
+        "rules": [],
+        "use_global_scoring": True,
+        "use_global_priority": True,
+    }
+    created = client.post(STREAM_ORDERING_SCOPES, json=payload)
+    assert created.status_code == 201
+    assert created.json()["leagues"] == ["mlb"]
+
+    duplicate = client.post(
+        STREAM_ORDERING_SCOPES,
+        json={**payload, "name": "MLB alternate", "sports": [], "leagues": ["mlb"]},
+    )
+    assert duplicate.status_code == 409
+
+
+def test_scoped_ruleset_requires_a_sport_or_league():
+    response = client.post(
+        STREAM_ORDERING_SCOPES,
+        json={
+            "name": "Empty",
+            "sports": [],
+            "leagues": [],
+            "rules": [],
+            "use_global_scoring": True,
+            "use_global_priority": True,
+        },
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

Adds sport and league scoped Stream Priority rulesets.
- Adds browser-style Global and scoped tabs with template-style
sport/league selection.
- Resolves rulesets by league, then sport, then Global.
- Supports independent Scoring and Priority inheritance from Global.
- Allows local scoped rules alongside inherited Global rules.
- Adds Clone from Global and Clear rules actions with confirmation.
- Shows the applied sorting scope in Dashboard Matched Rules
popovers.
- Adds scoped CRUD endpoints, persistence, migration support,
documentation, and tests.
## Validation
- `pytest tests/test_stream_ordering.py tests/
test_stream_ordering_api.py`
- `npm run build`
- `npm run lint`

Closes #763.