### PR TITLE
fix(keywords): never fire an exception keyword on a word the matched event is named with (#803)

### DIFF
--- a/docs/guide/channels/consolidation.md
+++ b/docs/guide/channels/consolidation.md
@@ -41,6 +41,8 @@ Each keyword has:
 A fresh install ships with eight language keywords seeded (Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese — all Sub-Consolidate), so alternate-language feeds split out of the box. Each seeded keyword is offered **once**: delete or rename one and it stays gone across restarts and upgrades. To get a deleted default back, add it again by hand.
 
 {: .note }
+A keyword never fires on a word the event itself is named with: the *Spanish* keyword leaves a `Spanish Grand Prix` stream alone (and *French* a French Open stream), while `En Español` or `(ESP)` on that same event still counts as a language feed.
+
 The Exception Keywords card is only *shown* in Consolidate mode, but stored keywords are checked on every run regardless of mode — a keyword's behavior overrides the global mode per-stream (an **Ignore** keyword drops its streams even in Separate mode).
 
 Keyword placement is **enforced every generation**: if a stream should move between a main channel and its keyword variant (because keywords or stream names changed), it's moved, and the main channel is always kept on the lower channel number than its variants.

--- a/teamarr/consumers/enforcement/keywords.py
+++ b/teamarr/consumers/enforcement/keywords.py
@@ -85,6 +85,7 @@ class KeywordEnforcer:
         from teamarr.database.channels import (
             add_stream_to_channel,
             check_exception_keyword,
+            event_identity_text,
             get_all_managed_channels,
             get_channel_streams,
             get_exception_keywords,
@@ -126,7 +127,7 @@ class KeywordEnforcer:
 
                         # What keyword should this stream have?
                         expected_keyword, behavior = check_exception_keyword(
-                            stream_name, exception_keywords
+                            stream_name, exception_keywords, event_identity_text(channel)
                         )
 
                         # Normalize: None for no keyword

--- a/teamarr/consumers/event_group_processor/xmltv.py
+++ b/teamarr/consumers/event_group_processor/xmltv.py
@@ -106,7 +106,11 @@ class XmltvRenderer:
         filler_cache: dict[int, EventFillerConfig | None] = {}  # {template_id: filler_config}
 
         # Load exception keywords for stream annotation (used by EPG generator)
-        from teamarr.database.channels import check_exception_keyword, get_exception_keywords
+        from teamarr.database.channels import (
+            check_exception_keyword,
+            event_identity_text,
+            get_exception_keywords,
+        )
 
         exception_keywords = get_exception_keywords(conn)
 
@@ -190,7 +194,9 @@ class XmltvRenderer:
             # Annotate match with exception keyword for EPG channel name parity
             stream_name = match.get("stream", {}).get("name", "")
             if stream_name and exception_keywords:
-                keyword_label, _ = check_exception_keyword(stream_name, exception_keywords)
+                keyword_label, _ = check_exception_keyword(
+                    stream_name, exception_keywords, event_identity_text(match.get("event"))
+                )
                 if keyword_label:
                     match["_exception_keyword"] = keyword_label
 

--- a/teamarr/consumers/lifecycle/creator.py
+++ b/teamarr/consumers/lifecycle/creator.py
@@ -234,7 +234,7 @@ class ChannelCreator(_LifecycleHost):
 
                         # Check exception keyword
                         matched_keyword, keyword_behavior = self._check_exception_keyword(
-                            stream_name, conn
+                            stream_name, conn, event
                         )
 
                         # V1 Parity: If behavior is 'ignore', skip stream entirely

--- a/teamarr/consumers/lifecycle/service.py
+++ b/teamarr/consumers/lifecycle/service.py
@@ -396,16 +396,20 @@ class ChannelLifecycleService(
         self,
         stream_name: str,
         conn: Connection,
+        event: Any = None,
     ) -> tuple[str | None, str | None]:
         """Check if stream name matches any exception keyword.
+
+        ``event`` (the matched Event) lets the check skip terms the event is
+        itself named with (#803).
 
         Returns:
             Tuple of (matched_keyword, behavior) or (None, None)
         """
-        from teamarr.database.channels import check_exception_keyword
+        from teamarr.database.channels import check_exception_keyword, event_identity_text
 
         keywords = self._get_exception_keywords(conn)
-        return check_exception_keyword(stream_name, keywords)
+        return check_exception_keyword(stream_name, keywords, event_identity_text(event))
 
     def _resolve_event_template(
         self,

--- a/teamarr/database/channels/__init__.py
+++ b/teamarr/database/channels/__init__.py
@@ -31,6 +31,7 @@ from .history import (
 # Keywords operations
 from .keywords import (
     check_exception_keyword,
+    event_identity_text,
     get_exception_keywords,
 )
 
@@ -105,6 +106,7 @@ __all__ = [
     # Keywords
     "get_exception_keywords",
     "check_exception_keyword",
+    "event_identity_text",
     # Settings helpers
     "get_dispatcharr_settings",
     "get_reconciliation_settings",

--- a/teamarr/database/channels/keywords.py
+++ b/teamarr/database/channels/keywords.py
@@ -6,6 +6,7 @@ Full CRUD is in database/exception_keywords.py.
 
 import re
 from sqlite3 import Connection
+from typing import Any
 
 from teamarr.database.exception_keywords import ExceptionKeyword, get_all_keywords
 
@@ -56,9 +57,29 @@ def _make_keyword_pattern(term: str) -> str:
     return start + escaped + end
 
 
+def event_identity_text(event: Any) -> str:
+    """The words an event is named with, for :func:`check_exception_keyword`.
+
+    Name, short name and venue country — "Tag Heuer Spanish Grand Prix",
+    "Spanish GP", "Spain". Accepts an Event, a managed-channel row (which
+    only carries ``event_name``) or a plain string.
+    """
+    if event is None:
+        return ""
+    if isinstance(event, str):
+        return event
+    parts = [
+        getattr(event, "name", None) or getattr(event, "event_name", None),
+        getattr(event, "short_name", None),
+        getattr(getattr(event, "venue", None), "country", None),
+    ]
+    return " | ".join(p for p in parts if p)
+
+
 def check_exception_keyword(
     stream_name: str,
     keywords: list[ExceptionKeyword],
+    event_text: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Check if stream name matches any exception keyword.
 
@@ -66,9 +87,18 @@ def check_exception_keyword(
     "Pelicans", while still supporting terms with special characters like "(ESP)"
     and multi-word phrases like "Peyton and Eli".
 
+    A term never fires on a word the matched event is itself named with
+    (#803): the seeded "Spanish" keyword, set to Ignore, dropped every
+    "Spanish Grand Prix" stream on a live install. Pass the event's identity
+    text (:func:`event_identity_text`) and any term found inside it is
+    skipped for that stream — "Spanish" for the Spanish GP, "French" for the
+    French Open — while "En Español" / "(ESP)" still fire, since the event
+    is not named with them.
+
     Args:
         stream_name: Stream name to check
         keywords: List of ExceptionKeyword objects
+        event_text: The matched event's name/short name/venue country, or None
 
     Returns:
         Tuple of (label, behavior) or (None, None) if no match.
@@ -76,12 +106,12 @@ def check_exception_keyword(
         channel naming and the {exception_keyword} template variable.
     """
     stream_lower = stream_name.lower()
-
+    event_lower = event_text.lower() if event_text else ""
     for kw in keywords:
         for term in kw.match_term_list:
             pattern = _make_keyword_pattern(term)
+            if event_lower and re.search(pattern, event_lower):
+                continue
             if re.search(pattern, stream_lower):
-                # Return the label (not the matched term) for channel naming
                 return (kw.label, kw.behavior)
-
     return (None, None)

--- a/tests/test_exception_keyword_event_guard.py
+++ b/tests/test_exception_keyword_event_guard.py
@@ -1,0 +1,106 @@
+# ruff: noqa: E501  — captured stream names are the fixtures
+"""Exception keywords never fire on a word the matched event is named with (#803).
+
+Prod, 2026-09-12: the seeded "Spanish" keyword, set to Ignore, dropped all 12
+matched Spanish Grand Prix streams at channel creation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from teamarr.database.channels.keywords import check_exception_keyword, event_identity_text
+from teamarr.database.exception_keywords import ExceptionKeyword
+
+LANGUAGES = [
+    ExceptionKeyword(
+        id=1, label="Spanish", match_terms="Spanish, En Español, (ESP), Español", behavior="ignore"
+    ),
+    ExceptionKeyword(
+        id=2, label="French", match_terms="French, (FRA), Français", behavior="ignore"
+    ),
+    ExceptionKeyword(
+        id=3, label="Italian", match_terms="Italian, (ITA), Italiano", behavior="ignore"
+    ),
+]
+
+
+@dataclass
+class _Venue:
+    country: str | None
+
+
+@dataclass
+class _Event:
+    name: str
+    short_name: str | None = None
+    venue: _Venue | None = None
+
+
+@dataclass
+class _ChannelRow:
+    event_name: str | None
+
+
+SPANISH_GP = _Event("Tag Heuer Spanish Grand Prix", "Spanish GP", _Venue("Spain"))
+
+
+class TestEventIdentityText:
+    def test_event_fields(self):
+        assert (
+            event_identity_text(SPANISH_GP) == "Tag Heuer Spanish Grand Prix | Spanish GP | Spain"
+        )
+
+    def test_channel_row_only_has_the_name(self):
+        assert (
+            event_identity_text(_ChannelRow("Pirelli Italian Grand Prix"))
+            == "Pirelli Italian Grand Prix"
+        )
+
+    def test_none_and_str(self):
+        assert event_identity_text(None) == ""
+        assert event_identity_text("French Open") == "French Open"
+
+
+class TestGuard:
+    def test_spanish_grand_prix_streams_survive_the_spanish_keyword(self):
+        stream = "TSN+ 07: Formula 1 On-Board Camera: Charles Leclerc - Spanish Grand Prix Practice #3 @ 12 Sep 06:20 AM ET"
+        assert check_exception_keyword(stream, LANGUAGES, event_identity_text(SPANISH_GP)) == (
+            None,
+            None,
+        )
+
+    def test_a_real_spanish_language_feed_of_the_spanish_gp_still_fires(self):
+        stream = "ESPN+ 41: En Español - Spanish Grand Prix Qualifying @ 12 Sep 10:00AM ET"
+        assert check_exception_keyword(stream, LANGUAGES, event_identity_text(SPANISH_GP)) == (
+            "Spanish",
+            "ignore",
+        )
+        stream = "F1: Spanish Grand Prix Race (ESP) [1080p]"
+        assert check_exception_keyword(stream, LANGUAGES, event_identity_text(SPANISH_GP)) == (
+            "Spanish",
+            "ignore",
+        )
+
+    def test_french_open_and_italian_gp(self):
+        assert check_exception_keyword(
+            "Tennis: French Open - Court Philippe-Chatrier", LANGUAGES, "French Open"
+        ) == (None, None)
+        assert check_exception_keyword(
+            "F1 TV 03: Italian Grand Prix - F1 Race", LANGUAGES, "Pirelli Italian Grand Prix"
+        ) == (None, None)
+
+    def test_without_event_text_behaviour_is_unchanged(self):
+        stream = "F1 TV 03: Italian Grand Prix - F1 Race"
+        assert check_exception_keyword(stream, LANGUAGES) == ("Italian", "ignore")
+
+    def test_other_events_are_not_shielded(self):
+        # The guard is per event: a Spanish-language NBA feed still fires.
+        assert check_exception_keyword(
+            "NBA: Lakers vs Celtics (Spanish)", LANGUAGES, "Los Angeles Lakers at Boston Celtics"
+        ) == ("Spanish", "ignore")
+
+    def test_enforcement_sees_the_channel_row_name(self):
+        row = _ChannelRow("Tag Heuer Spanish Grand Prix")
+        stream = "TSN+ 05: Formula 1 Driver Tracker - Spanish Grand Prix Practice #3"
+        assert check_exception_keyword(stream, LANGUAGES, event_identity_text(row)) == (None, None)


### PR DESCRIPTION
Closes #803 (on release).

## Problem

Prod, 2026-09-12: the seeded language keywords are set to **Ignore**, and "Spanish" is a term of the Spanish keyword. All 12 matched F1 streams that name the event (`… - Spanish Grand Prix Practice #3 @ …`) were skipped at channel creation — **0 reached a channel**. The Italian, Japanese, Chinese and Mexican Grands Prix, the French and Italian Opens and the Spanish Super Cup are the same shape.

## Fix

A term never fires on a word the matched event is itself named with. `check_exception_keyword` takes the event's identity text — name, short name, venue country (`event_identity_text`, which also reads a managed-channel row's `event_name`) — and skips any term found inside it. All three check sites pass the event: the channel creator (matched Event), keyword enforcement (channel row), the EPG writer (`match["event"]`).

`En Español` / `(ESP)` on the Spanish GP still fire: the event is not named with them. Nothing per sport, nothing per keyword.

## Tests

`tests/test_exception_keyword_event_guard.py` (9): the prod stream survives, a real Spanish-language feed of the same event is still ignored, French Open / Italian GP, no-event-text behaviour unchanged, other events not shielded, enforcement row path. Full suite 3,172 passing; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg