### PR TITLE
refactor(templates): public preview variables are raw provider values or {generated_preview} only (#613)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 ## Key Subsystems
 
 **Template Engine** (`teamarr/templates/`):
-- 258 variables in `variables/` (20 categories); chainable `|filter` transforms in `filters.py` (lower/upper/title/pascal/slug/urlencode) with permanent legacy aliases for 10 retired transform variables
+- 266 variables in `variables/` (20 categories); chainable `|filter` transforms in `filters.py` (lower/upper/title/pascal/slug/urlencode) with permanent legacy aliases for 10 retired transform variables
 - 33 condition evaluators in `conditions.py`
 - Suffix rules: `.next`, `.last` for multi-game scenarios
 - Template scope: each variable is tagged `TemplateScope.ALL` / `TEAM_ONLY` / `EVENT_ONLY` — gates variable picker by template type via `GET /variables?template_type=…`

--- a/docs/guide/epg/variables.md
+++ b/docs/guide/epg/variables.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Template Variables
 
-Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 258 variables across 20 categories, plus [filters](#filters-transforming-variable-values) that transform any variable's value.
+Templates use variables enclosed in curly braces that get replaced with real data when EPG is generated. Teamarr provides 266 variables across 20 categories, plus [filters](#filters-transforming-variable-values) that transform any variable's value.
 
 ## Team vs Event Templates
 
@@ -455,16 +455,6 @@ Provider editorial/context copy for a game, passed through raw. These are **spar
 | `{game_preview}` | Pregame preview blurb. Empty once a game is final (use `{game_recap}` then) | base, .next, .last | `Toronto Blue Jays (35-38) vs. Boston Red Sox` |
 | `{generated_preview}` | Opt-in sport-specific preview for baseball, football, and basketball, with a generic matchup sentence for other sports; composed from public fields and never betting information | base, .next, .last | `The Packers visit the Broncos at Empower Field...` |
 | `{week}` | Provider-reported football week number | base, .next, .last | `3` |
-| `{home_probable_starter}` / `{away_probable_starter}` | Baseball probable starter with ESPN-reported record and ERA | base, .next, .last | `M. Boyd (8-2, 4.02 ERA)` |
-| `{home_home_runs_leader}` / `{away_home_runs_leader}` | Exact home-run leader fact | base, .next, .last | `S. Ohtani — 30 home runs` |
-| `{home_batting_average_leader}` / `{away_batting_average_leader}` | Exact batting-average leader fact | base, .next, .last | `R. Arozarena — .272 batting average` |
-| `{home_rbi_leader}` / `{away_rbi_leader}` | Exact RBI leader fact | base, .next, .last | `J. Ramírez — 82 RBI` |
-| `{home_passing_leader}` / `{away_passing_leader}` | Exact football passing-leader fact | base, .next, .last | `B. Nix — 18/25, 246 YDS` |
-| `{home_rushing_leader}` / `{away_rushing_leader}` | Exact football rushing-leader fact | base, .next, .last | `J. Dobbins — 12 CAR, 68 YDS` |
-| `{home_receiving_leader}` / `{away_receiving_leader}` | Exact football receiving-leader fact | base, .next, .last | `C. Sutton — 6 REC, 84 YDS` |
-| `{home_points_leader}` / `{away_points_leader}` | Exact basketball points leader fact | base, .next, .last | `K. Cardoso — 14.7 points per game` |
-| `{home_rebounds_leader}` / `{away_rebounds_leader}` | Exact basketball rebounds leader fact | base, .next, .last | `K. Cardoso — 8.8 rebounds per game` |
-| `{home_assists_leader}` / `{away_assists_leader}` | Exact basketball assists leader fact | base, .next, .last | `N. Cloud — 5.0 assists per game` |
 | `{home_total_yards_per_game}` / `{away_total_yards_per_game}` | Football team total yards per game | base, .next, .last | `360` |
 | `{home_rushing_yards_per_game}` / `{away_rushing_yards_per_game}` | Football team rushing yards per game | base, .next, .last | `162` |
 | `{home_points_allowed_per_game}` / `{away_points_allowed_per_game}` | Basketball points allowed per game | base, .next, .last | `87.0` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ EPG:     Kansas City Chiefs @ Philadelphia Eagles
 
 - **176 pre-configured leagues across 15 sports**, plus ~228 more soccer leagues discovered live from ESPN — football, basketball, hockey, baseball, soccer, cricket, lacrosse, MMA, boxing, rugby, volleyball, Australian football, softball, racing (F1, NASCAR, IndyCar, IMSA, WEC), and tennis (ATP, WTA)
 - **Custom leagues** — add any competition from TheSportsDB (premium key required)
-- **258 template variables + chainable filters** — customize channel names and EPG with records, scores, venues, broadcasts, standings, playoff status, motorsports sessions, tennis context, and more
+- **266 template variables + chainable filters** — customize channel names and EPG with records, scores, venues, broadcasts, standings, playoff status, motorsports sessions, tennis context, and more
 - **Flexible matching** — stream-name matching, team streams, and EPG program matching per source; aliases, fuzzy matching, and custom regex extractors for inconsistent IPTV naming
 - **Channel management** — automatic create/update/delete lifecycle, numbering strategies, consolidation, feed separation, and stream priority rules
 - **Dynamic groups & profiles** — use existing Dispatcharr groups/profiles or create them on the fly with `{sport}` / `{league}` wildcards

--- a/docs/reference/architecture/template-engine.md
+++ b/docs/reference/architecture/template-engine.md
@@ -7,13 +7,13 @@ nav_order: 6
 
 # Template Engine
 
-The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 258 variables across 20 categories (plus chainable `|filter` value transforms), 33 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
+The template engine resolves `{variable}` placeholders in EPG titles, descriptions, and filler content. It supports 266 variables across 20 categories (plus chainable `|filter` value transforms), 33 condition evaluators, suffix rules for multi-game context, and template-type scoping for the variable picker.
 
 ## Architecture
 
 ```
 TemplateResolver
-  ├── VariableRegistry (258 variables, 20 categories)
+  ├── VariableRegistry (266 variables, 20 categories)
   ├── ConditionEvaluator (33 evaluators)
   └── ContextBuilder (Event + Team → TemplateContext)
 ```
@@ -234,7 +234,7 @@ optimistic layer while the debounced server render is in flight.
 | `templates/conditions.py` | 33 condition evaluators |
 | `templates/context.py` | Context dataclasses (Odds, GameContext, TemplateContext) |
 | `templates/context_builder.py` | Build TemplateContext from Event + Team |
-| `templates/variables/` | 20 category modules with 258 variable definitions |
+| `templates/variables/` | 20 category modules with 266 variable definitions |
 | `templates/variables/registry.py` | VariableRegistry singleton |
 | `templates/filters.py` | Chainable filter transforms (legacy aliases live in `resolver.py`) |
 | `templates/validation.py` | Template validation |

--- a/teamarr/providers/espn/preview.py
+++ b/teamarr/providers/espn/preview.py
@@ -115,32 +115,6 @@ def _parse_week(raw: Any) -> int | None:
         return None
 
 
-def _expand_team_abbreviations(summary: str, competition: dict, event: Event) -> str:
-    """Replace ESPN team codes in matchup prose with full display names."""
-    replacements: dict[str, str] = {}
-    for competitor in competition.get("competitors") or []:
-        team = competitor.get("team") or {}
-        abbreviation = str(team.get("abbreviation") or "").strip()
-        display_name = str(team.get("displayName") or "").strip()
-        if abbreviation and display_name:
-            replacements[abbreviation.casefold()] = display_name
-    for team in (event.home_team, event.away_team):
-        if team.abbreviation and team.name:
-            replacements.setdefault(team.abbreviation.casefold(), team.name)
-    if not replacements:
-        return summary
-    aliases = "|".join(
-        re.escape(abbreviation)
-        for abbreviation in sorted(replacements, key=len, reverse=True)
-    )
-    return re.sub(
-        rf"(?<![\w])(?:{aliases})(?![\w])",
-        lambda match: replacements[match.group(0).casefold()],
-        summary,
-        flags=re.IGNORECASE,
-    )
-
-
 def _leader_blocks(data: dict, competition: dict) -> list[dict]:
     """Return summary leaders, falling back to competitor-scoped leaders."""
     if data.get("leaders"):
@@ -222,6 +196,7 @@ def apply_generated_preview_fields(data: dict[str, Any], event: Event) -> None:
         (item for item in series_options if item.get("type") == "season"), None
     )
     if series and series.get("summary"):
-        event.series_summary = _expand_team_abbreviations(
-            str(series["summary"]), competition, event
-        )
+        # Raw provider text — {series_summary} is a public variable and public
+        # variables are never rewritten by our code (#613). The prose builder
+        # expands team codes for readability on its own copy.
+        event.series_summary = str(series["summary"])

--- a/teamarr/templates/generated_preview.py
+++ b/teamarr/templates/generated_preview.py
@@ -172,6 +172,28 @@ def _football_leader_prose(value: str, role: str) -> str:
     return f"{name} — {detail}" if detail else name
 
 
+def _expand_team_abbreviations(summary: str, event: Event) -> str:
+    """Replace ESPN team codes ("BOS leads 2-1") with full names in prose.
+
+    Applied only to the prose builder's copy: the {series_summary} variable
+    itself stays the provider's raw text (#613).
+    """
+    replacements = {
+        team.abbreviation.casefold(): team.name
+        for team in (event.home_team, event.away_team)
+        if team.abbreviation and team.name
+    }
+    if not replacements:
+        return summary
+    aliases = "|".join(re.escape(code) for code in sorted(replacements, key=len, reverse=True))
+    return re.sub(
+        rf"(?<![\w])(?:{aliases})(?![\w])",
+        lambda match: replacements[match.group(0).casefold()],
+        summary,
+        flags=re.IGNORECASE,
+    )
+
+
 def _series_clause(value: str) -> str:
     """Turn ESPN's compact series summary into a grammatical clause."""
     summary = value.strip().rstrip(".")
@@ -211,7 +233,7 @@ def _base_sentence(event: Event) -> str:
         phase = "preseason " if event.season_type == "preseason" else ""
         return f"The {away} visit the {home}{location} for a Week {event.week} {phase}matchup."
     if event.sport == "baseball" and event.series_summary:
-        summary = _series_clause(event.series_summary)
+        summary = _series_clause(_expand_team_abbreviations(event.series_summary, event))
         return f"The {away} visit the {home}{location}, with {summary}."
     return f"The {away} visit the {home}{location}."
 

--- a/teamarr/templates/variables/generated_preview.py
+++ b/teamarr/templates/variables/generated_preview.py
@@ -1,4 +1,4 @@
-"""Public typed facts used by the optional generated-preview formatter."""
+"""Raw typed facts exposed as variables, plus the optional generated preview."""
 
 from teamarr.templates.context import GameContext, TemplateContext
 from teamarr.templates.generated_preview import build_generated_preview
@@ -24,53 +24,24 @@ def _register_event_field(name: str, description: str, sample: str) -> None:
     )(extract)
 
 
+# Public variables are raw provider values passed through unchanged, or the
+# final {generated_preview} — never a string our own code composed (maintainer
+# policy, 2026-09-10, #613). The leader and probable-starter facts are
+# "Name — value label" strings assembled by the ESPN parser, so they stay
+# internal inputs to the prose builder and are deliberately NOT registered.
 _FIELD_DEFINITIONS = {
     "week": ("Provider-reported week number; empty when unavailable", "3"),
-    "home_probable_starter": (
-        "Home probable starter and ESPN-reported record/ERA",
-        "M. Boyd (8-2, 4.02 ERA)",
-    ),
-    "away_probable_starter": (
-        "Away probable starter and ESPN-reported record/ERA",
-        "L. Gilbert (10-5, 1.01 ERA)",
-    ),
-    "home_home_runs_leader": ("Home team home-run leader", "S. Ohtani — 30 home runs"),
-    "away_home_runs_leader": ("Away team home-run leader", "P. Crow-Armstrong — 31 home runs"),
-    "home_batting_average_leader": (
-        "Home team batting-average leader",
-        "R. Arozarena — .272 batting average",
-    ),
-    "away_batting_average_leader": (
-        "Away team batting-average leader",
-        "S. Kwan — .301 batting average",
-    ),
-    "home_rbi_leader": ("Home team RBI leader", "J. Ramírez — 82 RBI"),
-    "away_rbi_leader": ("Away team RBI leader", "K. Tucker — 75 RBI"),
-    "home_passing_leader": ("Home team passing leader", "B. Nix — 18/25, 246 YDS"),
-    "away_passing_leader": ("Away team passing leader", "J. Love — 17/24, 221 YDS"),
-    "home_rushing_leader": ("Home team rushing leader", "J. Dobbins — 12 CAR, 68 YDS"),
-    "away_rushing_leader": ("Away team rushing leader", "J. Jacobs — 14 CAR, 73 YDS"),
-    "home_receiving_leader": ("Home team receiving leader", "C. Sutton — 6 REC, 84 YDS"),
-    "away_receiving_leader": ("Away team receiving leader", "J. Reed — 5 REC, 79 YDS"),
     "home_total_yards_per_game": ("Home team total yards per game", "360"),
     "away_total_yards_per_game": ("Away team total yards per game", "204"),
     "home_rushing_yards_per_game": ("Home team rushing yards per game", "162"),
     "away_rushing_yards_per_game": ("Away team rushing yards per game", "63"),
-    "home_points_leader": ("Home team points-per-game leader", "L. Lacan — 11.6 points per game"),
-    "away_points_leader": ("Away team points-per-game leader", "K. Cardoso — 14.7 points per game"),
-    "home_rebounds_leader": (
-        "Home team rebounds-per-game leader",
-        "O. Nelson-Ododa — 5.9 rebounds per game",
-    ),
-    "away_rebounds_leader": (
-        "Away team rebounds-per-game leader",
-        "K. Cardoso — 8.8 rebounds per game",
-    ),
-    "home_assists_leader": ("Home team assists-per-game leader", "L. Lacan — 4.6 assists per game"),
-    "away_assists_leader": ("Away team assists-per-game leader", "N. Cloud — 5.0 assists per game"),
     "home_points_allowed_per_game": ("Home team points allowed per game", "87.0"),
     "away_points_allowed_per_game": ("Away team points allowed per game", "89.9"),
 }
+
+# Raw preview fields that ARE public variables (the rest of
+# GENERATED_PREVIEW_FIELDS feed {generated_preview} only).
+PUBLIC_PREVIEW_FIELDS: frozenset[str] = frozenset(_FIELD_DEFINITIONS)
 
 for _name, (_description, _sample) in _FIELD_DEFINITIONS.items():
     _register_event_field(_name, _description, _sample)

--- a/tests/templates/test_generated_preview.py
+++ b/tests/templates/test_generated_preview.py
@@ -10,8 +10,14 @@ from teamarr.providers.espn.preview import apply_generated_preview_fields
 from teamarr.services.sports_data import SportsDataService
 from teamarr.templates.conditions import ConditionEvaluator
 from teamarr.templates.context import GameContext, TeamChannelContext, TemplateContext
-from teamarr.templates.generated_preview import build_generated_preview
-from teamarr.templates.variables.generated_preview import extract_generated_preview
+from teamarr.templates.generated_preview import (
+    _expand_team_abbreviations,
+    build_generated_preview,
+)
+from teamarr.templates.variables.generated_preview import (
+    PUBLIC_PREVIEW_FIELDS,
+    extract_generated_preview,
+)
 from teamarr.templates.variables.registry import get_registry
 from tests.fakes import FakeCache
 
@@ -161,7 +167,9 @@ def test_baseball_parser_populates_exact_public_fields():
     assert event.away_home_runs_leader == "Willson Contreras — 26 home runs"
     assert event.home_batting_average_leader == "Otto Lopez — .307 batting average"
     assert event.away_rbi_leader == "Willson Contreras — 78 RBI"
-    assert event.series_summary == "Boston Red Sox leads 2-1"
+    # The public variable keeps ESPN's raw text; only the prose expands codes (#613).
+    assert event.series_summary == "BOS leads 2-1"
+    assert _expand_team_abbreviations(event.series_summary, event) == "Boston Red Sox leads 2-1"
     assert not hasattr(event, "pickcenter")
 
 
@@ -365,20 +373,23 @@ def test_basketball_parser_and_renderer_include_all_secondary_stats():
     assert "Olivia Nelson-Ododa with 5.9 rebounds per game" in text
 
 
-def test_named_variables_are_exact_and_generated_preview_is_opt_in():
+def test_composed_facts_are_not_public_variables_but_feed_the_preview():
+    """Policy (#613): a public variable is a raw provider value or the final
+    {generated_preview}. "Name — value label" strings are assembled by our
+    parser, so they are prose inputs only."""
     event = _event(
         away_home_runs_leader="Willson Contreras — 26 home runs",
         away_probable_starter="Payton Tolle (8-6, 3.08 ERA)",
+        week=3,
     )
     ctx, game = _context(event)
     registry = get_registry()
 
-    assert registry.get("away_home_runs_leader").extractor(ctx, game) == (
-        "Willson Contreras — 26 home runs"
-    )
-    assert registry.get("away_probable_starter").extractor(ctx, game) == (
-        "Payton Tolle (8-6, 3.08 ERA)"
-    )
+    assert registry.get("away_home_runs_leader") is None
+    assert registry.get("away_probable_starter") is None
+    assert registry.get("week").extractor(ctx, game) == "3"
+    assert "Willson Contreras" in build_generated_preview(event)
+    assert "Payton Tolle" in build_generated_preview(event)
     assert extract_generated_preview(ctx, game) == build_generated_preview(event)
     assert ConditionEvaluator().evaluate("has_generated_preview", None, ctx, game)
 
@@ -421,6 +432,11 @@ def test_generated_preview_field_registry_cache_and_refresh_parity():
         assert serialized[field_name] == expected
         assert getattr(restored, field_name) == expected
         assert getattr(refreshed, field_name) == expected
+        # Composed "Name — value label" strings are prose inputs only (#613);
+        # raw fields are public either here or via an older variable.
+        composed = field_name.endswith(("_leader", "_probable_starter"))
+        assert (registry.get(field_name) is None) == composed
+    for field_name in PUBLIC_PREVIEW_FIELDS:
         assert registry.get(field_name) is not None
 
 


### PR DESCRIPTION
Maintainer follow-up to #587 (merged 9d00eb69). Policy decided 2026-09-10: a template variable is either a value we receive and pass through unchanged, or the final `{generated_preview}` — never a string our own code composed.

- The 18 `*_leader` and 2 `*_probable_starter` fields ("Name — value label", assembled by the ESPN parser) are no longer registered as variables. They stay on `Event` as inputs to the prose builder, so `{generated_preview}` output is unchanged. Registry 286 → **266**.
- `{series_summary}` is ESPN's raw text again; the team-code expansion moved into the prose builder and applies to its own copy.
- Docs: composed-variable rows removed from the variables guide; count claims updated in `docs/index.md`, `docs/guide/epg/variables.md`, `docs/reference/architecture/template-engine.md` (×3) and `CLAUDE.md`.
- Tests: parity test asserts composed fields are *not* registered and every public raw field is; parser test pins the raw series summary and the prose-side expansion.

Gates: ruff clean · 3,043 tests passed · frontend build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg