### PR TITLE
fix(matching): keep the EPG anchor on the reverse-alias retry, skip replay/highlights titles (#716)

### DIFF
--- a/docs/guide/matching/program-matching.md
+++ b/docs/guide/matching/program-matching.md
@@ -169,7 +169,7 @@ A channel that shows **red** in Dispatcharr means no streams are currently attac
 ## Caveats & limits
 
 - **Attach/detach precision is bounded by generation cadence.** A stream can only swap in/out when EPG generation runs (your scheduled cron). With hourly runs, expect roughly hourly granularity — the buffers exist partly to cover this.
-- **Replays and studio shows are intentionally skipped.** Programs tagged *Classic Sport Event* (replays) or *Sports non-event* (studio/talk) don't match. A live channel showing offseason replays will legitimately match little or nothing.
+- **Replays and studio shows are intentionally skipped.** Programs tagged *Classic Sport Event* (replays) or *Sports non-event* (studio/talk) don't match, and so does any programme whose title or sub-title carries a replay or highlights word (*Hlts*, *Highlights*, *Replay*, *Encore*, *Rerun*, *Re-air*, *As-live*) — guides without categories, such as Sky and TNT, put that evidence in the title instead. A live channel showing offseason replays will legitimately match little or nothing.
 - **A matched event must actually exist.** EPG matching pairs a program to a real event in your subscribed leagues. A guide entry for a game in a league you don't follow (or a finished game) won't match.
 - **Strict name matching skips ambiguous names** to avoid wrong matches. Some channels may not resolve by name alone and will rely on the channel-mapping or direct-tvg_id strategies.
 

--- a/teamarr/consumers/matching/epg_matcher.py
+++ b/teamarr/consumers/matching/epg_matcher.py
@@ -46,6 +46,19 @@ _NON_EVENT = "sports non-event"
 _EVENT = "sports event"
 
 
+# Title tokens that mark a programme as a re-air or a highlights package
+# (#716). Category-based classification only works where the guide carries
+# Gracenote-style categories; UK feeds (Sky, TNT) tag nothing and put the
+# evidence in the title instead: "PL: Brighton v Leeds United Hlts",
+# "Serie A | Juventus v AC Milan" airing a day after the match as a replay.
+# Whole-word only — "classic" is deliberately absent (it is a real event word:
+# "Classic Boxing", "MLB Classic"), and so is "live", which names the opposite.
+_REPLAY_TITLE_RE = re.compile(
+    r"\b(?:hlts|highlights|replay|replays|encore|rerun|re-?air|as-live)\b",
+    re.IGNORECASE,
+)
+
+
 class EPGMatchPolicy(Enum):
     """Whether a program should be run through the matcher, based on categories.
 
@@ -60,15 +73,25 @@ class EPGMatchPolicy(Enum):
     SKIP_CLASSIC = "skip_classic"
 
 
-def classify_program_policy(categories: tuple[str, ...]) -> EPGMatchPolicy:
-    """Decide whether to attempt matching a program from its categories.
+def classify_program_policy(
+    categories: tuple[str, ...], title: str | None = None
+) -> EPGMatchPolicy:
+    """Decide whether to attempt matching a program from its categories and title.
 
     Precedence: SKIP_CLASSIC > SKIP_NON_EVENT > ATTEMPT. Classic wins because
     replays carry both "Sports event" and "Classic Sport Event".
 
-    Empty/unknown categories → ATTEMPT (fail safe via the match itself, never
-    fail open — a non-game simply won't extract two real teams in-window).
+    ``title`` (title and sub_title joined, #716) is a second, independent
+    source of the same verdict: a replay/highlights word anywhere in it is
+    SKIP_CLASSIC regardless of categories, because feeds that carry no
+    categories at all put that evidence in the title.
+
+    Empty/unknown categories and a clean title → ATTEMPT (fail safe via the
+    match itself, never fail open — a non-game simply won't extract two real
+    teams in-window).
     """
+    if title and _REPLAY_TITLE_RE.search(title):
+        return EPGMatchPolicy.SKIP_CLASSIC
     if not categories:
         return EPGMatchPolicy.ATTEMPT
     lowered = {c.strip().lower() for c in categories}
@@ -116,6 +139,7 @@ def should_attempt(program: DispatcharrProgram) -> bool:
 
     Requires a non-empty match input AND a non-skip category policy.
     """
-    if classify_program_policy(program.categories) is not EPGMatchPolicy.ATTEMPT:
+    title = " ".join(t for t in (program.title, program.sub_title) if t)
+    if classify_program_policy(program.categories, title) is not EPGMatchPolicy.ATTEMPT:
         return False
     return bool(build_match_input(program))

--- a/teamarr/consumers/matching/team_matcher.py
+++ b/teamarr/consumers/matching/team_matcher.py
@@ -2453,6 +2453,11 @@ class TeamMatcher:
                     classified=ctx.classified,
                     team1=canonical1,
                     team2=canonical2,
+                    # The EPG anchor must survive the retry (#716). Without it
+                    # the 90-minute gate that just rejected every candidate as
+                    # CANDIDATES_GATED is silently dropped, and a highlights or
+                    # replay programme binds to the live event hours earlier.
+                    anchor_dt=ctx.anchor_dt,
                     sport_durations=ctx.sport_durations,
                 )
 

--- a/tests/epg/test_epg_matcher_logic.py
+++ b/tests/epg/test_epg_matcher_logic.py
@@ -171,3 +171,36 @@ def test_should_attempt_true_for_generic_title_input():
 def test_should_attempt_false_when_match_input_empty():
     # truly nothing to match on
     assert should_attempt(_prog("", None)) is False
+
+
+# --- Title lexicon (#716): guides without categories name the replay in the title
+
+
+def test_highlights_token_in_title_is_skip_classic_without_categories():
+    # Sky's guide: no categories at all, the evidence is the trailing "Hlts".
+    assert (
+        classify_program_policy((), "PL: Brighton v Leeds United Hlts")
+        is EPGMatchPolicy.SKIP_CLASSIC
+    )
+
+
+def test_replay_token_beats_a_sports_event_category():
+    assert (
+        classify_program_policy(("Sports event",), "Serie A | Juventus v AC Milan Replay")
+        is EPGMatchPolicy.SKIP_CLASSIC
+    )
+
+
+def test_replay_words_are_whole_words_only():
+    # "Highlighted" and "Replayed" are not in the lexicon; "Classic" is a real
+    # event word ("Classic Boxing") and is deliberately not matched by title.
+    assert classify_program_policy((), "Classic Boxing: Ali v Frazier") is EPGMatchPolicy.ATTEMPT
+    highlighted = classify_program_policy((), "Highlighted Games: Cubs at Cardinals")
+    assert highlighted is EPGMatchPolicy.ATTEMPT
+    assert classify_program_policy((), "Live: Brighton v Leeds United") is EPGMatchPolicy.ATTEMPT
+
+
+def test_should_attempt_reads_title_and_sub_title_for_replay_words():
+    assert should_attempt(_prog(title="PL: Brighton v Leeds United Hlts", sub_title="")) is False
+    assert should_attempt(_prog(title="Serie A", sub_title="Juventus v AC Milan (Replay)")) is False
+    assert should_attempt(_prog(title="Serie A", sub_title="Juventus v AC Milan")) is True

--- a/tests/matching/test_reverse_alias_anchor.py
+++ b/tests/matching/test_reverse_alias_anchor.py
@@ -1,0 +1,100 @@
+"""The EPG anchor survives the reverse-alias retry (#716).
+
+Reporter's log: 'PL: Brighton v Leeds United Hlts' airing at 22:30 was bound to
+the 14:00 kick-off (Δ=510m). The primary pass correctly rejected every candidate
+as CANDIDATES_GATED — the 90-minute anchor gate did its job — and then the
+reverse-alias retry rebuilt the MatchContext without ``anchor_dt`` and matched
+with no time gate at all.
+"""
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from teamarr.consumers.matching.classifier import classify_stream
+from teamarr.consumers.matching.result import FailedReason
+from teamarr.consumers.matching.team_matcher import MatchContext
+from teamarr.core.types import Event, EventStatus, Team
+from tests.fakes import make_team_matcher
+
+TODAY = datetime.now(UTC).date()
+KICKOFF = datetime.combine(TODAY, datetime.min.time(), tzinfo=UTC) + timedelta(hours=14)
+
+
+def _team(name: str, abbr: str) -> Team:
+    return Team(
+        id=f"t-{abbr}",
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation=abbr,
+        league="eng.1",
+        sport="soccer",
+    )
+
+
+def _event() -> Event:
+    return Event(
+        id="401879290",
+        provider="espn",
+        name="Leeds United at Brighton & Hove Albion",
+        short_name="LEE @ BHA",
+        start_time=KICKOFF,
+        home_team=_team("Brighton & Hove Albion", "BHA"),
+        away_team=_team("Leeds United", "LEE"),
+        status=EventStatus(state="scheduled"),
+        league="eng.1",
+        sport="soccer",
+    )
+
+
+def _ctx(stream: str, anchor: datetime | None) -> MatchContext:
+    classified = classify_stream(stream)
+    return MatchContext(
+        stream_name=stream,
+        stream_id=2592,
+        group_id=1,
+        target_date=TODAY,
+        generation=1,
+        user_tz=ZoneInfo("UTC"),
+        classified=classified,
+        team1=classified.team1,
+        team2=classified.team2,
+        anchor_dt=anchor,
+    )
+
+
+STREAM = "PL: Brighton v Leeds United"
+EVENTS = [("eng.1", _event())]
+
+
+def test_reverse_alias_needed_the_builtin_alias_to_match_at_all():
+    """Control: 'Brighton' resolves only through the built-in alias table, so an
+    anchored programme at kick-off matches via the retry, not the primary pass."""
+    matcher = make_team_matcher()
+    ctx = _ctx(STREAM, KICKOFF + timedelta(minutes=5))
+    retry = matcher._try_reverse_alias_match(ctx, EVENTS, ["eng.1"])
+    assert retry is not None and retry.is_matched
+    assert retry.event is not None and retry.event.id == "401879290"
+
+
+def test_primary_pass_gates_a_programme_hours_after_kickoff():
+    matcher = make_team_matcher()
+    ctx = _ctx(STREAM, KICKOFF + timedelta(hours=8, minutes=30))
+    primary = matcher._match_against_multi_league_events(ctx, EVENTS)
+    assert primary.failed_reason is FailedReason.CANDIDATES_GATED
+
+
+def test_reverse_alias_retry_keeps_the_anchor_gate():
+    """The retry must not bind the 22:30 highlights slot to the 14:00 kick-off."""
+    matcher = make_team_matcher()
+    ctx = _ctx(STREAM, KICKOFF + timedelta(hours=8, minutes=30))
+    retry = matcher._try_reverse_alias_match(ctx, EVENTS, ["eng.1"])
+    assert retry is None or not retry.is_matched
+
+
+def test_unanchored_name_path_is_unchanged():
+    """A plain stream name (no EPG anchor) still matches through the retry."""
+    matcher = make_team_matcher()
+    ctx = _ctx(STREAM, None)
+    retry = matcher._try_reverse_alias_match(ctx, EVENTS, ["eng.1"])
+    assert retry is not None and retry.is_matched


### PR DESCRIPTION
Closes nothing yet — #716 gets `status: on-dev` at merge and closes at release.

## What was wrong
The EPG path's 90-minute anchor gate rejected every candidate correctly (`candidates_gated`), then `_try_reverse_alias_match` rebuilt the `MatchContext` **without `anchor_dt`** and matched with no time gate at all. That is how `PL: Brighton v Leeds United Hlts` at 22:30 bound to the 14:00 kick-off (Δ=510m), and `Serie A | Juventus v AC Milan` a day after the match (Δ=1695m).

## Fix
- Carry `anchor_dt` into the retry context (one line). Regression test fails on dev, passes here.
- `classify_program_policy` now also reads `title|sub_title` for a replay/highlights word (`hlts`, `highlights`, `replay`, `encore`, `rerun`, `re-air`, `as-live`) → `SKIP_CLASSIC`. Guides without categories (Sky, TNT) put the evidence in the title. Whole-word only; `classic` and `live` deliberately excluded.
- Docs: `docs/guide/matching/program-matching.md`.

## Gates
ruff clean · 3,022 tests passed · frontend build ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg