### PR TITLE
Fix generated preview team prose

### DIFF
--- a/teamarr/templates/generated_preview.py
+++ b/teamarr/templates/generated_preview.py
@@ -4,6 +4,7 @@ import re
 from collections import OrderedDict
 
 from teamarr.core import GENERATED_PREVIEW_FIELDS, Event, Team
+from teamarr.core.naming import team_with_article
 
 SUPPORTED_SPORTS = frozenset({"baseball", "football", "basketball"})
 
@@ -53,6 +54,35 @@ def _team_subject(team: Team) -> str:
     if short and full.lower().endswith(f" {short.lower()}"):
         return full[: -(len(short) + 1)]
     return full
+
+
+def _team_matchup_name(team: Team) -> str:
+    """Return the natural matchup name, reducing franchise names to mascots."""
+    short = (team.short_name or "").strip()
+    full = team.name.strip()
+    if short and full.casefold().endswith(f" {short.casefold()}"):
+        return short
+    return full
+
+
+def _team_is_plural(team: Team) -> bool:
+    """Use the mascot shape to choose plural versus singular agreement."""
+    short = (team.short_name or "").strip()
+    full = team.name.strip()
+    if not short or full.casefold() == short.casefold() or not full.casefold().endswith(
+        f" {short.casefold()}"
+    ):
+        return False
+    word = short.casefold().split()[-1].rstrip(".,")
+    return word.endswith(("s", "x", "z", "ch", "sh"))
+
+
+def _team_matchup_phrase(team: Team, *, sentence_start: bool = False) -> str:
+    name = _team_matchup_name(team)
+    phrase = team_with_article(name, team.league, team.sport)
+    if sentence_start and phrase:
+        return phrase[:1].upper() + phrase[1:]
+    return phrase
 
 
 def _recent_phrase(value: str) -> str:
@@ -225,17 +255,23 @@ def _probable_starter_sentence(value: str) -> str:
 
 
 def _base_sentence(event: Event) -> str:
-    away = event.away_team.name
-    home = event.home_team.name
+    if event.sport in SUPPORTED_SPORTS or event.sport == "soccer":
+        away = _team_matchup_phrase(event.away_team, sentence_start=True)
+        home = _team_matchup_phrase(event.home_team)
+        away_verb = "visit" if _team_is_plural(event.away_team) else "visits"
+    else:
+        away = f"The {event.away_team.name}"
+        home = f"the {event.home_team.name}"
+        away_verb = "visit"
     venue = event.venue.name if event.venue else ""
     location = f" at {venue}" if venue else ""
     if event.sport == "football" and event.week:
         phase = "preseason " if event.season_type == "preseason" else ""
-        return f"The {away} visit the {home}{location} for a Week {event.week} {phase}matchup."
+        return f"{away} {away_verb} {home}{location} for a Week {event.week} {phase}matchup."
     if event.sport == "baseball" and event.series_summary:
         summary = _series_clause(_expand_team_abbreviations(event.series_summary, event))
-        return f"The {away} visit the {home}{location}, with {summary}."
-    return f"The {away} visit the {home}{location}."
+        return f"{away} {away_verb} {home}{location}, with {summary}."
+    return f"{away} {away_verb} {home}{location}."
 
 
 def _baseball_sentence(event: Event, side: str) -> str:

--- a/teamarr/templates/generated_preview.py
+++ b/teamarr/templates/generated_preview.py
@@ -4,7 +4,6 @@ import re
 from collections import OrderedDict
 
 from teamarr.core import GENERATED_PREVIEW_FIELDS, Event, Team
-from teamarr.core.naming import team_with_article
 
 SUPPORTED_SPORTS = frozenset({"baseball", "football", "basketball"})
 
@@ -56,33 +55,27 @@ def _team_subject(team: Team) -> str:
     return full
 
 
-def _team_matchup_name(team: Team) -> str:
-    """Return the natural matchup name, reducing franchise names to mascots."""
+def _mascot(team: Team) -> str:
+    """Return the short name when it is a proper suffix of the full name."""
     short = (team.short_name or "").strip()
-    full = team.name.strip()
-    if short and full.casefold().endswith(f" {short.casefold()}"):
+    if short and team.name.strip().casefold().endswith(f" {short.casefold()}"):
         return short
-    return full
+    return ""
 
 
-def _team_is_plural(team: Team) -> bool:
-    """Use the mascot shape to choose plural versus singular agreement."""
-    short = (team.short_name or "").strip()
-    full = team.name.strip()
-    if not short or full.casefold() == short.casefold() or not full.casefold().endswith(
-        f" {short.casefold()}"
-    ):
-        return False
-    word = short.casefold().split()[-1].rstrip(".,")
-    return word.endswith(("s", "x", "z", "ch", "sh"))
+def _matchup_name(team: Team, article: str) -> tuple[str, bool]:
+    """Return the matchup name and whether it takes plural agreement (#785).
 
-
-def _team_matchup_phrase(team: Team, *, sentence_start: bool = False) -> str:
-    name = _team_matchup_name(team)
-    phrase = team_with_article(name, team.league, team.sport)
-    if sentence_start and phrase:
-        return phrase[:1].upper() + phrase[1:]
-    return phrase
+    Only a plural mascot reads with an article ("the Bills"); club names and
+    singular mascots keep the full, articleless name ("Arsenal", "Miami Heat").
+    A mascot counts as plural when its last word ends in "s", plus "Sox". Exact
+    grammatical number would need metadata the Team model doesn't carry.
+    """
+    mascot = _mascot(team)
+    word = mascot.casefold().split()[-1] if mascot else ""
+    if word.endswith("s") or word == "sox":
+        return f"{article} {mascot}", True
+    return team.name.strip(), False
 
 
 def _recent_phrase(value: str) -> str:
