### PR TITLE
fix(matching): translate cities on provider team names too (#797)

### DIFF
--- a/teamarr/consumers/matching/normalizer.py
+++ b/teamarr/consumers/matching/normalizer.py
@@ -13,14 +13,12 @@ import re
 from dataclasses import dataclass
 from datetime import date, time
 
-from unidecode import unidecode
-
 from teamarr.utilities.constants import (
     BROADCAST_NETWORKS,
-    CITY_TRANSLATIONS,
     LIVE_STATUS_PREFIXES,
     PROVIDER_PREFIXES,
 )
+from teamarr.utilities.fuzzy_match import translate_cities
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +251,10 @@ def apply_city_translations(text: str) -> str:
     First normalizes with unidecode (München → Munchen),
     then applies manual translations (munchen → munich).
 
+    Delegates to fuzzy_match.translate_cities, which normalize_text also runs
+    on provider team names — a stream-only copy of this logic made native
+    spellings the provider itself uses unmatchable (#797).
+
     Args:
         text: Text containing city names
 
@@ -261,23 +263,7 @@ def apply_city_translations(text: str) -> str:
     """
     if not text:
         return text
-
-    # First pass: unidecode to normalize accents
-    # This converts München → Munchen
-    text = unidecode(text)
-
-    # Second pass: apply manual translations
-    # Work on lowercased version for matching, preserve original case pattern
-    result = text
-    text_lower = text.lower()
-
-    for variant, english in CITY_TRANSLATIONS.items():
-        if variant in text_lower:
-            # Find the position and replace preserving some case
-            pattern = re.compile(re.escape(variant), re.IGNORECASE)
-            result = pattern.sub(english, result)
-
-    return result
+    return translate_cities(text)
 
 
 # =============================================================================

--- a/teamarr/utilities/constants.py
+++ b/teamarr/utilities/constants.py
@@ -12,6 +12,17 @@ in the database when possible.
 #
 # Format: normalized_variant -> english_name
 # All keys should be lowercase, already normalized (no accents via unidecode)
+#
+# Applied to BOTH sides of every comparison (#797): stream text through
+# normalize_for_matching, provider team names through normalize_text — both
+# call fuzzy_match.translate_cities. Translating only the stream side turned a
+# native spelling the provider itself uses ("Sevilla", "1. FC Nürnberg",
+# "F.C. København") into a guaranteed miss, because residual_contradicts reads
+# "nuremberg" vs "nurnberg" as two different teams.
+#
+# The pipeline translates text twice (normalize_for_matching, then
+# normalize_text on the result), so an english_name must never contain another
+# entry's variant.
 # =============================================================================
 
 CITY_TRANSLATIONS: dict[str, str] = {

--- a/teamarr/utilities/fuzzy_match.py
+++ b/teamarr/utilities/fuzzy_match.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 from rapidfuzz import fuzz
 from unidecode import unidecode
 
+from teamarr.utilities.constants import CITY_TRANSLATIONS
+
 if TYPE_CHECKING:
     from teamarr.core import Team
 
@@ -54,18 +56,35 @@ class FuzzyMatchResult:
     pattern_used: str | None = None
 
 
+def translate_cities(text: str) -> str:
+    """unidecode, then map native city spellings to English (München → Munich).
+
+    The one implementation of CITY_TRANSLATIONS. normalize_text runs it on
+    provider team names and normalize_stream / normalize_for_matching run it on
+    stream text, so the two sides can never disagree about a city (#797).
+    """
+    text = unidecode(text)
+    lowered = text.lower()
+    for variant, english in CITY_TRANSLATIONS.items():
+        if variant in lowered:
+            text = re.sub(re.escape(variant), english, text, flags=re.IGNORECASE)
+    return text
+
+
 @lru_cache(maxsize=16384)
 def normalize_text(value: str) -> str:
     """Normalize text for matching.
 
-    Applies: unidecode, lowercase, strip punctuation, normalize whitespace.
+    Applies: unidecode, city translations, lowercase, strip punctuation,
+    normalize whitespace. City translations must match normalize_for_matching,
+    which stream text passes through first (#797).
 
     Cached: the matcher re-normalizes the same event/team names for every
     stream × event comparison, making this the dominant pure-Python cost of
     the inner match loop without memoization.
     """
-    # Normalize: strip accents (é→e, ü→u), lowercase
-    normalized = unidecode(value).lower().strip()
+    # Normalize: strip accents (é→e, ü→u), translate cities, lowercase
+    normalized = translate_cities(value).lower().strip()
     # Remove apostrophes/backticks without adding a space so "O’Reilly",
     # "O`Reilly", and "OReilly" all normalize to "oreilly".
     # Hex escapes used to avoid source-encoding ambiguity: \x27=apostrophe, \x60=backtick.

--- a/tests/matching/test_city_translations.py
+++ b/tests/matching/test_city_translations.py
@@ -1,0 +1,103 @@
+"""City translations apply to provider team names too (#797).
+
+CITY_TRANSLATIONS ran on stream text (normalize_for_matching) but not on
+provider team names (normalize_text), so a native spelling ESPN itself uses
+became a guaranteed miss: "1. FC Nürnberg" normalized to "1 fc nuremberg" on
+the stream side and "1 fc nurnberg" on the team side, and residual_contradicts
+read the disagreeing residual word as a different team — score 0. Found on a
+Sky Deutschland EPG programme "2. BL | 1. FC Nürnberg - Hannover 96" while the
+Darmstadt game on the next channel matched.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from teamarr.consumers.matching.normalizer import normalize_for_matching
+from teamarr.consumers.matching.team_matcher import _best_name_score
+from teamarr.core.types import Event, EventStatus, Team
+from teamarr.utilities.constants import CITY_TRANSLATIONS
+from teamarr.utilities.fuzzy_match import normalize_text, translate_cities
+
+# Every ESPN soccer name whose native spelling contains a translated city,
+# from a live /teams sweep on 2026-09-11. Each scored 0 against itself.
+AFFECTED_ESPN_NAMES = [
+    "1. FC Nürnberg",
+    "Hannover 96",
+    "TSV Eintracht Braunschweig",
+    "Sevilla",
+    "Venezia",
+    "F.C. København",
+    "IFK Göteborg",
+]
+
+
+def _team(team_id: str, name: str, league: str) -> Team:
+    return Team(
+        id=team_id,
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation="",
+        league=league,
+        sport="soccer",
+    )
+
+
+def _event(away: str, home: str, league: str) -> Event:
+    start = datetime.now(UTC) + timedelta(hours=3)
+    return Event(
+        id="1",
+        provider="espn",
+        name=f"{away} at {home}",
+        short_name=f"{away} at {home}",
+        league=league,
+        sport="soccer",
+        start_time=start,
+        home_team=_team("h", home, league),
+        away_team=_team("a", away, league),
+        status=EventStatus(state="scheduled"),
+    )
+
+
+class TestBothSidesTranslate:
+    @pytest.mark.parametrize("name", AFFECTED_ESPN_NAMES)
+    def test_normalizers_agree(self, name):
+        assert normalize_for_matching(name) == normalize_text(name)
+
+    @pytest.mark.parametrize("name", AFFECTED_ESPN_NAMES)
+    def test_native_spelling_matches_its_own_team(self, name):
+        stream = normalize_for_matching(name)
+        assert _best_name_score(stream, _team("t", name, "ger.2")) == 100.0
+
+    def test_translation_toward_the_provider_name_still_works(self):
+        """The reason the table exists: ESPN writes "Bayern Munich"."""
+        stream = normalize_for_matching("FC Bayern München")
+        assert _best_name_score(stream, _team("t", "Bayern Munich", "ger.1")) == 100.0
+
+    def test_translation_is_idempotent(self):
+        """normalize_for_matching output is normalized again by normalize_text,
+        so a second pass must not rewrite anything."""
+        for english in CITY_TRANSLATIONS.values():
+            assert translate_cities(english) == english
+        for name in AFFECTED_ESPN_NAMES:
+            once = normalize_for_matching(name)
+            assert normalize_text(once) == once
+
+
+class TestReportedProgramme:
+    def test_nurnberg_hannover_matches(self, db_factory):
+        from tests.fakes import make_team_matcher
+
+        matcher = make_team_matcher(db_factory=db_factory)
+        event = _event("Hannover 96", "1. FC Nürnberg", "ger.2")
+        assert matcher._score_teams_against_event("1. FC Nürnberg", "Hannover 96", event)
+
+    def test_builtin_alias_key_is_reachable(self, db_factory):
+        """"sevilla fc" was keyed untranslated while lookups arrive translated."""
+        from tests.fakes import make_team_matcher
+
+        matcher = make_team_matcher(db_factory=db_factory)
+        assert matcher._resolve_alias(normalize_for_matching("Sevilla FC"), "esp.1")


### PR DESCRIPTION
Closes #797 (on release).

## Problem

`CITY_TRANSLATIONS` ran on stream text (`normalize_stream` / `normalize_for_matching`) but not on provider team names (`normalize_text`). A native spelling the provider itself uses therefore normalized differently on each side — `1 fc nuremberg` vs `1 fc nurnberg` — and `residual_contradicts` read the disagreeing residual word as a different team, zeroing the score. Reported on a Sky Deutschland programme `2. BL | 1. FC Nürnberg - Hannover 96` while the Darmstadt game on the next channel matched.

Affected ESPN names (live `/teams` sweep): 1. FC Nürnberg, Hannover 96, TSV Eintracht Braunschweig, Sevilla, Venezia, F.C. København, IFK Göteborg.

## Fix

- New `fuzzy_match.translate_cities` — the single implementation of the table, behaviour identical to the old `apply_city_translations`.
- `normalize_text` now runs it, so team names, the identity index, the candidate token index, the description fallback and built-in alias keys (`bayern munchen`, `sevilla fc` — unreachable before) all see the same form as stream text.
- `apply_city_translations` delegates to it. Same class of defect as #653.

Translation is idempotent (asserted), so the `normalize_for_matching` → `normalize_text` double pass is safe.

## Tests

`tests/matching/test_city_translations.py`: both normalizers agree on every affected name, each native spelling scores 100 against its own team, München → Munich still matches, idempotency, the reported Nürnberg–Hannover pair scores, and the `sevilla fc` alias resolves.

Gates: `ruff check` clean · `pytest tests/` 3073 passed · `npm run build` ok.