### PR TITLE
perf(espn): fetch the D-1..D+1 event window as one ranged scoreboard call (#808)

### DIFF
--- a/teamarr/providers/espn/provider.py
+++ b/teamarr/providers/espn/provider.py
@@ -8,6 +8,7 @@ import logging
 import re
 from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from teamarr.core import (
     SEASON_OFFSEASON,
@@ -266,11 +267,18 @@ class ESPNProvider(MMAParserMixin, TennisParserMixin, TournamentParserMixin, Spo
         sport_league: tuple[str, str] | None,
     ) -> list[Event]:
         """Standard per-date scoreboard fetch (non-MMA, non-tournament)."""
-        date_str = target_date.strftime("%Y%m%d")
+        return self._scoreboard_events_for(league, target_date.strftime("%Y%m%d"), sport_league)
+
+    def _scoreboard_events_for(
+        self, league: str, date_str: str, sport_league: tuple[str, str] | None
+    ) -> list[Event]:
+        """One scoreboard request for ``date_str`` (a day or a ``A-B`` range), parsed."""
         data = self._client.get_scoreboard(league, date_str, sport_league)
         if not data:
             return []
+        return self._parse_scoreboard_payload(data, league)
 
+    def _parse_scoreboard_payload(self, data: dict, league: str) -> list[Event]:
         # Capture league name from scoreboard for discovered leagues
         self._capture_league_name(data, league)
 
@@ -281,6 +289,56 @@ class ESPNProvider(MMAParserMixin, TennisParserMixin, TournamentParserMixin, Spo
                 events.append(event)
 
         return events
+
+    # ESPN files a scoreboard event under the US-Eastern date of its start
+    # (verified 2026-09-12: 161/161 events across MLB, NFL, NCAAF, EPL, La
+    # Liga). The span fetch below re-creates those buckets from a ranged
+    # response, so the service's per-day raw cache stays the cache of record.
+    SCOREBOARD_BUCKET_TZ = ZoneInfo("America/New_York")
+
+    def get_events_span(
+        self, league: str, start: date, end: date
+    ) -> dict[date, list[Event]] | None:
+        """The provider-day buckets ``start..end`` from ONE ranged scoreboard call (#808).
+
+        The date seam unions D-1, D and D+1 (#601); on a cold cache that was
+        three requests per league. ESPN accepts ``?dates=YYYYMMDD-YYYYMMDD``
+        and answers with the identical event set (measured over 16 league ×
+        weekend cases, including college football's per-conference ``groups``
+        calls), so the union costs one request. Returns the events keyed by
+        the bucket day ESPN would have filed them under, every day in the span
+        present (empty days included), so the caller can cache each bucket
+        exactly as a per-day fetch would have. ``None`` for the MMA and
+        tournament paths, which have their own windowing — the caller falls
+        back to per-day fetches.
+        ``None`` also when the request itself fails, so a blip on the range
+        endpoint costs nothing: the per-day fetches take over.
+        """
+        if end < start:
+            return None
+        sport_league = self._get_sport_league_from_db(league)
+        sport = self._get_sport(league)
+        if self._is_mma(league, sport) or sport in TOURNAMENT_SPORTS:
+            return None
+        data = self._client.get_scoreboard(league, f"{start:%Y%m%d}-{end:%Y%m%d}", sport_league)
+        if not data:
+            # A failed range request must not become three cached empty days;
+            # declining lets the caller fetch each day as before.
+            return None
+        events = self._parse_scoreboard_payload(data, league)
+        buckets: dict[date, list[Event]] = {}
+        day = start
+        while day <= end:
+            buckets[day] = []
+            day += timedelta(days=1)
+        for event in events:
+            bucket_day = event.start_time.astimezone(self.SCOREBOARD_BUCKET_TZ).date()
+            # A range answer is the union of its days; anything ESPN filed
+            # outside the asked-for days is not something a per-day fetch
+            # would have returned, so it is dropped rather than mis-filed.
+            if bucket_day in buckets:
+                buckets[bucket_day].append(event)
+        return buckets
 
     def get_sample_candidates(self, league: str) -> list[Event]:
         """Recent + upcoming events for a sample preview, in ≤2 calls.

--- a/teamarr/services/sports_data.py
+++ b/teamarr/services/sports_data.py
@@ -376,9 +376,11 @@ class SportsDataService:
         A failing neighbour bucket must never cost us the day actually asked
         for, so each fetch is isolated.
         """
+        days = provider_day_buckets(target_date)
+        self._prefill_span_buckets(provider, league, days)
         seen: set[tuple[str | None, str | None]] = set()
         events: list[Event] = []
-        for day in provider_day_buckets(target_date):
+        for day in days:
             try:
                 bucket = self._fetch_provider_day(provider, league, day)
             except Exception as e:  # noqa: BLE001 - one bad bucket ≠ lost day
@@ -398,6 +400,79 @@ class SportsDataService:
                 events.append(event)
         return events
 
+    def _prefill_span_buckets(
+        self, provider: SportsProvider, league: str, days: list[date]
+    ) -> None:
+        """Fill the missing raw day buckets with ONE ranged provider call (#808).
+
+        The per-day raw cache stays the cache of record: a provider that can
+        answer a date range (``get_events_span`` — ESPN) returns the events
+        already keyed by ITS bucket day, and each bucket is stored exactly as a
+        per-day fetch would store it, TTL included. Only when two or more of
+        the wanted days are missing is the range worth a request; one missing
+        day is the same single call either way, and that is the steady state
+        for consecutive target dates (D+1 of one day is D of the next). Any
+        failure or a ``None`` answer leaves the buckets missing, so the caller's
+        per-day loop fetches them as before — the range is an optimisation,
+        never the only path.
+        """
+        span = getattr(provider, "get_events_span", None)
+        if span is None:
+            return
+        missing = [
+            d for d in days if isinstance(self._load_raw_bucket(provider, league, d), _CacheMiss)
+        ]
+        if len(missing) < 2:
+            return
+        start, end = min(missing), max(missing)
+        try:
+            buckets = span(league, start, end)
+        except Exception as e:  # noqa: BLE001 - fall back to per-day fetches
+            logger.warning(
+                "[EVENTS] %s span %s..%s for %s failed, using day buckets: %s",
+                type(provider).__name__,
+                start,
+                end,
+                league,
+                e,
+            )
+            return
+        if not isinstance(buckets, dict):
+            # None = the provider declined (MMA/tournament paths, a failed
+            # request); anything else is not a bucket map. Either way the
+            # per-day loop below fetches as before.
+            return
+        for day in missing:
+            raw_key = self._raw_bucket_key(provider, league, day)
+            with self._cache.lock_key(raw_key):
+                if isinstance(self._load_raw_bucket(provider, league, day), _CacheMiss):
+                    self._store_raw_bucket(raw_key, day, buckets.get(day, []))
+
+    def _raw_bucket_key(self, provider: SportsProvider, league: str, day: date) -> str:
+        return make_cache_key("events_raw", type(provider).__name__, league, day.isoformat())
+
+    def _load_raw_bucket(
+        self, provider: SportsProvider, league: str, day: date
+    ) -> list[Event] | _CacheMiss:
+        cached = self._cache.get(self._raw_bucket_key(provider, league, day))
+        if not isinstance(cached, list):
+            return _CACHE_MISS
+        if any(_event_dict_is_stale(e) for e in cached if isinstance(e, dict)):
+            return _CACHE_MISS
+        try:
+            return [dict_to_event(e) for e in cached]
+        except (KeyError, TypeError) as e:
+            logger.warning("[CACHE_ERROR] Raw bucket deserialization failed: %s", e)
+            return _CACHE_MISS
+
+    def _store_raw_bucket(self, raw_key: str, day: date, events: list[Event]) -> None:
+        all_final = len(events) == 0 or all(is_event_final(e) for e in events)
+        self._cache.set(
+            raw_key,
+            [event_to_dict(e) for e in events],
+            get_events_cache_ttl(day, all_events_final=all_final),
+        )
+
     def _fetch_provider_day(
         self, provider: SportsProvider, league: str, day: date
     ) -> list[Event]:
@@ -415,38 +490,19 @@ class SportsDataService:
         matching. Lock order is always events_v2 → events_raw, never the
         reverse, so the nesting cannot cycle.
         """
-        raw_key = make_cache_key(
-            "events_raw", type(provider).__name__, league, day.isoformat()
-        )
+        raw_key = self._raw_bucket_key(provider, league, day)
 
-        def load_bucket() -> list[Event] | _CacheMiss:
-            cached = self._cache.get(raw_key)
-            if not isinstance(cached, list):
-                return _CACHE_MISS
-            if any(_event_dict_is_stale(e) for e in cached if isinstance(e, dict)):
-                return _CACHE_MISS
-            try:
-                return [dict_to_event(e) for e in cached]
-            except (KeyError, TypeError) as e:
-                logger.warning("[CACHE_ERROR] Raw bucket deserialization failed: %s", e)
-                return _CACHE_MISS
-
-        hit = load_bucket()
+        hit = self._load_raw_bucket(provider, league, day)
         if not isinstance(hit, _CacheMiss):
             return hit
 
         with self._cache.lock_key(raw_key):
-            hit = load_bucket()
+            hit = self._load_raw_bucket(provider, league, day)
             if not isinstance(hit, _CacheMiss):
                 return hit
 
             events = provider.get_events(league, day)
-            all_final = len(events) == 0 or all(is_event_final(e) for e in events)
-            self._cache.set(
-                raw_key,
-                [event_to_dict(e) for e in events],
-                get_events_cache_ttl(day, all_events_final=all_final),
-            )
+            self._store_raw_bucket(raw_key, day, events)
             return events
 
     def get_sample_event(self, league: str) -> Event | None:

--- a/tests/providers/test_espn_span_fetch.py
+++ b/tests/providers/test_espn_span_fetch.py
@@ -1,0 +1,98 @@
+"""ESPN ranged scoreboard fetch (#808): one call for D-1..D+1, filed into ESPN's own day buckets."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from teamarr.core import Event, EventStatus, Team
+from teamarr.providers.espn.provider import ESPNProvider
+
+
+def _team(name: str) -> Team:
+    return Team(
+        id=name,
+        provider="espn",
+        name=name,
+        short_name=name,
+        abbreviation=name[:3].upper(),
+        league="mlb",
+        sport="baseball",
+    )
+
+
+def _event(event_id: str, start: datetime) -> Event:
+    return Event(
+        id=event_id,
+        provider="espn",
+        name=event_id,
+        short_name=event_id,
+        start_time=start,
+        home_team=_team("H"),
+        away_team=_team("A"),
+        status=EventStatus(state="scheduled"),
+        league="mlb",
+        sport="baseball",
+    )
+
+
+@pytest.fixture
+def espn(monkeypatch):
+    provider = ESPNProvider(client=object(), league_mapping_source=None)
+    monkeypatch.setattr(provider, "_get_sport_league_from_db", lambda league: ("baseball", "mlb"))
+    monkeypatch.setattr(
+        provider,
+        "_get_sport",
+        lambda league: {"ufc": "mma", "atp": "tennis"}.get(league, "baseball"),
+    )
+    monkeypatch.setattr(provider, "_is_mma", lambda league, sport: sport == "mma")
+    return provider
+
+
+def test_span_is_one_ranged_request_filed_by_eastern_day(espn, monkeypatch):
+    calls: list[str] = []
+    events = [
+        _event("fri-night", datetime(2026, 9, 12, 1, 40, tzinfo=UTC)),  # 9:40pm ET on the 11th
+        _event("sat", datetime(2026, 9, 12, 20, 0, tzinfo=UTC)),
+        _event("outside", datetime(2026, 9, 15, 20, 0, tzinfo=UTC)),  # not a wanted day
+    ]
+
+    class Client:
+        def get_scoreboard(self, league, date_str=None, sport_league=None):
+            calls.append(date_str)
+            return {"events": ["payload"]}
+
+    espn._client = Client()
+    monkeypatch.setattr(espn, "_parse_scoreboard_payload", lambda data, league: list(events))
+    buckets = espn.get_events_span("mlb", date(2026, 9, 11), date(2026, 9, 13))
+    assert calls == ["20260911-20260913"]
+    assert buckets is not None
+    assert sorted(buckets) == [date(2026, 9, 11), date(2026, 9, 12), date(2026, 9, 13)]
+    assert [e.id for e in buckets[date(2026, 9, 11)]] == ["fri-night"]  # ESPN files by ET date
+    assert [e.id for e in buckets[date(2026, 9, 12)]] == ["sat"]
+    assert buckets[date(2026, 9, 13)] == []  # empty day still present, so it caches as empty
+    assert not any(e.id == "outside" for day in buckets.values() for e in day)
+
+
+@pytest.mark.parametrize("league", ["ufc", "atp"])
+def test_mma_and_tournament_paths_decline_the_span(espn, league):
+    class Client:
+        def get_scoreboard(self, *a, **k):
+            pytest.fail("must not fetch")
+
+    espn._client = Client()
+    assert espn.get_events_span(league, date(2026, 9, 11), date(2026, 9, 13)) is None
+
+
+def test_failed_request_declines_instead_of_caching_empties(espn):
+    class Client:
+        def get_scoreboard(self, *a, **k):
+            return None
+
+    espn._client = Client()
+    assert espn.get_events_span("mlb", date(2026, 9, 11), date(2026, 9, 13)) is None
+
+
+def test_inverted_span_declines(espn):
+    assert espn.get_events_span("mlb", date(2026, 9, 13), date(2026, 9, 11)) is None

--- a/tests/services/test_event_date_seam.py
+++ b/tests/services/test_event_date_seam.py
@@ -329,3 +329,96 @@ def test_failing_neighbour_bucket_does_not_lose_the_requested_day():
     service.add_provider(_FlakyNeighbour([fight]))
 
     assert [e.id for e in service.get_events("boxing", date(2026, 8, 22))] == ["sat"]
+
+
+# ---------------------------------------------------------------------------
+# Ranged span fetch (#808)
+# ---------------------------------------------------------------------------
+
+
+class _SpanProvider(_DayBucketedProvider):
+    """A day-bucketed API that can also answer a date range in one call (ESPN)."""
+
+    def __init__(self, events, *, span_answer="buckets"):
+        super().__init__(events)
+        self.spans_fetched: list[tuple[date, date]] = []
+        self.span_answer = span_answer
+
+    def get_events_span(self, league, start, end):
+        self.spans_fetched.append((start, end))
+        if self.span_answer == "none":
+            return None
+        if self.span_answer == "raise":
+            raise RuntimeError("range endpoint down")
+        if self.span_answer == "garbage":
+            return object()  # a MagicMock-shaped provider answers like this
+        buckets = {}
+        day = start
+        while day <= end:
+            buckets[day] = [e for e in self.events if e.start_time.date() == day]
+            day += timedelta(days=1)
+        return buckets
+
+
+def _span_service(events, **kw):
+    service = SportsDataService(providers=[])
+    service._cache = _FakeCache()
+    provider = _SpanProvider(events, **kw)
+    service.add_provider(provider)
+    return service, provider
+
+
+def test_cold_lookup_is_one_ranged_call_not_three_buckets():
+    service, provider = _span_service([])
+    service.get_events("ita.1", date(2026, 8, 29))
+    assert provider.spans_fetched == [(date(2026, 8, 28), date(2026, 8, 30))]
+    assert provider.days_fetched == []
+    # Every day of the span is now a raw bucket, empty ones included.
+    raw = [k for k in service._cache.store if k.startswith("events_raw:")]
+    assert len(raw) == 3
+
+
+def test_span_result_equals_the_bucketed_result(monkeypatch):
+    """The #601 regression case, served by the range instead of three buckets."""
+    _use_tz(monkeypatch, ZoneInfo("Australia/Sydney"))
+    juventus = _event("juve", datetime(2026, 8, 29, 18, 45, tzinfo=UTC))
+    service, provider = _span_service([juventus])
+    assert [e.id for e in service.get_events("ita.1", date(2026, 8, 30))] == ["juve"]
+    assert service.get_events("ita.1", date(2026, 8, 29)) == []
+    # First lookup: one range (29..31). Second: only the 28th is missing, so
+    # a single per-day fetch — never a second range.
+    assert provider.spans_fetched == [(date(2026, 8, 29), date(2026, 8, 31))]
+    assert provider.days_fetched == [date(2026, 8, 28)]
+
+
+def test_consecutive_dates_fetch_only_the_new_day_per_day():
+    """Steady state: one missing bucket is one call either way — no range."""
+    service, provider = _span_service([])
+    service.get_events("ita.1", date(2026, 8, 29))
+    service.get_events("ita.1", date(2026, 8, 30))
+    assert provider.spans_fetched == [(date(2026, 8, 28), date(2026, 8, 30))]
+    assert provider.days_fetched == [date(2026, 8, 31)]
+
+
+def test_two_missing_non_adjacent_buckets_still_use_one_range():
+    service, provider = _span_service([])
+    # Warm only the middle day.
+    service._fetch_provider_day(provider, "ita.1", date(2026, 8, 29))
+    provider.days_fetched.clear()
+    service.get_events("ita.1", date(2026, 8, 29))
+    assert provider.spans_fetched == [(date(2026, 8, 28), date(2026, 8, 30))]
+    assert provider.days_fetched == []
+
+
+@pytest.mark.parametrize("answer", ["none", "raise", "garbage"])
+def test_span_declining_or_failing_falls_back_to_day_buckets(answer):
+    service, provider = _span_service([], span_answer=answer)
+    service.get_events("ita.1", date(2026, 8, 29))
+    assert provider.spans_fetched == [(date(2026, 8, 28), date(2026, 8, 30))]
+    assert provider.days_fetched == [date(2026, 8, 28), date(2026, 8, 29), date(2026, 8, 30)]
+
+
+def test_providers_without_a_span_method_are_untouched():
+    service, provider = _bucketed_service([])
+    service.get_events("ita.1", date(2026, 8, 29))
+    assert provider.days_fetched == [date(2026, 8, 28), date(2026, 8, 29), date(2026, 8, 30)]

--- a/tests/test_espn_team_schedule_dedup.py
+++ b/tests/test_espn_team_schedule_dedup.py
@@ -71,10 +71,11 @@ def test_scoreboard_fetched_once_per_day_across_teams(monkeypatch):
     for i in range(n_teams):
         service_opt.get_team_schedule(f"team{i}", "verify-on", days_ahead=days_ahead)
 
-    # Flat regardless of team count — the whole point. The +2 is the pair of
-    # boundary buckets: a contiguous run of N days spans N+2 provider-days
-    # once each day fetches D-1..D+1 (#601).
-    assert client_opt.scoreboard_calls == days_ahead + 2
+    # Flat regardless of team count — the whole point. A contiguous run of N
+    # days spans N+2 provider-day buckets (D-1..D+1, #601); the first day
+    # fetches its three buckets as ONE ranged request (#808) and every later
+    # day adds exactly one new bucket, so the run costs N requests.
+    assert client_opt.scoreboard_calls == days_ahead
 
 
 def test_optimization_cuts_redundant_fetches(monkeypatch):
@@ -90,5 +91,5 @@ def test_optimization_cuts_redundant_fetches(monkeypatch):
         service_on.get_team_schedule(f"team{i}", "verify-on", days_ahead=days_ahead)
 
     assert client_off.scoreboard_calls == n_teams * days_ahead
-    assert client_on.scoreboard_calls == days_ahead + 2
+    assert client_on.scoreboard_calls == days_ahead  # one range + (N-1) new buckets (#808)
     assert client_on.scoreboard_calls < client_off.scoreboard_calls


### PR DESCRIPTION
Closes #808 (on release). Bead `teamarr-2mzz`.

## Problem

The #601 date seam builds each target date's candidate set by unioning three provider-day buckets (D-1, D, D+1). On a cold cache that is three ESPN scoreboard requests per league per date.

## Measured first

- ESPN answers `?dates=YYYYMMDD-YYYYMMDD` with the **identical** event-id set as the three per-day calls, exactly as the app makes them (no `limit`): 16 league × weekend cases, 0 differences, including college football's per-conference `groups` calls (85/85, 81/81).
- ESPN files every scoreboard event under the **US-Eastern date** of its start: 161/161 events across MLB, NFL, NCAAF, EPL, La Liga. So a range answer can be split back into the same per-day buckets the seam already caches.
- Live through the real service on a cold cache: MLB 3 → 1 request, college football 3 → 1 (× its 5 groups), identical events; F1 stays at 3 (tournament path declines the range by design).
- Passing `limit=1000` makes ESPN cap a college call at 25 — the app never passes it; noted so nobody "optimises" that in.

## Change

- `ESPNProvider.get_events_span(league, start, end)` — one ranged request, returned as `{bucket_day: [events]}` with every day present (empty included). `None` for MMA/tournament paths and for a failed request, so the caller falls back.
- `SportsDataService._prefill_span_buckets` — when two or more of D-1..D+1 are missing from the raw cache, fill them from one span call, stored exactly as per-day fetches would store them (same keys, same TTLs). One missing bucket is fetched per day as before, which is the steady state for consecutive dates. Anything but a dict answer is a decline.
- The raw bucket load/store was extracted into helpers shared by both paths.

Call budget: a contiguous run of N days now costs N requests (was N+2); an isolated cold date costs 1 (was 3). `test_espn_team_schedule_dedup` expectations updated accordingly; the MagicMock-based fan-out budget tests are untouched because a mock's span answer is not a dict and therefore declines.

## Tests

7 new seam tests (one range on cold, steady-state per-day, non-adjacent misses, decline/raise/garbage fallbacks, providers without the method untouched) and 4 provider tests (date string, Eastern-day filing, out-of-range dropped, MMA/tournament/failure decline). Full suite 3,240; ruff clean; frontend builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAkD5Qr8TYazFo4eEfW5dg