@@ -255,14 +248,9 @@ def _probable_starter_sentence(value: str) -> str:
 
 
 def _base_sentence(event: Event) -> str:
-    if event.sport in SUPPORTED_SPORTS or event.sport == "soccer":
-        away = _team_matchup_phrase(event.away_team, sentence_start=True)
-        home = _team_matchup_phrase(event.home_team)
-        away_verb = "visit" if _team_is_plural(event.away_team) else "visits"
-    else:
-        away = f"The {event.away_team.name}"
-        home = f"the {event.home_team.name}"
-        away_verb = "visit"
+    away, away_plural = _matchup_name(event.away_team, "The")
+    home, _ = _matchup_name(event.home_team, "the")
+    away_verb = "visit" if away_plural else "visits"
     venue = event.venue.name if event.venue else ""
     location = f" at {venue}" if venue else ""
     if event.sport == "football" and event.week:

--- a/tests/templates/test_generated_preview.py
+++ b/tests/templates/test_generated_preview.py
@@ -196,15 +196,44 @@ def test_baseball_renderer_includes_starter_and_exact_leader_fallbacks():
     assert "72-59 after going 3-2 in its last 5 games" in text
 
 
+def _named_team(
+    name: str, short_name: str, abbreviation: str, league: str, sport: str
+) -> Team:
+    return Team(
+        id=abbreviation,
+        provider="espn",
+        name=name,
+        short_name=short_name,
+        abbreviation=abbreviation,
+        league=league,
+        sport=sport,
+    )
+
+
 @pytest.mark.parametrize(
     ("sport", "league", "away", "home", "expected"),
     [
-        ("soccer", "eng.1", ("Arsenal", "Arsenal"), ("Chelsea", "Chelsea"),
+        # Clubs: short name is the full name, so no mascot and no article.
+        ("soccer", "eng.1", ("Arsenal", "Arsenal", "ARS"), ("Chelsea", "Chelsea", "CHE"),
          "Arsenal visits Chelsea at Example Park."),
-        ("football", "nfl", ("Buffalo Bills", "Bills"), ("Miami Dolphins", "Dolphins"),
+        # Plural mascots take the article and a plural verb.
+        ("football", "nfl", ("Buffalo Bills", "Bills", "BUF"),
+         ("Miami Dolphins", "Dolphins", "MIA"),
          "The Bills visit the Dolphins at Example Park for a Week 3 matchup."),
-        ("baseball", "mlb", ("Orlando Magic", "Magic"), ("Miami Heat", "Heat"),
-         "The Magic visits the Heat at Example Park."),
+        # Singular mascots keep the full articleless name.
+        ("basketball", "nba", ("Miami Heat", "Heat", "MIA"), ("Utah Jazz", "Jazz", "UTA"),
+         "Miami Heat visits Utah Jazz at Example Park."),
+        ("basketball", "mens-college-basketball",
+         ("Green Bay Phoenix", "Phoenix", "GB"), ("Orlando Magic", "Magic", "ORL"),
+         "Green Bay Phoenix visits Orlando Magic at Example Park."),
+        # Each side is decided independently.
+        ("basketball", "nba", ("Utah Jazz", "Jazz", "UTA"),
+         ("Boston Celtics", "Celtics", "BOS"),
+         "Utah Jazz visits the Celtics at Example Park."),
+        # Sox is the one plural mascot that does not end in s.
+        ("baseball", "mlb", ("Boston Red Sox", "Red Sox", "BOS"),
+         ("Chicago White Sox", "White Sox", "CHW"),
+         "The Red Sox visit the White Sox at Example Park."),
     ],
 )
 def test_base_sentence_uses_team_identity_for_articles_and_agreement(
@@ -213,19 +242,26 @@ def test_base_sentence_uses_team_identity_for_articles_and_agreement(
     event = _event(
         sport=sport,
         league=league,
-        away_team=Team(
-            id="away", provider="espn", name=away[0], short_name=away[1],
-            abbreviation="AWY", league=league, sport=sport,
-        ),
-        home_team=Team(
-            id="home", provider="espn", name=home[0], short_name=home[1],
-            abbreviation="HOM", league=league, sport=sport,
-        ),
+        away_team=_named_team(*away, league, sport),
+        home_team=_named_team(*home, league, sport),
         week=3 if sport == "football" else None,
-        away_team_record="1-0" if sport == "baseball" else None,
+        away_team_record="1-0",
     )
 
     assert build_generated_preview(event).startswith(expected)
+
+
+def test_baseball_series_sentence_uses_matchup_names():
+    event = _event(
+        away_team=_named_team("Boston Red Sox", "Red Sox", "BOS", "mlb", "baseball"),
+        home_team=_named_team("Miami Marlins", "Marlins", "MIA", "mlb", "baseball"),
+        series_summary="BOS leads series 2-1",
+    )
+
+    assert build_generated_preview(event).startswith(
+        "The Red Sox visit the Marlins at Example Park, "
+        "with the Boston Red Sox leading the series 2-1."
+    )
 
 
 def test_baseball_renderer_normalizes_series_summary_grammar():
@@ -589,7 +625,7 @@ def test_unsupported_sport_generates_only_generic_complete_matchup():
     ctx, game = _context(event)
 
     assert build_generated_preview(event) == (
-        "The New York Rangers visit the Boston Bruins at TD Garden."
+        "The Rangers visit the Bruins at TD Garden."
     )
     assert ConditionEvaluator().evaluate("has_generated_preview", None, ctx, game)
     assert "44-22-8" not in build_generated_preview(event)

--- a/tests/templates/test_generated_preview.py
+++ b/tests/templates/test_generated_preview.py
@@ -4,6 +4,8 @@ from dataclasses import fields
 from datetime import UTC, datetime
 from unittest.mock import patch
 
+import pytest
+
 from teamarr.core import GENERATED_PREVIEW_FIELDS, Event, EventStatus, Team, Venue
 from teamarr.database.provider_cache import dict_to_event, event_to_dict
 from teamarr.providers.espn.preview import apply_generated_preview_fields
@@ -192,6 +194,38 @@ def test_baseball_renderer_includes_starter_and_exact_leader_fallbacks():
     assert "Probable starter Payton Tolle is 8-6 with a 3.08 ERA" in text
     assert "Probable starter Tyler Phillips is 3-6 with a 3.67 ERA" in text
     assert "72-59 after going 3-2 in its last 5 games" in text
+
+
+@pytest.mark.parametrize(
+    ("sport", "league", "away", "home", "expected"),
+    [
+        ("soccer", "eng.1", ("Arsenal", "Arsenal"), ("Chelsea", "Chelsea"),
+         "Arsenal visits Chelsea at Example Park."),
+        ("football", "nfl", ("Buffalo Bills", "Bills"), ("Miami Dolphins", "Dolphins"),
+         "The Bills visit the Dolphins at Example Park for a Week 3 matchup."),
+        ("baseball", "mlb", ("Orlando Magic", "Magic"), ("Miami Heat", "Heat"),
+         "The Magic visits the Heat at Example Park."),
+    ],
+)
+def test_base_sentence_uses_team_identity_for_articles_and_agreement(
+    sport, league, away, home, expected
+):
+    event = _event(
+        sport=sport,
+        league=league,
+        away_team=Team(
+            id="away", provider="espn", name=away[0], short_name=away[1],
+            abbreviation="AWY", league=league, sport=sport,
+        ),
+        home_team=Team(
+            id="home", provider="espn", name=home[0], short_name=home[1],
+            abbreviation="HOM", league=league, sport=sport,
+        ),
+        week=3 if sport == "football" else None,
+        away_team_record="1-0" if sport == "baseball" else None,
+    )
+
+    assert build_generated_preview(event).startswith(expected)
 
 
 def test_baseball_renderer_normalizes_series_summary_grammar():
@@ -526,7 +560,7 @@ def test_nfl_stat_abbreviations_expand_in_generated_prose():
     apply_generated_preview_fields(payload, event)
 
     assert build_generated_preview(event) == (
-        "The Pittsburgh Steelers visit the Buffalo Bills at Highmark Stadium for a "
+        "The Steelers visit the Bills at Highmark Stadium for a "
         "Week 4 preseason matchup. Pittsburgh enters at 1-1 after going 2-3 in its "
         "last 5 games, producing 343 total yards per game, including 85 rushing yards "
         "per game. Team leaders include Drew Allar with 11/23 completions for 110 "


### PR DESCRIPTION
## Summary
- Matchup sentence decides article and verb from the team's `short_name` vs full name alone — no per-sport branches.
- A mascot is a `short_name` that is a proper suffix of the full name. Plural mascots (last word ends in `s`, plus `Sox`) read with an article: *The Bills visit the Dolphins*.
- Clubs and singular mascots keep the full, articleless name with a singular verb: *Arsenal visits Chelsea*, *Miami Heat visits Utah Jazz*, *Green Bay Phoenix visits Orlando Magic*.
- Applies to the week, series and plain sentences, and to non-preview sports (hockey now reads *The Rangers visit the Bruins*).
- Tests: club, plural, singular (Heat/Jazz/Phoenix/Magic), mixed sides, the Sox exception, and a real baseball `series_summary` sentence.

Exact grammatical number would need metadata the Team model doesn't carry; the `s`/Sox rule is the deliberate approximation.

Fixes #785

## Validation
- pytest tests/ (3269 passed)
- ruff check teamarr/ tests/
- frontend build