### PR TITLE
feat(sources): bulk edit covers subscription override, stream filters and custom regex (#551)

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -41,7 +41,7 @@ The Sources page header shows an overall **X% matched** summary and the **Add St
 | **Status** | Enable/disable toggle |
 | **Actions** | Preview matches, clear cache, edit, delete |
 
-Column headers sort, and a filter row narrows the list by name and status. Selecting rows raises a bulk action bar: **Enable**, **Disable**, **Clear Cache**, **Edit** (bulk-edit shared settings), and **Delete**. When stale sources exist, a **Delete all stale** action appears.
+Column headers sort, and a filter row narrows the list by name and status. Selecting rows raises a bulk action bar: **Enable**, **Disable**, **Clear Cache**, **Edit** (bulk-edit shared settings), and **Delete**. Bulk **Edit** covers the stream timezone, the team filter, the three matching toggles, the subscription (league) override, the built-in-filter skip, the stream include/exclude regexes and every custom regex — only the fields you check are changed, and setting a pattern in bulk also switches it on while clearing it switches it off. When stale sources exist, a **Delete all stale** action appears.
 
 To see *which* streams matched or failed (and fix failures manually), use the **Matched**/**Failed** drill-downs in the [Dashboard](../dashboard)'s run history — the Sources table shows rates, not per-stream detail. The per-source **preview** button shows current stream matches without running a full generation.
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -202,6 +202,29 @@ export interface BulkGroupUpdateRequest {
   clear_subscription_leagues?: boolean
   clear_subscription_soccer_mode?: boolean
   clear_subscription_soccer_followed_teams?: boolean
+  // Stream filters + custom regex (#551): a pattern set here is also switched on;
+  // a clear_* flag removes it and switches it off.
+  skip_builtin_filter?: boolean | null
+  stream_include_regex?: string | null
+  stream_exclude_regex?: string | null
+  custom_regex_teams?: string | null
+  custom_regex_date?: string | null
+  custom_regex_month?: string | null
+  custom_regex_day?: string | null
+  custom_regex_time?: string | null
+  custom_regex_league?: string | null
+  custom_regex_fighters?: string | null
+  custom_regex_event_name?: string | null
+  clear_stream_include_regex?: boolean
+  clear_stream_exclude_regex?: boolean
+  clear_custom_regex_teams?: boolean
+  clear_custom_regex_date?: boolean
+  clear_custom_regex_month?: boolean
+  clear_custom_regex_day?: boolean
+  clear_custom_regex_time?: boolean
+  clear_custom_regex_league?: boolean
+  clear_custom_regex_fighters?: boolean
+  clear_custom_regex_event_name?: boolean
 }
 
 export interface BulkGroupUpdateResult {

--- a/frontend/src/pages/event-groups/BulkEditDialog.tsx
+++ b/frontend/src/pages/event-groups/BulkEditDialog.tsx
@@ -13,10 +13,37 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
 import { StreamTimezoneSelector } from "@/components/StreamTimezoneSelector"
 import { TeamPicker } from "@/components/TeamPicker"
+import { LeaguePicker } from "@/components/LeaguePicker"
+import { SoccerModeSelector, type SoccerMode } from "@/components/SoccerModeSelector"
 import { useBulkUpdateGroups } from "@/hooks/useGroups"
-import type { TeamFilterEntry } from "@/api/types"
+import { jsToPython } from "@/lib/regex-utils"
+import { cn } from "@/lib/utils"
+import type { BulkGroupUpdateRequest, SoccerFollowedTeam, TeamFilterEntry } from "@/api/types"
+
+/**
+ * Regex fields bulk edit can set (#551). One control per pattern: setting a
+ * pattern also switches it on for every selected source, clearing it switches
+ * it off — the backend applies that rule from the plain field + clear_* flag.
+ */
+const REGEX_FIELDS = [
+  { key: "stream_include_regex", label: "Include streams matching", placeholder: "e.g., Gonzaga|Washington State|Eastern Washington" },
+  { key: "stream_exclude_regex", label: "Exclude streams matching", placeholder: "e.g., \\(ES\\)|\\(ALT\\)|All.?Star" },
+  { key: "custom_regex_teams", label: "Teams", placeholder: "(?<team1>[A-Z]{2,3})\\s*[@vs]+\\s*(?<team2>[A-Z]{2,3})" },
+  { key: "custom_regex_date", label: "Date", placeholder: "(?<day>\\d{1,2})/(?<month>\\d{1,2})/(?<year>\\d{2,4})" },
+  { key: "custom_regex_month", label: "Month", placeholder: "(?<month>\\w+)" },
+  { key: "custom_regex_day", label: "Day", placeholder: "(?<day>\\d{1,2})" },
+  { key: "custom_regex_time", label: "Time", placeholder: "(?<time>\\d{1,2}:\\d{2}\\s*(?:AM|PM)?)" },
+  { key: "custom_regex_league", label: "League", placeholder: "(?<league>NHL|NBA|NFL|MLB)" },
+  { key: "custom_regex_fighters", label: "Fighters", placeholder: "(?<fighter1>\\w+)\\s+vs\\.?\\s+(?<fighter2>\\w+)" },
+  { key: "custom_regex_event_name", label: "Event name", placeholder: "(?<event_name>UFC\\s*\\d+|Bellator\\s*\\d+)" },
+] as const
+
+type RegexKey = (typeof REGEX_FIELDS)[number]["key"]
+type RegexAction = "set" | "clear"
+type RegexEdit = { action: RegexAction; pattern: string }
 
 interface BulkEditDialogProps {
   open: boolean
@@ -78,16 +105,40 @@ function BulkEditForm({
   const [epgMatchEnabled, setEpgMatchEnabled] = useState(false)
   const [epgMatch, setEpgMatch] = useState(false)
 
+  // Subscription override (#551): set a shared league list, or reset to global.
+  const [subscriptionEnabled, setSubscriptionEnabled] = useState(false)
+  const [subscriptionAction, setSubscriptionAction] = useState<"set" | "clear">("set")
+  const [overrideNonSoccerLeagues, setOverrideNonSoccerLeagues] = useState<string[]>([])
+  const [overrideSoccerLeagues, setOverrideSoccerLeagues] = useState<string[]>([])
+  const [overrideSoccerMode, setOverrideSoccerMode] = useState<SoccerMode | null>(null)
+  const [overrideFollowedTeams, setOverrideFollowedTeams] = useState<SoccerFollowedTeam[]>([])
+
+  // Stream filters + custom regex (#551): each field is opt-in, then set or clear.
+  const [skipBuiltinEnabled, setSkipBuiltinEnabled] = useState(false)
+  const [skipBuiltin, setSkipBuiltin] = useState(false)
+  const [regexEdits, setRegexEdits] = useState<Partial<Record<RegexKey, RegexEdit>>>({})
+
+  const setRegexEdit = (key: RegexKey, edit: RegexEdit | null) =>
+    setRegexEdits((prev) => {
+      const next = { ...prev }
+      if (edit) next[key] = edit
+      else delete next[key]
+      return next
+    })
+
   const anyFieldEnabled =
     streamTimezoneEnabled ||
     teamFilterEnabled ||
     nameMatchEnabled ||
     teamStreamsEnabled ||
-    epgMatchEnabled
+    epgMatchEnabled ||
+    subscriptionEnabled ||
+    skipBuiltinEnabled ||
+    Object.keys(regexEdits).length > 0
 
   const handleApply = async () => {
     // Build request with only enabled fields
-    const request: Record<string, unknown> & { group_ids: number[] } = {
+    const request: BulkGroupUpdateRequest = {
       group_ids: Array.from(selectedIds),
     }
 
@@ -128,6 +179,31 @@ function BulkEditForm({
           request.exclude_teams = teamFilterTeams
           request.clear_include_teams = true
         }
+      }
+    }
+
+    if (subscriptionEnabled) {
+      if (subscriptionAction === "clear") {
+        request.clear_subscription_leagues = true
+        request.clear_subscription_soccer_mode = true
+        request.clear_subscription_soccer_followed_teams = true
+      } else {
+        request.subscription_leagues = [...overrideNonSoccerLeagues, ...overrideSoccerLeagues]
+        request.subscription_soccer_mode = overrideSoccerMode
+        request.subscription_soccer_followed_teams =
+          overrideFollowedTeams.length > 0 ? overrideFollowedTeams : null
+      }
+    }
+
+    if (skipBuiltinEnabled) {
+      request.skip_builtin_filter = skipBuiltin
+    }
+
+    for (const [key, edit] of Object.entries(regexEdits) as [RegexKey, RegexEdit][]) {
+      if (edit.action === "clear") {
+        request[`clear_${key}`] = true
+      } else if (edit.pattern.trim()) {
+        request[key] = jsToPython(edit.pattern.trim())
       }
     }
 
@@ -313,6 +389,157 @@ function BulkEditForm({
               </span>
             </div>
           )}
+        </div>
+
+        {/* Subscription Override (#551) */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={subscriptionEnabled}
+              onCheckedChange={(checked) => setSubscriptionEnabled(!!checked)}
+            />
+            <span className="text-sm font-medium">Subscription override (leagues)</span>
+          </label>
+          {subscriptionEnabled && (
+            <div className="space-y-3 pl-6">
+              <div className="flex gap-4">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="bulk-subscription-action"
+                    checked={subscriptionAction === "set"}
+                    onChange={() => setSubscriptionAction("set")}
+                    className="accent-primary"
+                  />
+                  <span className="text-sm">Set custom leagues</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="bulk-subscription-action"
+                    checked={subscriptionAction === "clear"}
+                    onChange={() => setSubscriptionAction("clear")}
+                    className="accent-primary"
+                  />
+                  <span className="text-sm">Use global subscription</span>
+                </label>
+              </div>
+              {subscriptionAction === "set" ? (
+                <>
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Non-Soccer Sports</Label>
+                    <LeaguePicker
+                      selectedLeagues={overrideNonSoccerLeagues}
+                      onSelectionChange={setOverrideNonSoccerLeagues}
+                      excludeSport="soccer"
+                      maxHeight="max-h-48"
+                      showSearch={true}
+                      showSelectedBadges={true}
+                      maxBadges={8}
+                    />
+                  </div>
+                  <div className="border-t" />
+                  <div className="space-y-2">
+                    <Label className="text-sm font-medium">Soccer Leagues</Label>
+                    <SoccerModeSelector
+                      mode={overrideSoccerMode}
+                      onModeChange={setOverrideSoccerMode}
+                      selectedLeagues={overrideSoccerLeagues}
+                      onLeaguesChange={setOverrideSoccerLeagues}
+                      followedTeams={overrideFollowedTeams}
+                      onFollowedTeamsChange={setOverrideFollowedTeams}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Replaces each selected source's league override with this list.
+                  </p>
+                </>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Removes per-source league overrides. Sources will match against the global
+                  subscription (set on the Subscriptions page).
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Stream filters + custom regex (#551) */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <Checkbox
+              checked={skipBuiltinEnabled}
+              onCheckedChange={(checked) => setSkipBuiltinEnabled(!!checked)}
+            />
+            <span className="text-sm font-medium">Skip built-in filter</span>
+          </label>
+          {skipBuiltinEnabled && (
+            <div className="flex items-center gap-3 pl-6">
+              <Switch checked={skipBuiltin} onCheckedChange={setSkipBuiltin} />
+              <span className="text-sm text-muted-foreground">
+                {skipBuiltin
+                  ? "Enabled — rely on your include/exclude regex instead of the built-in event filter"
+                  : "Disabled — built-in event filter runs first"}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Stream filters &amp; custom regex</p>
+          <p className="text-xs text-muted-foreground">
+            Check a field to change it on every selected source. Setting a pattern also switches
+            it on; clearing switches it off. Unchecked fields are left as they are.
+          </p>
+          <div className="space-y-2 pl-1">
+            {REGEX_FIELDS.map(({ key, label, placeholder }) => {
+              const edit = regexEdits[key]
+              return (
+                <div key={key} className="space-y-1">
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <Checkbox
+                      checked={!!edit}
+                      onCheckedChange={(checked) =>
+                        setRegexEdit(key, checked ? { action: "set", pattern: "" } : null)
+                      }
+                    />
+                    <span className="text-sm">{label}</span>
+                  </label>
+                  {edit && (
+                    <div className="flex items-center gap-3 pl-6">
+                      <label className="flex items-center gap-1 cursor-pointer text-xs">
+                        <input
+                          type="radio"
+                          name={`bulk-regex-${key}`}
+                          checked={edit.action === "set"}
+                          onChange={() => setRegexEdit(key, { ...edit, action: "set" })}
+                          className="accent-primary"
+                        />
+                        Set
+                      </label>
+                      <label className="flex items-center gap-1 cursor-pointer text-xs">
+                        <input
+                          type="radio"
+                          name={`bulk-regex-${key}`}
+                          checked={edit.action === "clear"}
+                          onChange={() => setRegexEdit(key, { ...edit, action: "clear" })}
+                          className="accent-primary"
+                        />
+                        Clear
+                      </label>
+                      <Input
+                        value={edit.pattern}
+                        onChange={(e) => setRegexEdit(key, { ...edit, pattern: e.target.value })}
+                        placeholder={placeholder}
+                        disabled={edit.action === "clear"}
+                        className={cn("font-mono text-sm", edit.action === "clear" && "opacity-50")}
+                      />
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
         </div>
 
         {/* EPG Program Matching */}

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -7,6 +7,7 @@ Provides REST API for:
 """
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import Response
@@ -1013,13 +1014,13 @@ BULK_REGEX_FIELDS = (
 )
 
 
-def _bulk_regex_kwargs(request: "BulkGroupUpdateRequest") -> dict[str, object]:
+def _bulk_regex_kwargs(request: "BulkGroupUpdateRequest") -> dict[str, Any]:
     """update_group kwargs for the regex fields of a bulk request (#551).
 
     Bulk carries one control per pattern: setting it enables it, clearing it
     disables it. Fields the request does not mention are left untouched.
     """
-    kwargs: dict[str, object] = {}
+    kwargs: dict[str, Any] = {}
     for field in BULK_REGEX_FIELDS:
         if getattr(request, f"clear_{field}"):
             kwargs[f"clear_{field}"] = True

--- a/teamarr/api/routes/groups.py
+++ b/teamarr/api/routes/groups.py
@@ -440,6 +440,31 @@ class BulkGroupUpdateRequest(BaseModel):
     clear_subscription_soccer_mode: bool = False
     clear_subscription_soccer_followed_teams: bool = False
 
+    # Stream filters + custom regex (#551). A pattern set here is also switched
+    # ON for every selected group; a clear_* flag removes it and switches it OFF —
+    # one control per field in bulk, unlike the per-source form.
+    skip_builtin_filter: bool | None = None
+    stream_include_regex: str | None = None
+    stream_exclude_regex: str | None = None
+    custom_regex_teams: str | None = None
+    custom_regex_date: str | None = None
+    custom_regex_month: str | None = None
+    custom_regex_day: str | None = None
+    custom_regex_time: str | None = None
+    custom_regex_league: str | None = None
+    custom_regex_fighters: str | None = None
+    custom_regex_event_name: str | None = None
+    clear_stream_include_regex: bool = False
+    clear_stream_exclude_regex: bool = False
+    clear_custom_regex_teams: bool = False
+    clear_custom_regex_date: bool = False
+    clear_custom_regex_month: bool = False
+    clear_custom_regex_day: bool = False
+    clear_custom_regex_time: bool = False
+    clear_custom_regex_league: bool = False
+    clear_custom_regex_fighters: bool = False
+    clear_custom_regex_event_name: bool = False
+
 
 class ClearCacheRequest(BaseModel):
     """Request to clear stream match cache for multiple groups."""
@@ -974,6 +999,39 @@ def create_groups_bulk(request: BulkGroupCreateRequest):
     )
 
 
+BULK_REGEX_FIELDS = (
+    "stream_include_regex",
+    "stream_exclude_regex",
+    "custom_regex_teams",
+    "custom_regex_date",
+    "custom_regex_month",
+    "custom_regex_day",
+    "custom_regex_time",
+    "custom_regex_league",
+    "custom_regex_fighters",
+    "custom_regex_event_name",
+)
+
+
+def _bulk_regex_kwargs(request: "BulkGroupUpdateRequest") -> dict[str, object]:
+    """update_group kwargs for the regex fields of a bulk request (#551).
+
+    Bulk carries one control per pattern: setting it enables it, clearing it
+    disables it. Fields the request does not mention are left untouched.
+    """
+    kwargs: dict[str, object] = {}
+    for field in BULK_REGEX_FIELDS:
+        if getattr(request, f"clear_{field}"):
+            kwargs[f"clear_{field}"] = True
+            kwargs[f"{field}_enabled"] = False
+        elif getattr(request, field) is not None:
+            kwargs[field] = getattr(request, field)
+            kwargs[f"{field}_enabled"] = True
+    if request.skip_builtin_filter is not None:
+        kwargs["skip_builtin_filter"] = request.skip_builtin_filter
+    return kwargs
+
+
 @router.put("/bulk", response_model=BulkGroupUpdateResponse)
 def update_groups_bulk(request: BulkGroupUpdateRequest):
     """Bulk update event EPG groups with shared settings.
@@ -1072,6 +1130,8 @@ def update_groups_bulk(request: BulkGroupUpdateRequest):
                     clear_subscription_leagues=request.clear_subscription_leagues,
                     clear_subscription_soccer_mode=request.clear_subscription_soccer_mode,
                     clear_subscription_soccer_followed_teams=request.clear_subscription_soccer_followed_teams,
+                    # Stream filters + custom regex (#551)
+                    **_bulk_regex_kwargs(request),
                 )
 
                 results.append(

--- a/tests/test_groups_bulk_update.py
+++ b/tests/test_groups_bulk_update.py
@@ -1,0 +1,120 @@
+"""Bulk edit covers stream filters, custom regex and the subscription override (#551).
+
+The DB layer always accepted every field; the bulk request model exposed only a
+handful. Bulk carries one control per regex: setting a pattern also switches
+it on for every selected source, clearing it switches it off. Fields the
+request does not mention are left exactly as they were.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from teamarr.api.app import app
+from teamarr.database import init_db
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "test.db"))
+    init_db()
+
+
+def _make_group(name: str, **extra) -> int:
+    resp = client.post("/api/v1/groups", json={"name": name, "leagues": ["eng.1"], **extra})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _get(gid: int) -> dict:
+    return client.get(f"/api/v1/groups/{gid}").json()
+
+
+class TestBulkRegex:
+    def test_setting_a_pattern_also_enables_it_on_every_group(self, isolated_db):
+        a, b = _make_group("A"), _make_group("B")
+
+        resp = client.put(
+            "/api/v1/groups/bulk",
+            json={
+                "group_ids": [a, b],
+                "stream_include_regex": r"EPL|Premier",
+                "custom_regex_teams": r"(?P<team1>\w+) v (?P<team2>\w+)",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["total_updated"] == 2
+
+        for gid in (a, b):
+            got = _get(gid)
+            assert got["stream_include_regex"] == r"EPL|Premier"
+            assert got["stream_include_regex_enabled"] is True
+            assert got["custom_regex_teams"] == r"(?P<team1>\w+) v (?P<team2>\w+)"
+            assert got["custom_regex_teams_enabled"] is True
+
+    def test_clearing_a_pattern_also_disables_it(self, isolated_db):
+        gid = _make_group(
+            "A", stream_exclude_regex=r"\(ALT\)", stream_exclude_regex_enabled=True
+        )
+        assert _get(gid)["stream_exclude_regex_enabled"] is True
+
+        resp = client.put(
+            "/api/v1/groups/bulk",
+            json={"group_ids": [gid], "clear_stream_exclude_regex": True},
+        )
+        assert resp.status_code == 200, resp.text
+        got = _get(gid)
+        assert got["stream_exclude_regex"] is None
+        assert got["stream_exclude_regex_enabled"] is False
+
+    def test_unmentioned_fields_are_left_alone(self, isolated_db):
+        gid = _make_group(
+            "A",
+            custom_regex_date=r"(?P<day>\d+)/(?P<month>\d+)",
+            custom_regex_date_enabled=True,
+            skip_builtin_filter=True,
+        )
+
+        resp = client.put(
+            "/api/v1/groups/bulk",
+            json={"group_ids": [gid], "custom_regex_league": r"(?P<league>NHL)"},
+        )
+        assert resp.status_code == 200, resp.text
+        got = _get(gid)
+        assert got["custom_regex_date"] == r"(?P<day>\d+)/(?P<month>\d+)"
+        assert got["custom_regex_date_enabled"] is True
+        assert got["skip_builtin_filter"] is True
+        assert got["custom_regex_league"] == r"(?P<league>NHL)"
+        assert got["custom_regex_league_enabled"] is True
+
+    def test_skip_builtin_filter_is_bulk_settable(self, isolated_db):
+        a, b = _make_group("A"), _make_group("B", skip_builtin_filter=True)
+
+        resp = client.put(
+            "/api/v1/groups/bulk", json={"group_ids": [a, b], "skip_builtin_filter": False}
+        )
+        assert resp.status_code == 200, resp.text
+        assert _get(a)["skip_builtin_filter"] is False
+        assert _get(b)["skip_builtin_filter"] is False
+
+
+class TestBulkSubscriptionOverride:
+    def test_set_and_clear_subscription_leagues(self, isolated_db):
+        a, b = _make_group("A"), _make_group("B")
+
+        resp = client.put(
+            "/api/v1/groups/bulk",
+            json={"group_ids": [a, b], "subscription_leagues": ["nfl", "eng.1"]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert _get(a)["subscription_leagues"] == ["nfl", "eng.1"]
+        assert _get(b)["subscription_leagues"] == ["nfl", "eng.1"]
+
+        resp = client.put(
+            "/api/v1/groups/bulk",
+            json={"group_ids": [a], "clear_subscription_leagues": True},
+        )
+        assert resp.status_code == 200, resp.text
+        assert _get(a)["subscription_leagues"] is None
+        assert _get(b)["subscription_leagues"] == ["nfl", "eng.1"]


### PR DESCRIPTION
Closes nothing yet — #551 gets `status: on-dev` at merge.

The DB layer always accepted every field; the bulk request model exposed a handful and the dialog fewer still (timezone, team filter, three matching toggles). Bulk now also carries:

- **Subscription override** — set a shared league list (non-soccer + soccer mode/leagues/followed teams) or reset the selection to the global subscription.
- **Skip built-in filter** toggle.
- **Stream include/exclude regex** and all **eight custom regexes** (teams, date, month, day, time, league, fighters, event name).

One control per pattern in bulk (maintainer decision 2026-09-10): setting a pattern also switches it **on** for every selected source; clearing it switches it **off**. Unmentioned fields are left untouched. Name, display name, sort position and channel start number stay per-source by nature. Patterns go through the same `jsToPython` conversion as the single-source form.

- Backend: `BulkGroupUpdateRequest` + `_bulk_regex_kwargs` in `api/routes/groups.py`; DB layer unchanged.
- Frontend: `BulkEditDialog.tsx` two new sections; `BulkGroupUpdateRequest` type.
- Tests: `tests/test_groups_bulk_update.py` (set-enables, clear-disables, untouched fields, skip-builtin, subscription set/clear) — the endpoint had no coverage before.
- Docs: `docs/guide/sources/index.md` bulk-edit sentence.

Gates: ruff clean · 3,048 tests passed · tsc + build + eslint clean. Not verified in a live browser (no dev server up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg