### PR TITLE
feat(channels): 'Order streams now' — reorder-only pass without a generation run (#576)

### DIFF
--- a/docs/guide/channels/stream-priority.md
+++ b/docs/guide/channels/stream-priority.md
@@ -116,7 +116,11 @@ While an event is airing, scheduled generation runs won't displace the channel's
 
 The pin holds because the top slot is presumed to be what somebody is watching. When a probe contradicts that — the cached [Stream Stats](#rule-types) say the stream is **dead or a black screen** — the pin releases and normal rule ordering takes the top slot, because a stream that isn't there is not one anybody is watching. Only an actual measurement lifts it: a stream with no stats, or stats that say nothing about liveness, stays pinned, since not knowing a stream is dead is not the same as knowing it is.
 
-A **manually triggered** generation run bypasses this pin entirely — that's your escape hatch if the pinned stream is the wrong one for any other reason: fix your rules (or remove the bad stream) and hit Generate.
+A **manually triggered** generation run bypasses this pin entirely — that's your escape hatch if the pinned stream is the wrong one for any other reason: fix your rules (or remove the bad stream) and hit Generate, or press **Order streams now** on this page.
+
+## Order streams now
+
+The **Order streams now** button at the bottom of the rules page re-sorts every managed channel by the saved rules without running a generation: it pulls fresh Stream Stats from Dispatcharr, re-applies the rules, and pushes only the channels whose order changed. Nothing else runs — no matching, no EPG rebuild, no media-server refresh — so it finishes in seconds. Like a manual generation it bypasses the live-event #1 pin, and it is unavailable while you have unsaved rule edits or a generation is in progress.
 
 ## Why is a stream ordered this way?
 

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -566,6 +566,19 @@ export async function updateStreamOrderingSettings(
   return api.put("/settings/stream-ordering", data)
 }
 
+export interface ApplyStreamOrderingResult {
+  channels_reordered: number
+  streams_reordered: number
+  windows_synced: number
+  order_drift_synced: number
+  stats_refreshed: number
+}
+
+/** Re-sort every managed channel's streams now, without a generation run (#576). */
+export async function applyStreamOrdering(): Promise<ApplyStreamOrderingResult> {
+  return api.post("/settings/stream-ordering/apply", {})
+}
+
 export async function getStreamOrderingScopes(): Promise<StreamOrderingScope[]> {
   return api.get("/settings/stream-ordering/scopes")
 }

--- a/frontend/src/components/StreamOrderingManager.tsx
+++ b/frontend/src/components/StreamOrderingManager.tsx
@@ -13,6 +13,7 @@ import {
   Upload,
   Pencil,
   Copy,
+  ArrowDownUp,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SaveButton } from "@/components/ui/save-button"
@@ -41,6 +42,7 @@ import {
   useUpdateStreamOrderingScope,
   useDeleteStreamOrderingScope,
   useTeamFilterSettings,
+  useApplyStreamOrdering,
 } from "@/hooks/useSettings"
 import { useGroups } from "@/hooks/useGroups"
 import { useChannelGroupsWithChannels } from "@/hooks/useDispatcharr"
@@ -1054,6 +1056,21 @@ export function StreamOrderingManager() {
       },
     })
 
+  // Reorder-only pass (#576). Disabled while there are unsaved rule edits so
+  // the button always applies what the page shows as saved.
+  const applyOrdering = useApplyStreamOrdering()
+  const handleApplyNow = async () => {
+    try {
+      const r = await applyOrdering.mutateAsync()
+      toast.success(
+        `Reordered ${r.channels_reordered} channel${r.channels_reordered === 1 ? "" : "s"} ` +
+          `(${r.streams_reordered} streams); stats refreshed for ${r.stats_refreshed}`
+      )
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to reorder streams")
+    }
+  }
+
   const handleSave = async () => {
     // Validate rules — no-value types (team_feed, not_team_feed, catch_all) don't require a value
     const invalidRules = rules.filter(r => !NO_VALUE_TYPES.has(r.type) && !r.value.trim())
@@ -1524,7 +1541,31 @@ export function StreamOrderingManager() {
           </p>
         )}
 
-        <div className="flex items-center justify-end pt-2 border-t">
+        <div className="flex items-center justify-between gap-3 pt-2 border-t">
+          <RichTooltip
+            content={
+              <>
+                Re-sorts every managed channel's streams by the saved rules right now, pulling
+                fresh Stream Stats from Dispatcharr first. Nothing else runs — no matching, no
+                EPG rebuild. Like a manual generation, this can move a live channel's #1 stream.
+              </>
+            }
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleApplyNow}
+              disabled={applyOrdering.isPending || hasChanges}
+            >
+              {applyOrdering.isPending ? (
+                <LoaderCircle className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ArrowDownUp className="h-4 w-4 mr-2" />
+              )}
+              Order streams now
+            </Button>
+          </RichTooltip>
           <SaveButton
             onClick={handleSave}
             pending={updateSettings.isPending || updateScope.isPending}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -24,6 +24,7 @@ import {
   updateChannelNumberingSettings,
   getStreamOrderingSettings,
   updateStreamOrderingSettings,
+  applyStreamOrdering,
   getStreamOrderingScopes,
   getStreamOrderingScope,
   createStreamOrderingScope,
@@ -151,6 +152,11 @@ export const useStreamOrderingSettings = settingsQueryHook(
 export const useUpdateStreamOrderingSettings = settingsMutationHook(updateStreamOrderingSettings, [
   ["settings", "stream-ordering"],
 ])
+
+/** Reorder-only pass (#576): no query to invalidate — it changes Dispatcharr, not settings. */
+export function useApplyStreamOrdering() {
+  return useMutation({ mutationFn: applyStreamOrdering })
+}
 
 export const useStreamOrderingScopes = settingsQueryHook(
   "stream-ordering-scopes",

--- a/teamarr/api/routes/settings/stream_ordering.py
+++ b/teamarr/api/routes/settings/stream_ordering.py
@@ -1,6 +1,7 @@
 """Stream ordering settings endpoints."""
 
 from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import BaseModel
 
 from teamarr.database import get_db
 from teamarr.database.settings.types import NO_VALUE_RULE_TYPES, VALID_RULE_TYPES
@@ -15,6 +16,46 @@ from .models import (
 )
 
 router = APIRouter()
+
+
+class ApplyStreamOrderingResponse(BaseModel):
+    """Counts from a reorder-only pass (#576)."""
+
+    channels_reordered: int = 0
+    streams_reordered: int = 0
+    windows_synced: int = 0
+    order_drift_synced: int = 0
+    stats_refreshed: int = 0
+
+
+@router.post("/settings/stream-ordering/apply", response_model=ApplyStreamOrderingResponse)
+def apply_stream_ordering():
+    """Re-sort every managed channel's streams now, without a generation run (#576).
+
+    Pulls current stream stats from Dispatcharr, re-applies the ordering rules
+    and pushes only the channels whose order changed. Nothing else runs — no
+    matching, provider calls, EPG rebuild or media-server refresh. Like a
+    manual generation, it bypasses the live-event #1 pin. Returns 409 while a
+    generation is in progress.
+    """
+    from teamarr.consumers.generation import run_stream_ordering_only
+    from teamarr.database.settings import get_dispatcharr_settings
+    from teamarr.dispatcharr import get_dispatcharr_connection
+
+    with get_db() as conn:
+        dispatcharr_settings = get_dispatcharr_settings(conn)
+    client = None
+    if dispatcharr_settings.enabled and dispatcharr_settings.url:
+        client = get_dispatcharr_connection(get_db)
+
+    result = run_stream_ordering_only(get_db, client, manual=True)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Generation already in progress",
+        )
+    fields = ApplyStreamOrderingResponse.model_fields
+    return ApplyStreamOrderingResponse(**{k: int(v) for k, v in result.items() if k in fields})
 
 
 def _validated_rules(rules) -> list[dict]:

--- a/teamarr/consumers/generation.py
+++ b/teamarr/consumers/generation.py
@@ -1201,6 +1201,42 @@ def _push_stream_orders(
     return failures
 
 
+def run_stream_ordering_only(
+    db_factory: Callable[[], Any],
+    dispatcharr_client: Any | None,
+    manual: bool = True,
+) -> dict | None:
+    """Re-sort every managed channel's streams without a generation run (#576).
+
+    The whole ordering step and nothing else: pull current stats from
+    Dispatcharr, re-apply the rules, push only the channels whose order
+    changed. No matching, no provider calls, no EPG rebuild, no media-server
+    refresh, no run-history row. Takes the generation lock so it can never
+    overlap a real run (or vice versa); returns None when a run is in
+    progress so the caller can answer 409.
+
+    ``manual`` defaults True: this is the user's button, and like a manual
+    generation it bypasses the live-event #1 pin (#232) — the escape hatch
+    when the pinned stream is wrong. A scheduled caller must pass False.
+    """
+    global _generation_running
+
+    if not _generation_lock.acquire(blocking=False):
+        return None
+    if _generation_running:
+        _generation_lock.release()
+        return None
+    _generation_running = True
+    try:
+        logger.info("[ORDERING] Manual stream re-order (no generation)")
+        return _apply_stream_ordering(
+            db_factory, dispatcharr_client, lambda *a, **k: None, manual=manual
+        )
+    finally:
+        _generation_running = False
+        _generation_lock.release()
+
+
 def _apply_stream_ordering(
     db_factory: Callable[[], Any],
     dispatcharr_client: Any | None,

--- a/tests/test_stream_ordering_apply.py
+++ b/tests/test_stream_ordering_apply.py
@@ -1,0 +1,87 @@
+"""Reorder-only pass (#576): the ordering step without a generation run.
+
+One endpoint, one button. It takes the generation lock so it can never overlap
+a real run, answers 409 while one is in progress, and — being user-triggered —
+bypasses the live-event #1 pin exactly like a manual generation (#232).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from teamarr.api.app import app
+from teamarr.consumers import generation
+from teamarr.database import init_db
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "test.db"))
+    init_db()
+
+
+def test_apply_runs_the_ordering_step_only(isolated_db, monkeypatch):
+    seen: dict = {}
+
+    def fake_apply(db_factory, dispatcharr_client, update_progress, manual=False):
+        seen["manual"] = manual
+        seen["client"] = dispatcharr_client
+        update_progress("ordering", 50, "no-op callback must be callable")
+        return {
+            "channels_reordered": 3,
+            "streams_reordered": 7,
+            "windows_synced": 1,
+            "order_drift_synced": 2,
+            "stats_refreshed": 40,
+            "ignored_extra_key": "x",
+        }
+
+    monkeypatch.setattr(generation, "_apply_stream_ordering", fake_apply)
+
+    resp = client.post("/api/v1/settings/stream-ordering/apply")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "channels_reordered": 3,
+        "streams_reordered": 7,
+        "windows_synced": 1,
+        "order_drift_synced": 2,
+        "stats_refreshed": 40,
+    }
+    # The button is the escape hatch: it bypasses the live pin like Generate does.
+    assert seen["manual"] is True
+    # Dispatcharr is not configured in the isolated DB → DB-only pass.
+    assert seen["client"] is None
+
+
+def test_apply_is_409_while_a_generation_holds_the_lock(isolated_db, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        generation, "_apply_stream_ordering", lambda *a, **k: called.append(1) or {}
+    )
+    assert generation._generation_lock.acquire(blocking=False)
+    try:
+        resp = client.post("/api/v1/settings/stream-ordering/apply")
+    finally:
+        generation._generation_lock.release()
+    assert resp.status_code == 409
+    assert called == []
+
+
+def test_lock_is_released_after_a_pass(isolated_db, monkeypatch):
+    monkeypatch.setattr(generation, "_apply_stream_ordering", lambda *a, **k: {})
+    assert client.post("/api/v1/settings/stream-ordering/apply").status_code == 200
+    assert generation._generation_lock.acquire(blocking=False)
+    generation._generation_lock.release()
+    assert generation._generation_running is False
+
+
+def test_scheduled_caller_keeps_the_live_pin(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        generation,
+        "_apply_stream_ordering",
+        lambda db, c, p, manual=False: seen.setdefault("manual", manual) or {},
+    )
+    generation.run_stream_ordering_only(lambda: None, None, manual=False)
+    assert seen["manual"] is False


### PR DESCRIPTION
First cut of #576, deliberately without scheduling (maintainer decision 2026-09-10: a button now; a cron can wrap the same entry point later if it earns its keep).

- `POST /settings/stream-ordering/apply` → `run_stream_ordering_only()` runs the existing ordering step and nothing else: fresh Stream Stats from Dispatcharr, rules re-applied, only changed channels pushed. No matching, provider calls, EPG rebuild, media-server refresh or run-history row.
- Takes the generation lock: never overlaps a run, answers **409** while one is in progress.
- User-triggered, so it **bypasses the live-event #1 pin** like a manual generation (#232). Scheduled callers pass `manual=False` and keep the pin — pinned by a test.
- UI: **Order streams now** button at the bottom of the Stream Priority page, tooltip explains the pin bypass, disabled while there are unsaved rule edits, toast with counts.
- Docs: new "Order streams now" section in `docs/guide/channels/stream-priority.md`.

Gates: ruff clean · 3,047 tests passed · tsc + build + eslint + Pyright clean. Not verified in a live browser (no dev server up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg