### PR TITLE
fix(sources): remember list filters and sort across edit-and-back (#552)

### DIFF
--- a/frontend/src/hooks/usePersistentState.ts
+++ b/frontend/src/hooks/usePersistentState.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react"
+
+/**
+ * useState persisted to sessionStorage under the `teamarr.` namespace (#552).
+ *
+ * For list controls — filters, sort — that should survive navigating to a
+ * detail page and back but need not outlive the tab: sessionStorage is
+ * per-tab and cleared when it closes, so a stale filter never greets the
+ * next visit. Falls back to plain in-memory state when storage is
+ * unavailable (private windows, blocked site data). Values are JSON; a
+ * value that fails to parse is treated as absent.
+ */
+export function usePersistentState<T>(key: string | null | undefined, defaultValue: T) {
+  const storageKey = key ? `teamarr.${key}` : null
+
+  const [value, setValue] = useState<T>(() => {
+    if (!storageKey) return defaultValue
+    try {
+      const raw = sessionStorage.getItem(storageKey)
+      return raw === null ? defaultValue : (JSON.parse(raw) as T)
+    } catch {
+      return defaultValue
+    }
+  })
+
+  useEffect(() => {
+    if (!storageKey) return
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify(value))
+    } catch {
+      /* ignore — non-persistent fallback */
+    }
+  }, [storageKey, value])
+
+  return [value, setValue] as const
+}

--- a/frontend/src/hooks/useTableSort.ts
+++ b/frontend/src/hooks/useTableSort.ts
@@ -1,4 +1,6 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { usePersistentState } from "@/hooks/usePersistentState"
 
 export type SortDirection = "asc" | "desc"
 
@@ -17,6 +19,17 @@ interface UseTableSortOptions<Row, Col extends string> {
    * field). Omit to keep the input order.
    */
   defaultCompare?: (a: Row, b: Row) => number
+  /**
+   * Remember the sort for the tab's lifetime under `teamarr.<persistKey>.sort`
+   * (#552), so leaving for a detail page and coming back keeps it. Omit for
+   * plain in-memory state.
+   */
+  persistKey?: string
+}
+
+interface SortState<Col extends string> {
+  column: Col | null
+  direction: SortDirection
 }
 
 /**
@@ -27,32 +40,33 @@ export function useTableSort<Row, Col extends string>({
   comparators,
   cycleToNull = false,
   defaultCompare,
+  persistKey,
 }: UseTableSortOptions<Row, Col>) {
-  const [sortColumn, setSortColumn] = useState<Col | null>(null)
-  const [sortDirection, setSortDirection] = useState<SortDirection>("asc")
+  const [sort, setSort] = usePersistentState<SortState<Col>>(
+    persistKey ? `${persistKey}.sort` : null,
+    { column: null, direction: "asc" }
+  )
+  const { column: sortColumn, direction: sortDirection } = sort
 
   const handleSort = useCallback(
     (column: Col) => {
       if (sortColumn !== column) {
-        setSortColumn(column)
-        setSortDirection("asc")
+        setSort({ column, direction: "asc" })
       } else if (sortDirection === "asc") {
-        setSortDirection("desc")
+        setSort({ column, direction: "desc" })
       } else if (cycleToNull) {
-        setSortColumn(null)
-        setSortDirection("asc")
+        setSort({ column: null, direction: "asc" })
       } else {
-        setSortDirection("asc")
+        setSort({ column, direction: "asc" })
       }
     },
-    [sortColumn, sortDirection, cycleToNull]
+    [sortColumn, sortDirection, cycleToNull, setSort]
   )
 
   /** Clear the column sort, returning to the default ordering. */
   const clearSort = useCallback(() => {
-    setSortColumn(null)
-    setSortDirection("asc")
-  }, [])
+    setSort({ column: null, direction: "asc" })
+  }, [setSort])
 
   const sortedRows = useMemo(() => {
     const result = [...rows]

--- a/frontend/src/pages/EventGroups.tsx
+++ b/frontend/src/pages/EventGroups.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/components/ui/dialog"
 import { FilterSelect } from "@/components/ui/filter-select"
 import { ConfirmDialog } from "@/components/ui/confirm-dialog"
+import { usePersistentState } from "@/hooks/usePersistentState"
 import { useTableSort } from "@/hooks/useTableSort"
 import { useRowSelection } from "@/hooks/useRowSelection"
 import { Input } from "@/components/ui/input"
@@ -127,9 +128,13 @@ export function EventGroups() {
   const [clearCacheConfirm, setClearCacheConfirm] = useState<EventGroup | null>(null)
   const [showBulkClearCache, setShowBulkClearCache] = useState(false)
 
-  // Filter state
-  const [nameFilter, setNameFilter] = useState("")
-  const [statusFilter, setStatusFilter] = useState<"" | "enabled" | "disabled">("")
+  // Filter state — remembered for the tab's lifetime so editing a source and
+  // coming back does not reset the list (#552).
+  const [nameFilter, setNameFilter] = usePersistentState("sources.list.name", "")
+  const [statusFilter, setStatusFilter] = usePersistentState<"" | "enabled" | "disabled">(
+    "sources.list.status",
+    ""
+  )
 
   const [deleteConfirm, setDeleteConfirm] = useState<EventGroup | null>(null)
   const [showBulkDelete, setShowBulkDelete] = useState(false)
@@ -155,6 +160,7 @@ export function EventGroups() {
       comparators: SORT_COMPARATORS,
       cycleToNull: true,
       defaultCompare: BY_SORT_ORDER,
+      persistKey: "sources.list",
     })
 
   const isDndActive = sortColumn === null


### PR DESCRIPTION
Name filter, status filter and column sort on the Sources page lived in component state and reset on every navigation to a source's edit page (#552, @FractalBoy).

- New `usePersistentState` hook: `useState` persisted to **sessionStorage** under `teamarr.*` — survives edit-and-back, cleared when the tab closes, in-memory fallback when storage is blocked.
- `useTableSort` gains an optional `persistKey` (column + direction as one JSON value; `cycleToNull` and `clearSort` go through the same setter).
- `EventGroups.tsx` wires the two filters and the sort to `sources.list.*`.

Gates: `tsc --noEmit` clean · `npm run build` ok · ESLint clean on the three files. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg