### PR TITLE
fix(matching): one lookback for every match method — EPG window reads MATCH_WINDOW_DAYS (#744)

### DIFF
--- a/docs/reference/architecture/database.md
+++ b/docs/reference/architecture/database.md
@@ -55,7 +55,7 @@ The settings table is a single row with 133 columns, organized into these groups
 |--------|---------|-------------|
 | `team_schedule_days_ahead` | 30 | Days to fetch for `.next` variables |
 | `event_match_days_ahead` | 3 | Event matching window forward |
-| `event_match_days_back` | 7 | Event matching window backward |
+| `event_match_days_back` | 7 | Retired (#744) — unread; every match method looks back `MATCH_WINDOW_DAYS` (30) |
 | `epg_output_days_ahead` | 14 | Days in XMLTV output |
 | `epg_lookback_hours` | 6 | Check for in-progress games |
 

--- a/teamarr/consumers/event_group_processor/matching.py
+++ b/teamarr/consumers/event_group_processor/matching.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING, Any
 from teamarr.consumers.event_group_processor.stream_fetcher import (
     managed_channel_ids,
 )
-from teamarr.consumers.matching import BatchMatchResult, StreamCategory, StreamMatcher
+from teamarr.consumers.matching import (
+    MATCH_WINDOW_DAYS,
+    BatchMatchResult,
+    StreamCategory,
+    StreamMatcher,
+)
 from teamarr.consumers.matching.epg_resolver import (
     EpgCatalogIndex,
     build_epg_catalog_index,
@@ -112,7 +117,7 @@ class StreamMatching:
             row = conn.execute(
                 "SELECT include_final_events, "
                 "epg_xtream_fallback_enabled, epg_xtream_cache_hours, "
-                "event_match_days_back, event_match_days_ahead, "
+                "event_match_days_ahead, "
                 "tennis_majors_only "
                 "FROM settings WHERE id = 1"
             ).fetchone()
@@ -121,7 +126,6 @@ class StreamMatching:
             )
             xtream_fallback = bool(row["epg_xtream_fallback_enabled"]) if row else False
             xtream_cache_hours = (row["epg_xtream_cache_hours"] if row else 24) or 24
-            match_days_back = (row["event_match_days_back"] if row else 7) or 7
             match_days_ahead = (row["event_match_days_ahead"] if row else 3) or 3
             tennis_majors_only = bool(row["tennis_majors_only"]) if row else False
 
@@ -140,7 +144,7 @@ class StreamMatching:
         # epg_index is None → matcher behaves exactly as before.
         epg_index = self._build_epg_index(
             group, streams, target_date,
-            match_days_back, match_days_ahead, xtream_fallback,
+            match_days_ahead, xtream_fallback,
             xtream_cache_hours,
         )
 
@@ -207,7 +211,6 @@ class StreamMatching:
         group,
         streams: list[dict],
         target_date: date,
-        match_days_back: int,
         match_days_ahead: int,
         xtream_fallback: bool = False,
         xtream_cache_hours: int = 24,
@@ -256,10 +259,14 @@ class StreamMatching:
         )
 
         # Window mirrors the event match window so programs overlapping any
-        # candidate event are indexed. Localize to the user's timezone before
-        # converting to UTC (to_utc rejects naive datetimes).
+        # candidate event are indexed. The back edge is the same MATCH_WINDOW_DAYS
+        # the name matcher uses (#744): one lookback for every match method,
+        # hidden and hardcoded by design — this used to read the retired
+        # event_match_days_back column and silently disagreed (7 vs 30).
+        # Localize to the user's timezone before converting to UTC (to_utc
+        # rejects naive datetimes).
         day_start = datetime.combine(target_date, time.min, tzinfo=get_user_timezone())
-        window_start = to_utc(day_start - timedelta(days=match_days_back))
+        window_start = to_utc(day_start - timedelta(days=MATCH_WINDOW_DAYS))
         window_end = to_utc(day_start + timedelta(days=match_days_ahead + 1))
 
         try:

--- a/teamarr/database/schema.sql
+++ b/teamarr/database/schema.sql
@@ -166,7 +166,7 @@ CREATE TABLE IF NOT EXISTS settings (
     -- Look Ahead Settings
     team_schedule_days_ahead INTEGER DEFAULT 30,    -- How far to fetch team schedules (for .next vars, conditionals)
     event_match_days_ahead INTEGER DEFAULT 3,       -- Event-stream matching window forward (Event Groups only)
-    event_match_days_back INTEGER DEFAULT 7,        -- Event-stream matching window backward (for weekly sports like NFL)
+    event_match_days_back INTEGER DEFAULT 7,        -- RETIRED (Jan 2026, #744): unread. Lookback is MATCH_WINDOW_DAYS for every match method
     epg_output_days_ahead INTEGER DEFAULT 14,       -- Days to include in final XMLTV
     epg_lookback_hours INTEGER DEFAULT 6,           -- Check for in-progress games
 

--- a/tests/epg/test_epg_window_lookback.py
+++ b/tests/epg/test_epg_window_lookback.py
@@ -1,0 +1,74 @@
+"""One lookback for every match method (#744).
+
+The name matcher has always looked back ``MATCH_WINDOW_DAYS`` (30) so past
+games keep feeding stats. The EPG programme window was meant to mirror it but
+read the retired ``event_match_days_back`` column (default 7) instead, so the
+two paths silently disagreed and the column — invisible in the UI and API since
+January 2026 — still steered one of them. The window now derives from the same
+constant and the column is unread.
+"""
+
+from datetime import date, datetime, time, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+from teamarr.consumers.event_group_processor import matching as matching_mod
+from teamarr.consumers.event_group_processor.matching import StreamMatching
+from teamarr.consumers.matching import MATCH_WINDOW_DAYS
+from teamarr.consumers.matching.epg_index import EPGProgramIndex
+
+TARGET = date(2026, 9, 10)
+UTC = ZoneInfo("UTC")
+
+
+class _Harness(StreamMatching):
+    def __init__(self):
+        self._dispatcharr_client = SimpleNamespace(epg=object())
+
+    def _epg_resolution_inputs(self):
+        return SimpleNamespace(
+            epg_data_list=[],
+            stream_channels={},
+            active_source_ids=set(),
+            channel_by_uuid={},
+            own_source_id=None,
+            catalog=None,
+        )
+
+
+def _capture_window(monkeypatch):
+    seen: dict[str, datetime] = {}
+
+    def fake_build(_epg, _resolution, window_start, window_end):
+        seen["start"], seen["end"] = window_start, window_end
+        return EPGProgramIndex({})
+
+    monkeypatch.setattr(EPGProgramIndex, "build", staticmethod(fake_build))
+    monkeypatch.setattr(
+        "teamarr.consumers.matching.epg_resolver.resolve_program_tvg_ids",
+        lambda *a, **k: ({"espn.us": "1"}, None),
+    )
+    monkeypatch.setattr(matching_mod, "get_user_timezone", lambda: UTC)
+    return seen
+
+
+def test_epg_programme_window_looks_back_match_window_days(monkeypatch):
+    seen = _capture_window(monkeypatch)
+    group = SimpleNamespace(id=1, epg_match_enabled=True)
+
+    _Harness()._build_epg_index(group, [{"tvg_id": "espn.us"}], TARGET, 3)
+
+    day_start = datetime.combine(TARGET, time.min, tzinfo=UTC)
+    assert seen["start"] == day_start - timedelta(days=MATCH_WINDOW_DAYS)
+    assert seen["end"] == day_start + timedelta(days=3 + 1)
+    assert MATCH_WINDOW_DAYS == 30
+
+
+def test_settings_query_no_longer_reads_the_retired_column():
+    import inspect
+
+    # A quoted occurrence is SQL or a row lookup; the comment naming the
+    # retired column is allowed to stay.
+    source = inspect.getsource(StreamMatching)
+    assert '"event_match_days_back' not in source
+    assert "event_match_days_back," not in source


### PR DESCRIPTION
`event_match_days_back` was retired from the UI and API in Jan 2026 (3ea937d5) and the name matcher has looked back `MATCH_WINDOW_DAYS` (30) ever since, so past games keep feeding stats. The EPG programme window, added later, still read the orphaned column (default 7) — the two paths silently disagreed and a setting nobody could edit steered one of them.

Decision (maintainer, 2026-09-10): one lookback for every match method, hidden and hardcoded. Both paths now derive from the same constant. The column stays in the schema, marked retired and unread (settings-registry parity tests keep it aligned).

- `event_group_processor/matching.py`: settings query and `_build_epg_index` no longer read the column; window back edge = `MATCH_WINDOW_DAYS`.
- `schema.sql` comment + `docs/reference/architecture/database.md` row mark it retired.
- `tests/epg/test_epg_window_lookback.py` pins the back edge to the constant and that the column is unread.

Gates: ruff clean · 3,016 tests passed · frontend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg