### PR TITLE
fix(tests): date the Dayton short-code fixtures to today (#813)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -933,3 +933,4 @@
 {"id":"int-f620be9f9c35c6d0f85347182b8be9f9","kind":"field_change","created_at":"2026-09-11T12:10:10.332562436Z","actor":"luke","issue_id":"teamarr-ptm8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-6a128bdace443a25c71a64bf8c54346d","kind":"field_change","created_at":"2026-09-11T12:13:47.374033279Z","actor":"luke","issue_id":"teamarr-6moo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d0a93f103bd6f8fc157dbf383b5d5a2b","kind":"field_change","created_at":"2026-09-11T18:32:48.267832386Z","actor":"luke","issue_id":"teamarr-duvz","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-7255e434c29fdceb1159f8582a026d56","kind":"field_change","created_at":"2026-09-13T02:01:57.855686186Z","actor":"luke","issue_id":"teamarr-7y5g","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/tests/matching/test_short_code_matching.py
+++ b/tests/matching/test_short_code_matching.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 from teamarr.consumers.matching.classifier import classify_stream
-from teamarr.consumers.matching.result import ResultCategory
+from teamarr.consumers.matching.result import FailedReason, ResultCategory
 from teamarr.consumers.matching.team_matcher import (
     MatchContext,
     _abbrev_equals,
@@ -20,6 +20,12 @@ from teamarr.core.types import Event, EventStatus, Team
 from tests.fakes import make_team_matcher
 
 TODAY = datetime.now(UTC).date()
+# Stream-name spellings of TODAY (#813). Fixtures whose event is built at
+# TODAY must annotate their stream with the same day, or the classifier reads
+# a date the event cannot satisfy and every such test rots into DATE_MISMATCH
+# the moment the wall clock moves past the hardcoded one.
+TODAY_MON_DAY = f"{TODAY:%b} {TODAY.day}"  # "Sep 12"
+TODAY_DAY_MON = f"{TODAY.day:02d} {TODAY:%b}"  # "12 Sep"
 
 
 def _team(name: str, abbr: str, league: str = "mlb") -> Team:
@@ -160,13 +166,17 @@ class TestCommonWordAbbreviations:
         south_florida = _team("South Florida Bulls", "USF", "womens-college-volleyball")
         event = _event(south_florida, dayton, "evt-day")
         outcome = _match(
-            "DAZN CA 16: MLTT - Week 1, Day 1 @ 11 Sep 03:00 PM ET", event
+            f"DAZN CA 16: MLTT - Week 1, Day 1 @ {TODAY_DAY_MON} 03:00 PM ET", event
         )
+        # Dated to the event's own day so the rejection can only come from the
+        # DAY stopword — a stale date would pass this test for free, which is
+        # exactly how it rotted (#813). Pinning the reason keeps it honest.
         assert outcome.category != ResultCategory.MATCHED
+        assert outcome.failed_reason == FailedReason.TEAMS_NOT_PARSED
 
     def test_full_name_dayton_streams_still_match(self):
         dayton = _team("Dayton Flyers", "DAY", "womens-college-volleyball")
         south_florida = _team("South Florida Bulls", "USF", "womens-college-volleyball")
         event = _event(south_florida, dayton, "evt-day")
-        outcome = _match("Dayton vs. South Florida @ Sep 11 5:00PM ET", event)
+        outcome = _match(f"Dayton vs. South Florida @ {TODAY_MON_DAY} 5:00PM ET", event)
         assert outcome.category == ResultCategory.MATCHED


### PR DESCRIPTION
Closes #813.

`tests/matching/test_short_code_matching.py` builds its events at `TODAY`, but two Dayton fixtures hardcoded **Sep 11** in the stream name. Once the wall clock moved past it, the classifier read a date the event couldn't satisfy:

```
FAILED tests/matching/test_short_code_matching.py::TestCommonWordAbbreviations::test_full_name_dayton_streams_still_match
  assert <ResultCategory.FAILED> == <ResultCategory.MATCHED>
  ... failed_reason=<FailedReason.DATE_MISMATCH> parsed_team1='Dayton', parsed_team2='South Florida'
```

This is red on `dev`, so every open PR's `Lint & test backend` job fails on it regardless of contents (found via #812).

The negative fixture, `test_junk_day_stream_does_not_match_dayton`, degraded more quietly — it kept passing, but on the date mismatch instead of on the `DAY` stopword (#705/#788) it exists to prove.

## Fix

Both stream dates now derive from `TODAY`, the same source the event uses, and the negative fixture pins `FailedReason.TEAMS_NOT_PARSED` so it can't silently start passing for free again.

`3240 passed`, ruff clean.
