### PR TITLE
feat: {conference_abbrev} wildcard for channel group patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ All `update_channel` calls go through `_safe_update_channel`, which checks `Oper
 - API routes build responses with `to_model(Model, dataclass)` from `api/routes/settings/models.py`; frontend hooks are factory-generated with scoped cache invalidation (`frontend/src/hooks/useSettings.ts`).
 
 **Dynamic Groups** (`teamarr/consumers/lifecycle/dynamic_resolver.py`):
-- `{sport}`, `{league}`, and `{conference}` wildcards (`{conference}` = home team's NCAA conference from `provider_group_cache`, #91)
+- `{sport}`, `{league}`, `{conference}`, `{conference_abbrev}`, and `{division}` wildcards — the conference ones resolve the home team's NCAA conference from `provider_group_cache` (#91; abbrev #777, division #717)
 - Auto-creates in Dispatcharr
 - **Group/profile names are keyed through `_group_key` — trim + lowercase, never collapse internal whitespace (#745).** Both `create_channel_group` and `create_profile` post `name.strip()`, so a name differing only at the ends can never create what it was looking for: the cache lookup misses, Dispatcharr refuses the create as a duplicate of the group that was already there, the channel gets a null `channel_group_id`, and it repeats every run because nothing about that state changes. Collapsing *internal* runs looks like the same idea and is not safe — on a live install's 3,097 groups, trimming collided 0 keys while collapsing collided 18, all real distinct groups separated only by `\xa0` vs a regular space. Any new name→id cache against Dispatcharr must go through `_group_key` on both populate and lookup.
 

--- a/docs/guide/channels/output.md
+++ b/docs/guide/channels/output.md
@@ -39,14 +39,14 @@ Pick a static group from the dropdown. By default the list hides M3U-sourced gro
 | **Static** | All channels go to the selected group above |
 | **Dynamic by Sport** | Auto-creates and assigns groups named by sport |
 | **Dynamic by League** | Auto-creates and assigns groups named by league |
-| **Custom pattern** | Define a pattern using `{sport}`, `{league}`, `{conference}`, and `{division}` placeholders |
+| **Custom pattern** | Define a pattern using `{sport}`, `{league}`, `{conference}`, `{conference_abbrev}`, and `{division}` placeholders |
 
 When **Custom pattern** is selected, a pattern field appears. For example, `{sport} | {league}` creates groups like "Hockey | NHL". Teamarr creates these dynamic groups in Dispatcharr automatically.
 
-In group patterns, `{sport}` resolves to the sport's display name ("Hockey"), and `{league}` to the league's **short alias** — "EPL", not "English Premier League". `{conference}` resolves to the home team's conference name for NCAA football/basketball events ("Southeastern Conference"), and `{division}` to that conference's division — **FBS** or **FCS** for college football, **Division I** for college basketball. Events without conference data fall back to the static group.
+In group patterns, `{sport}` resolves to the sport's display name ("Hockey"), and `{league}` to the league's **short alias** — "EPL", not "English Premier League". `{conference}` resolves to the home team's conference name for NCAA football/basketball events ("Southeastern Conference"), `{conference_abbrev}` to its compact form ("SEC", "ACC", "Big Ten"), and `{division}` to that conference's division — **FBS** or **FCS** for college football, **Division I** for college basketball. Events without conference data fall back to the static group.
 
 {: .note }
-`{division}` is the light-touch way to tame a college football Saturday: `{league} | {division}` splits ~80 games into "NCAAF | FBS" and "NCAAF | FCS" without the 25 groups `{conference}` produces. Both wildcards bucket on the **home** team, so an FBS-vs-FCS game lands in FBS — which is where you want it, since the FCS side is the visitor in those matchups. `{division}` needs a conference-tree refresh (Settings → Cache → Refresh) before it resolves; until then those events fall back to the static group.
+`{division}` is the light-touch way to tame a college football Saturday: `{league} | {division}` splits ~80 games into "NCAAF | FBS" and "NCAAF | FCS" without the 25 groups `{conference}` produces. When you do want per-conference groups but not the long names, `{conference_abbrev}` gives you "NCAAF | SEC" instead of "NCAAF | Southeastern Conference". All three wildcards bucket on the **home** team, so an FBS-vs-FCS game lands in FBS — which is where you want it, since the FCS side is the visitor in those matchups. `{division}` needs a conference-tree refresh (Settings → Cache → Refresh) before it resolves; until then those events fall back to the static group.
 
 A few failure modes are handled gracefully: a pattern whose wildcard can't resolve for an event falls back to the static group; and if a configured static group has been deleted in Dispatcharr, the channels are created **ungrouped** with a log warning telling you to re-select a group.
 

--- a/docs/guide/dispatcharr-integration.md
+++ b/docs/guide/dispatcharr-integration.md
@@ -37,7 +37,7 @@ Go to **Channels → Dispatcharr Output** to configure where Teamarr channels la
 
 - **Default Channel Profiles** — which Dispatcharr profiles Teamarr channels appear in
 - **Default Stream Profile** — which stream profile to assign to streams
-- **Default Channel Group** — a static group, or a dynamic pattern like `{sport} | {league}` that auto-creates groups (`{conference}` and `{division}` also available for NCAA leagues)
+- **Default Channel Group** — a static group, or a dynamic pattern like `{sport} | {league}` that auto-creates groups (`{conference}`, `{conference_abbrev}`, and `{division}` also available for NCAA leagues)
 
 ![Channels → Dispatcharr Output configuration cards](../assets/images/channels-output.png)
 
@@ -56,7 +56,7 @@ Once connected, each generation run manages the full channel lifecycle in Dispat
 
 ### Profile & Group Sync
 
-Teamarr enforces profile and group assignments on every generation run. If someone manually changes a channel's profiles in Dispatcharr, Teamarr corrects it on the next run. Dynamic wildcards (`{sport}`, `{league}`, `{conference}`, and `{division}` for groups) automatically create profiles and groups in Dispatcharr if they don't exist.
+Teamarr enforces profile and group assignments on every generation run. If someone manually changes a channel's profiles in Dispatcharr, Teamarr corrects it on the next run. Dynamic wildcards (`{sport}`, `{league}`, `{conference}`, `{conference_abbrev}`, and `{division}` for groups) automatically create profiles and groups in Dispatcharr if they don't exist.
 
 ### Reconciliation
 

--- a/frontend/src/components/DispatcharrOutputSettings.tsx
+++ b/frontend/src/components/DispatcharrOutputSettings.tsx
@@ -263,8 +263,8 @@ export function DispatcharrOutputSettings() {
             </Select>
             <p className="text-xs text-muted-foreground">
               Static uses the group above. Dynamic modes auto-create groups named by sport or league.
-              Custom lets you define a pattern with {"{sport}"}, {"{league}"}, {"{conference}"}, and{" "}
-              {"{division}"} (NCAA) placeholders.
+              Custom lets you define a pattern with {"{sport}"}, {"{league}"}, {"{conference}"},
+              {"{conference_abbrev}"}, and {"{division}"} (the last three NCAA) placeholders.
             </p>
           </div>
 
@@ -281,10 +281,11 @@ export function DispatcharrOutputSettings() {
                 className="w-64"
               />
               <p className="text-xs text-muted-foreground">
-                Use {"{sport}"}, {"{league}"}, {"{conference}"}, and {"{division}"} (the last two
-                NCAA only) as placeholders. Example: "{"{sport}"} | {"{league}"}" creates groups like
-                "Hockey | NHL"; "{"{league}"} | {"{division}"}" splits college football into
-                "NCAAF | FBS" and "NCAAF | FCS".
+                Use {"{sport}"}, {"{league}"}, {"{conference}"}, {"{conference_abbrev}"}, and{" "}
+                {"{division}"} (the last three NCAA only) as placeholders. Example:{" "}
+                "{"{sport}"} | {"{league}"}" creates groups like "Hockey | NHL";{" "}
+                "{"{league}"} | {"{conference_abbrev}"}" buckets college football by "NCAAF | SEC"
+                instead of the full conference name.
               </p>
             </div>
           )}

--- a/frontend/src/components/PerLeagueChannelConfig.tsx
+++ b/frontend/src/components/PerLeagueChannelConfig.tsx
@@ -279,9 +279,9 @@ function LeagueConfigRow({
                       className="w-64 mt-2"
                     />
                     <p className="text-xs text-muted-foreground mt-1">
-                      {"{sport}"}, {"{league}"}, plus {"{conference}"} and {"{division}"} for NCAA
-                      leagues — "{"{league}"} | {"{division}"}" splits college football into
-                      "NCAAF | FBS" and "NCAAF | FCS".
+                      {"{sport}"}, {"{league}"}, plus {"{conference}"}, {"{conference_abbrev}"}, and{" "}
+                      {"{division}"} for NCAA leagues — "{"{league}"} | {"{conference_abbrev}"}"
+                      buckets college football as "NCAAF | SEC".
                     </p>
                   </>
                 )}

--- a/teamarr/consumers/lifecycle/dynamic_resolver.py
+++ b/teamarr/consumers/lifecycle/dynamic_resolver.py
@@ -583,8 +583,21 @@ class DynamicResolver:
                     # Pattern - resolve it
                     resolved_name = self.resolve_pattern(item, event_sport, event_league)
 
-                    # Check if wildcards remain unresolved
-                    if "{sport}" in resolved_name or "{league}" in resolved_name:
+                    # Check if wildcards remain unresolved. The conference
+                    # tokens are never passed here (profiles get sport/league
+                    # only), so without these checks a profile pattern using
+                    # one would create a profile literally named
+                    # "NCAAF | {conference}".
+                    if any(
+                        token in resolved_name
+                        for token in (
+                            "{sport}",
+                            "{league}",
+                            "{conference}",
+                            "{conference_abbrev}",
+                            "{division}",
+                        )
+                    ):
                         logger.warning(
                             "[RESOLVER] Profile pattern has unresolved wildcards: %s -> %s",
                             item,

--- a/teamarr/consumers/lifecycle/dynamic_resolver.py
+++ b/teamarr/consumers/lifecycle/dynamic_resolver.py
@@ -1,7 +1,7 @@
 """Dynamic channel group and profile resolver.
 
-Resolves {sport}, {league}, {conference} and {division} wildcards to actual
-Dispatcharr group/profile IDs.
+Resolves {sport}, {league}, {conference}, {conference_abbrev} and {division}
+wildcards to actual Dispatcharr group/profile IDs.
 Auto-creates groups/profiles in Dispatcharr if they don't exist.
 """
 
@@ -236,6 +236,16 @@ class DynamicResolver:
         group = self._get_event_group(event)
         return group["name"] if group else None
 
+    def get_event_conference_abbrev(self, event: Any) -> str | None:
+        """Conference abbreviation for an event's home team (#777).
+
+        The cached tree's compact label ('SEC', 'ACC', 'Big Ten') — ESPN's
+        shortName for the conference. None when the tree row carries none,
+        so the pattern falls back like any unresolved wildcard.
+        """
+        group = self._get_event_group(event)
+        return group.get("abbrev") if group else None
+
     def get_event_division(self, event: Any) -> str | None:
         """Division for an event's home team — the conference's parent (#717).
 
@@ -265,6 +275,7 @@ class DynamicResolver:
         event_league: str | None,
         conference: str | None = None,
         division: str | None = None,
+        conference_abbrev: str | None = None,
     ) -> str:
         """Interpolate pattern with event data.
 
@@ -274,6 +285,8 @@ class DynamicResolver:
             event_league: Event's league code (e.g., 'eng.1', 'nfl')
             conference: Conference name for the {conference} wildcard (#91)
             division: Division name for the {division} wildcard (#717)
+            conference_abbrev: Conference abbreviation for the
+                {conference_abbrev} wildcard (#777)
 
         Returns:
             Resolved string with wildcards replaced by display names
@@ -288,11 +301,16 @@ class DynamicResolver:
             alias = self.get_league_alias(event_league)
             result = result.replace("{league}", alias)
 
+        # Exact-token replaces: '{conference}' cannot match inside
+        # '{conference_abbrev}' because the latter's brace follows '_'.
         if conference and "{conference}" in result:
             result = result.replace("{conference}", conference)
 
         if division and "{division}" in result:
             result = result.replace("{division}", division)
+
+        if conference_abbrev and "{conference_abbrev}" in result:
+            result = result.replace("{conference_abbrev}", conference_abbrev)
 
         return result
 
@@ -437,13 +455,13 @@ class DynamicResolver:
 
         Args:
             mode: 'static' or pattern string containing
-                {sport}/{league}/{conference}/{division}
+                {sport}/{league}/{conference}/{conference_abbrev}/{division}
             static_group_id: Group ID to use for 'static' mode
             event_sport: Event's sport code
             event_league: Event's league code
-            event: The event itself — needed only for the {conference} (#91)
-                and {division} (#717) wildcards, which resolve from the
-                home team
+            event: The event itself — needed only for the {conference} (#91),
+                {conference_abbrev} (#777) and {division} (#717) wildcards,
+                which resolve from the home team
 
         Returns:
             Resolved group ID or None
@@ -486,17 +504,24 @@ class DynamicResolver:
                 self.get_event_conference(event) if "{conference}" in mode else None
             )
             division = self.get_event_division(event) if "{division}" in mode else None
+            conference_abbrev = (
+                self.get_event_conference_abbrev(event)
+                if "{conference_abbrev}" in mode
+                else None
+            )
             resolved_name = self.resolve_pattern(
-                mode, event_sport, event_league, conference, division
+                mode, event_sport, event_league, conference, division, conference_abbrev
             )
 
             # Check if any wildcards remain unresolved (a non-NCAA event under
-            # a {conference}/{division} pattern falls back to the static group)
+            # a {conference}/{conference_abbrev}/{division} pattern falls back
+            # to the static group)
             if (
                 "{sport}" in resolved_name
                 or "{league}" in resolved_name
                 or "{conference}" in resolved_name
                 or "{division}" in resolved_name
+                or "{conference_abbrev}" in resolved_name
             ):
                 logger.warning(
                     "[RESOLVER] Pattern has unresolved wildcards: %s -> %s (sport=%s, league=%s)",

--- a/tests/test_provider_groups.py
+++ b/tests/test_provider_groups.py
@@ -402,3 +402,15 @@ def test_resolve_channel_group_falls_back_when_abbrev_unknown(db_conn):
         == 42
     )
     resolver._get_or_create_group.assert_called_once_with("NCAAF | SEC")
+
+
+def test_profile_pattern_skips_unresolved_conference_tokens(db_conn):
+    """A profile pattern using a conference token is skipped, not created
+    as a profile literally named 'NCAAF | {conference}'."""
+    resolver = _resolver_with_cache(db_conn)
+    resolver._initialized = True
+    resolver._league_aliases = {CFB: "NCAAF"}
+    resolver._get_or_create_profile = MagicMock()
+
+    assert resolver.resolve_channel_profiles(["{league} | {conference}"], "football", CFB) == []
+    resolver._get_or_create_profile.assert_not_called()

--- a/tests/test_provider_groups.py
+++ b/tests/test_provider_groups.py
@@ -1,8 +1,8 @@
 """Provider group (conference) cache — #91, epic y5l8.
 
 Covers the DB round-trip, the core-tree walk with $ref parsing, the
-conferences API endpoint, and the dynamic-resolver {conference} and
-{division} (#717) wildcards.
+conferences API endpoint, and the dynamic-resolver {conference},
+{conference_abbrev} (#777) and {division} (#717) wildcards.
 """
 
 from unittest.mock import MagicMock
@@ -35,6 +35,8 @@ B1G = {
 }
 # A tree cached before #717 carries no parent — {division} must stay silent
 MVFC = {"key": "21", "name": "Missouri Valley Football Conference", "team_ids": ["2"]}
+# Neither shortName nor abbreviation published — {conference_abbrev} defers
+NO_ABBREV = {**SEC, "key": "77", "abbrev": None, "team_ids": ["300"]}
 
 
 # ---------------------------------------------------------------------------
@@ -268,10 +270,11 @@ def test_event_division_none_without_parent_data(db_conn):
 
 
 def test_home_team_group_cached_once(db_conn):
-    """Conference and division share one lookup per team."""
+    """Conference, abbreviation and division share one lookup per team."""
     resolver = _resolver_with_cache(db_conn)
     event = _cfb_event("2")
     resolver.get_event_conference(event)
+    resolver.get_event_conference_abbrev(event)
     resolver.get_event_division(event)
     assert len(resolver._group_by_team) == 1
 
@@ -310,3 +313,92 @@ def test_resolve_channel_group_falls_back_when_division_unknown(db_conn):
         == 42
     )
     resolver._get_or_create_group.assert_called_once_with("NCAAF | FBS")
+
+
+# ---------------------------------------------------------------------------
+# {conference_abbrev} wildcard (#777)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_pattern_replaces_conference_abbrev():
+    resolver = DynamicResolver()
+    resolver._initialized = True
+    resolver._league_aliases = {CFB: "NCAAF"}
+    assert (
+        resolver.resolve_pattern(
+            "{league} | {conference_abbrev}",
+            "football",
+            CFB,
+            "Southeastern Conference",
+            "FBS",
+            "SEC",
+        )
+        == "NCAAF | SEC"
+    )
+
+
+def test_resolve_pattern_conference_and_abbrev_coexist():
+    """Replacing {conference} must not eat the {conference_abbrev} token."""
+    resolver = DynamicResolver()
+    assert (
+        resolver.resolve_pattern(
+            "{conference} | {conference_abbrev}",
+            "football",
+            CFB,
+            "Southeastern Conference",
+            None,
+            "SEC",
+        )
+        == "Southeastern Conference | SEC"
+    )
+
+
+def test_event_conference_abbrev_from_home_team(db_conn):
+    resolver = _resolver_with_cache(db_conn)
+    assert resolver.get_event_conference_abbrev(_cfb_event("2")) == "SEC"
+    # Unknown team / non-NCAA league resolves to None (pattern falls back)
+    assert resolver.get_event_conference_abbrev(_cfb_event("9999")) is None
+    assert resolver.get_event_conference_abbrev(None) is None
+
+
+def test_event_conference_abbrev_none_without_abbrev(db_conn):
+    """A tree row with no abbreviation defers rather than inventing a label."""
+    save_provider_groups(db_conn, "espn", CFB, 2026, [NO_ABBREV])
+    resolver = DynamicResolver()
+    resolver._db_conn = db_conn
+    assert resolver.get_event_conference(_cfb_event("300")) == "Southeastern Conference"
+    assert resolver.get_event_conference_abbrev(_cfb_event("300")) is None
+
+
+def test_resolve_channel_group_falls_back_when_abbrev_unknown(db_conn):
+    """An event with no cached abbreviation under {conference_abbrev} lands
+    in the static group, same contract as {conference}/{division}."""
+    resolver = _resolver_with_cache(db_conn)
+    resolver._initialized = True
+    resolver._groups_loaded = True
+    resolver._known_group_ids = {7}
+    resolver._league_aliases = {CFB: "NCAAF"}
+    resolver._get_or_create_group = MagicMock(return_value=42)
+
+    assert (
+        resolver.resolve_channel_group(
+            mode="{league} | {conference_abbrev}",
+            static_group_id=7,
+            event_sport="football",
+            event_league=CFB,
+            event=_cfb_event("9999"),  # not in the conference tree
+        )
+        == 7
+    )
+
+    assert (
+        resolver.resolve_channel_group(
+            mode="{league} | {conference_abbrev}",
+            static_group_id=7,
+            event_sport="football",
+            event_league=CFB,
+            event=_cfb_event("2"),
+        )
+        == 42
+    )
+    resolver._get_or_create_group.assert_called_once_with("NCAAF | SEC")


### PR DESCRIPTION
Closes #777.

## Problem
Custom channel-group patterns with `{conference}` write out the full NCAA conference name ("Atlantic Coast Conference"), making group names longer than some users want.

## Solution
Add a `{conference_abbrev}` wildcard that resolves to the conference's compact form ("ACC", "SEC", "Big Ten"). The abbreviation data already existed — `provider_group_cache.group_abbrev` has been cached from ESPN's `shortName` since the `{conference}` wildcard landed (#91), and `get_team_group` already returned it; the resolver just never exposed it.

Implementation mirrors `{division}` (#717) exactly:
- `DynamicResolver.get_event_conference_abbrev()` — from the home team's cached conference (shares the same per-team lookup cache as `{conference}`/`{division}`)
- `resolve_pattern()` — new `conference_abbrev` param + exact-token replace (cannot collide with `{conference}` since the brace follows `_`)
- `resolve_channel_group()` — resolves it for pattern mode; an event with no abbreviation (non-NCAA, or a tree row without one) falls back to the static group, same contract as the other wildcards

## Example
`{league} | {conference_abbrev}` → "NCAAF | SEC" instead of "NCAAF | Southeastern Conference"

## Changes
- `teamarr/consumers/lifecycle/dynamic_resolver.py` — the wildcard
- `DispatcharrOutputSettings.tsx`, `PerLeagueChannelConfig.tsx` — pattern help text
- `tests/test_provider_groups.py` — 5 new tests (resolution, coexistence with `{conference}`, home-team lookup, missing-abbrev deferral, static-group fallback)
- `docs/guide/channels/output.md`, `docs/guide/dispatcharr-integration.md`, `CLAUDE.md` — wildcard documentation

## Testing
- `ruff check teamarr/ tests/` — clean
- `pytest tests/` — 3274 passed
- `npm run build` — clean